### PR TITLE
Fix file structure parsing

### DIFF
--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -119,11 +119,12 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
     }
 
     private getFileStructure(): string {
-        if (!fs.existsSync(this.dotnetPath)) {
-            return `Dotnet Path (${ this.dotnetPath }) does not exist`;
+        const folderPath = path.dirname(this.dotnetPath);
+        if (!fs.existsSync(folderPath)) {
+            return `Dotnet Path (${ path.basename(folderPath) }) does not exist`;
         }
         // Get 2 levels worth of content of the folder
-        let files = fs.readdirSync(this.dotnetPath).map(file => path.join(this.dotnetPath, file));
+        let files = fs.readdirSync(folderPath).map(file => path.join(folderPath, file));
         for (const file of files) {
             if (fs.statSync(file).isDirectory()) {
                 files = files.concat(fs.readdirSync(file).map(fileName => path.join(file, fileName)));
@@ -131,7 +132,7 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
         }
         const relativeFiles: string[] = [];
         for (const file of files) {
-            relativeFiles.push(path.relative(this.dotnetPath, file));
+            relativeFiles.push(path.relative(path.dirname(folderPath), file));
         }
 
         return relativeFiles.join('\n');

--- a/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
@@ -12,9 +12,9 @@ const reportOption = 'Report an issue';
 const hideOption = 'Don\'t show again';
 let showMessage = true;
 
-export async function callWithErrorHandling<T>(callback: () => T, context: IIssueContext): Promise<T | undefined> {
+export function callWithErrorHandling<T>(callback: () => T, context: IIssueContext): T | undefined {
     try {
-        return await callback();
+        return callback();
     } catch (error) {
         if (error.constructor.name !== 'UserCancelledError' && showMessage) {
             window.showErrorMessage(`${errorMessage}: ${ error.message }`, reportOption, hideOption).then(async (response: string | undefined) => {

--- a/vscode-dotnet-runtime-library/src/extension.ts
+++ b/vscode-dotnet-runtime-library/src/extension.ts
@@ -70,12 +70,13 @@ export function activate(context: vscode.ExtensionContext, parentExtensionId: st
     });
 
     const dotnetAcquireRegistration = vscode.commands.registerCommand('dotnet.acquire', async (commandContext: IDotnetAcquireContext) => {
-        return callWithErrorHandling<Promise<IDotnetAcquireResult>>(() => {
+        const dotnetPath = await callWithErrorHandling<Promise<IDotnetAcquireResult>>(async () => {
             if (!commandContext.version || commandContext.version === 'latest') {
                 throw new Error(`Cannot acquire .NET Core version "${commandContext.version}". Please provide a valid version.`);
             }
             return acquisitionWorker.acquire(commandContext.version);
         }, issueContext);
+        return dotnetPath;
     });
     const dotnetUninstallAllRegistration = vscode.commands.registerCommand('dotnet.uninstallAll', async () => {
         await callWithErrorHandling(() => acquisitionWorker.uninstallAll(), issueContext);


### PR DESCRIPTION
- On dotnet install validation error we parse the relative file structure of the dotnet folder. Expected file structure was off, fixing to ensure we get the right data.
- Fixing async to return dotnet path on acquisition