### PR TITLE
Updating publishing account

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"description": "Allows acquisition of the .NET Core runtime specifically for VSCode extension authors.",
 	"icon": "images/dotnetIcon.png",
 	"version": "0.1.0",
-	"publisher": "ms-azuretools",
+	"publisher": "ms-dotnettools",
 	"engines": {
 		"vscode": "^1.41.0"
 	},

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -955,6 +955,7 @@
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=3.5.0",
 				"mocha": "^7.0.0",
+				"open": "^7.0.2",
 				"request": "^2.88.0",
 				"request-promise-native": "^1.0.8",
 				"rimraf": "2.6.3",
@@ -1780,6 +1781,11 @@
 					"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
 					"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
 				},
+				"is-docker": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+					"integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
+				},
 				"is-extglob": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1823,6 +1829,11 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+				},
+				"is-wsl": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+					"integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog=="
 				},
 				"isexe": {
 					"version": "2.0.0",
@@ -2059,6 +2070,15 @@
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
 						"wrappy": "1"
+					}
+				},
+				"open": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/open/-/open-7.0.2.tgz",
+					"integrity": "sha512-70E/pFTPr7nZ9nLDPNTcj3IVqnNvKuP4VsBmoKV9YGTnChe0mlS3C4qM7qKarhZ8rGaHKLfo+vBTHXDp6ZSyLQ==",
+					"requires": {
+						"is-docker": "^2.0.0",
+						"is-wsl": "^2.1.1"
 					}
 				},
 				"p-limit": {

--- a/sample/package.json
+++ b/sample/package.json
@@ -8,7 +8,7 @@
 	},
 	"license": "MIT",
 	"version": "0.0.1",
-	"publisher": "ms-azuretools",
+	"publisher": "ms-dotnettools",
 	"engines": {
 		"vscode": "^1.41.0"
 	},
@@ -53,7 +53,7 @@
 		]
 	},
 	"scripts": {
-		"vscode:prepublish": "npm run compile",
+		"vscode:prepublish": "npm install && npm run compile",
 		"compile": "npm run clean && tsc -p ./",
 		"watch": "npm run clean && tsc -watch -p ./",
 		"test": "npm run compile && node ./node_modules/vscode/bin/test",

--- a/sample/src/extension.ts
+++ b/sample/src/extension.ts
@@ -18,7 +18,7 @@ export function activate(context: vscode.ExtensionContext) {
     NOTE: This sample should technically have the following in its package.json:
 
     "extensionDependencies": [
-        "ms-azuretools.vscode-dotnet-runtime"
+        "ms-dotnettools.vscode-dotnet-runtime"
     ]
 
     This would enable the sample to require the vscode-dotnet-runtime extension
@@ -28,7 +28,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     */
 
-    acquisitionLibrary.activate(context, 'ms-azuretools.sample-extension');
+    acquisitionLibrary.activate(context, 'ms-dotnettools.sample-extension');
 
     // --------------------------------------------------------------------------
 
@@ -43,7 +43,7 @@ export function activate(context: vscode.ExtensionContext) {
                 throw new Error('Couldn\'t resolve the dotnet path!');
             }
 
-            const sampleExtension = vscode.extensions.getExtension('ms-azuretools.sample-extension');
+            const sampleExtension = vscode.extensions.getExtension('ms-dotnettools.sample-extension');
             if (!sampleExtension) {
                 throw new Error('Could not find sample extension.');
             }

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -10,7 +10,7 @@
 		"vscode": "^1.41.0"
 	},
 	"version": "0.1.0",
-	"publisher": "ms-azuretools",
+	"publisher": "ms-dotnettools",
 	"activationEvents": [
 		"onCommand:dotnet.acquire",
 		"onCommand:dotnet.uninstallAll",

--- a/vscode-dotnet-runtime-extension/src/DotnetCoreAcquistionId.ts
+++ b/vscode-dotnet-runtime-extension/src/DotnetCoreAcquistionId.ts
@@ -3,4 +3,4 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export const dotnetCoreAcquisitionExtensionId = 'ms-azuretools.vscode-dotnet-runtime';
+export const dotnetCoreAcquisitionExtensionId = 'ms-dotnettools.vscode-dotnet-runtime';


### PR DESCRIPTION
Changing publishing account from `ms-azuretools` to `ms-dotnettools`. Token in release pipeline has been updated as well. 

cc @KathleenDollard 