### PR TITLE
Set TLS before running install script

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -86,7 +86,7 @@ export class AcquisitionInvoker extends IAcquisitionInvoker {
             const dotnetInstallDirEscaped = path.replace(/'/g, `''`);
 
             // Surround with single quotes instead of double quotes (see https://github.com/dotnet/cli/issues/11521)
-            return`'${dotnetInstallDirEscaped}'`;
+            return `'${dotnetInstallDirEscaped}'`;
         } else {
             return `"${path}"`;
         }

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -33,7 +33,7 @@ export class AcquisitionInvoker extends IAcquisitionInvoker {
         const installCommand = await this.getInstallCommand(installContext.version, installContext.installDir);
         return new Promise<void>((resolve, reject) => {
             try {
-                const windowsFullCommand = `powershell.exe -ExecutionPolicy unrestricted -Command "& { [Net.ServicePointManager]::SecurityProtocol = 'Tls12, Tls13' ; & ${installCommand} }`;
+                const windowsFullCommand = `powershell.exe -ExecutionPolicy unrestricted -Command "& { [System.Net.ServicePointManager]::SecurityProtocol=[System.Net.SecurityProtocolType]::Tls12+[System.Net.SecurityProtocolType]::Tls13 ; & ${installCommand} }`;
                 cp.exec(winOS ? windowsFullCommand : installCommand,
                         { cwd: process.cwd(), maxBuffer: 500 * 1024, timeout: 30000, killSignal: 'SIGKILL' },
                         async (error, stdout, stderr) => {


### PR DESCRIPTION
Fixes dotnet install script errors that arise when TLS is not set. TLS needs to be set before the install script is invoked to avoid breaking those using TLS13. 
Related fix in the SDK: dotnet/installer#7068

cc @StephenWeatherford 