### PR TITLE
Updating error message format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8198,7 +8198,7 @@
 						"shelljs": "0.8.3",
 						"tslint": "5.16.0",
 						"typescript": "3.4.5",
-						"vscode-extension-telemetry": "^0.1.2",
+						"vscode-extension-telemetry": "^0.1.4",
 						"vscode-test": "^1.3.0"
 					},
 					"dependencies": {
@@ -8389,14 +8389,14 @@
 							}
 						},
 						"applicationinsights": {
-							"version": "1.4.0",
-							"resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.4.0.tgz",
-							"integrity": "sha512-TV8MYb0Kw9uE2cdu4V/UvTKdOABkX2+Fga9iDz0zqV7FLrNXfmAugWZmmdTx4JoynYkln3d5CUHY3oVSUEbfFw==",
+							"version": "1.7.4",
+							"resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
+							"integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
 							"requires": {
 								"cls-hooked": "^4.2.2",
 								"continuation-local-storage": "^3.2.1",
 								"diagnostic-channel": "0.2.0",
-								"diagnostic-channel-publishers": "^0.3.2"
+								"diagnostic-channel-publishers": "^0.3.3"
 							}
 						},
 						"argparse": {
@@ -8769,9 +8769,9 @@
 							}
 						},
 						"diagnostic-channel-publishers": {
-							"version": "0.3.3",
-							"resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.3.tgz",
-							"integrity": "sha512-qIocRYU5TrGUkBlDDxaziAK1+squ8Yf2Ls4HldL3xxb/jzmWO2Enux7CvevNKYmF2kDXZ9HiRqwjPsjk8L+i2Q=="
+							"version": "0.3.4",
+							"resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
+							"integrity": "sha512-SZ1zMfFiEabf4Qx0Og9V1gMsRoqz3O+5ENkVcNOfI+SMJ3QhQsdEoKX99r0zvreagXot2parPxmrwwUM/ja8ug=="
 						},
 						"diff": {
 							"version": "4.0.2",
@@ -9990,11 +9990,11 @@
 							}
 						},
 						"vscode-extension-telemetry": {
-							"version": "0.1.2",
-							"resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.2.tgz",
-							"integrity": "sha512-FSbaZKlIH3VKvBJsKw7v5bESWHXzltji2rtjaJeJglpQH4tfClzwHMzlMXUZGiblV++djEzb1gW8mb5E+wxFsg==",
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.4.tgz",
+							"integrity": "sha512-9U2pUZ/YwZBfA8CkBrHwMxjnq9Ab+ng8daJWJzEQ6CAxlZyRhmck23bx2lqqpEwGWJCiuceQy4k0Me6llEB4zw==",
 							"requires": {
-								"applicationinsights": "1.4.0"
+								"applicationinsights": "1.7.4"
 							}
 						},
 						"vscode-test": {

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -962,7 +962,6 @@
 				"shelljs": "0.8.3",
 				"tslint": "5.16.0",
 				"typescript": "3.4.5",
-				"vscode-extension-telemetry": "^0.1.2",
 				"vscode-test": "^1.3.0"
 			},
 			"dependencies": {

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -3942,6 +3942,7 @@
 				"shelljs": "0.8.3",
 				"tslint": "5.16.0",
 				"typescript": "3.4.5",
+				"vscode-extension-telemetry": "^0.1.4",
 				"vscode-test": "^1.3.0"
 			},
 			"dependencies": {
@@ -4132,14 +4133,14 @@
 					}
 				},
 				"applicationinsights": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.4.0.tgz",
-					"integrity": "sha512-TV8MYb0Kw9uE2cdu4V/UvTKdOABkX2+Fga9iDz0zqV7FLrNXfmAugWZmmdTx4JoynYkln3d5CUHY3oVSUEbfFw==",
+					"version": "1.7.4",
+					"resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
+					"integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
 					"requires": {
 						"cls-hooked": "^4.2.2",
 						"continuation-local-storage": "^3.2.1",
 						"diagnostic-channel": "0.2.0",
-						"diagnostic-channel-publishers": "^0.3.2"
+						"diagnostic-channel-publishers": "^0.3.3"
 					}
 				},
 				"argparse": {
@@ -4512,9 +4513,9 @@
 					}
 				},
 				"diagnostic-channel-publishers": {
-					"version": "0.3.3",
-					"resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.3.tgz",
-					"integrity": "sha512-qIocRYU5TrGUkBlDDxaziAK1+squ8Yf2Ls4HldL3xxb/jzmWO2Enux7CvevNKYmF2kDXZ9HiRqwjPsjk8L+i2Q=="
+					"version": "0.3.4",
+					"resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
+					"integrity": "sha512-SZ1zMfFiEabf4Qx0Og9V1gMsRoqz3O+5ENkVcNOfI+SMJ3QhQsdEoKX99r0zvreagXot2parPxmrwwUM/ja8ug=="
 				},
 				"diff": {
 					"version": "4.0.2",
@@ -5733,11 +5734,11 @@
 					}
 				},
 				"vscode-extension-telemetry": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.2.tgz",
-					"integrity": "sha512-FSbaZKlIH3VKvBJsKw7v5bESWHXzltji2rtjaJeJglpQH4tfClzwHMzlMXUZGiblV++djEzb1gW8mb5E+wxFsg==",
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.4.tgz",
+					"integrity": "sha512-9U2pUZ/YwZBfA8CkBrHwMxjnq9Ab+ng8daJWJzEQ6CAxlZyRhmck23bx2lqqpEwGWJCiuceQy4k0Me6llEB4zw==",
 					"requires": {
-						"applicationinsights": "1.4.0"
+						"applicationinsights": "1.7.4"
 					}
 				},
 				"vscode-test": {

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -3942,7 +3942,6 @@
 				"shelljs": "0.8.3",
 				"tslint": "5.16.0",
 				"typescript": "3.4.5",
-				"vscode-extension-telemetry": "^0.1.2",
 				"vscode-test": "^1.3.0"
 			},
 			"dependencies": {

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -118,7 +118,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function() {
       await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
       assert(false); // An error should have been thrown
     } catch (error) {
-      const versionError = MockTelemetryReporter.telemetryEvents.find((event: any) => event.eventName === 'DotnetVersionResolutionError');
+      const versionError = MockTelemetryReporter.telemetryEvents.find((event: any) => event.eventName === '[ERROR]:DotnetVersionResolutionError');
       assert.exists(versionError);
     }
   }).timeout(2000);

--- a/vscode-dotnet-runtime-library/package-lock.json
+++ b/vscode-dotnet-runtime-library/package-lock.json
@@ -190,14 +190,14 @@
 			}
 		},
 		"applicationinsights": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.4.0.tgz",
-			"integrity": "sha512-TV8MYb0Kw9uE2cdu4V/UvTKdOABkX2+Fga9iDz0zqV7FLrNXfmAugWZmmdTx4JoynYkln3d5CUHY3oVSUEbfFw==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
+			"integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
 			"requires": {
 				"cls-hooked": "^4.2.2",
 				"continuation-local-storage": "^3.2.1",
 				"diagnostic-channel": "0.2.0",
-				"diagnostic-channel-publishers": "^0.3.2"
+				"diagnostic-channel-publishers": "^0.3.3"
 			}
 		},
 		"argparse": {
@@ -1791,11 +1791,11 @@
 			}
 		},
 		"vscode-extension-telemetry": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.2.tgz",
-			"integrity": "sha512-FSbaZKlIH3VKvBJsKw7v5bESWHXzltji2rtjaJeJglpQH4tfClzwHMzlMXUZGiblV++djEzb1gW8mb5E+wxFsg==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.4.tgz",
+			"integrity": "sha512-9U2pUZ/YwZBfA8CkBrHwMxjnq9Ab+ng8daJWJzEQ6CAxlZyRhmck23bx2lqqpEwGWJCiuceQy4k0Me6llEB4zw==",
 			"requires": {
-				"applicationinsights": "1.4.0"
+				"applicationinsights": "1.7.4"
 			}
 		},
 		"vscode-test": {

--- a/vscode-dotnet-runtime-library/package-lock.json
+++ b/vscode-dotnet-runtime-library/package-lock.json
@@ -1,7 +1,8 @@
 {
 	"name": "vscode-dotnet-runtime-library",
-	"requires": true,
+	"version": "0.1.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.8.3",

--- a/vscode-dotnet-runtime-library/package.json
+++ b/vscode-dotnet-runtime-library/package.json
@@ -45,7 +45,7 @@
 		"shelljs": "0.8.3",
 		"tslint": "5.16.0",
 		"typescript": "3.4.5",
-		"vscode-extension-telemetry": "^0.1.2",
+		"vscode-extension-telemetry": "^0.1.4",
 		"vscode-test": "^1.3.0"
 	}
 }

--- a/vscode-dotnet-runtime-library/package.json
+++ b/vscode-dotnet-runtime-library/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "vscode-dotnet-runtime-library",
 	"description": "A library to acquire .NET Core tooling.",
+	"version": "0.1.1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/dotnet/vscode-dotnet-runtime.git"

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -54,7 +54,7 @@ export class AcquisitionInvoker extends IAcquisitionInvoker {
                             reject(offlineError);
                         } else if (error.signal === 'SIGKILL') {
                             error.message = timeoutConstants.timeoutMessage;
-                            this.eventStream.post(new DotnetAcquisitionTimeoutError(error, installContext.timeoutValue));
+                            this.eventStream.post(new DotnetAcquisitionTimeoutError(error, installContext.version, installContext.timeoutValue));
                             reject(error);
                         } else {
                             this.eventStream.post(new DotnetAcquisitionInstallError(error, installContext.version));

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -57,18 +57,6 @@ export abstract class DotnetAcquisitionError extends IEvent {
     }
 }
 
-export class DotnetVersionResolutionError extends DotnetAcquisitionError {
-    public readonly eventName = 'DotnetVersionResolutionError';
-
-    constructor(error: Error, private readonly version: string) { super(error); }
-
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
-        return {ErrorMessage : this.error.message,
-                RequestedVersion : this.version,
-                ErrorName : this.error.name,
-                StackTrace : this.error.stack ? this.error.stack : ''};
-    }
-}
 
 export class DotnetInstallScriptAcquisitionError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetInstallScriptAcquisitionError';
@@ -107,19 +95,24 @@ export class DotnetOfflineFailure extends DotnetAcquisitionVersionError {
     public readonly eventName = 'DotnetOfflineFailure';
 }
 
-export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionError {
+export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError {
     public readonly eventName = 'DotnetAcquisitionTimeoutError';
 
-    constructor(error: Error, public readonly timeoutValue: number) {
-        super(error);
+    constructor(error: Error, version: string, public readonly timeoutValue: number) {
+        super(error, version);
     }
 
     public getProperties(telemetry = false): { [key: string]: string } | undefined {
         return {ErrorMessage : this.error.message,
             TimeoutValue : this.timeoutValue.toString(),
+            Version : this.version,
             ErrorName : this.error.name,
             StackTrace : this.error.stack ? this.error.stack : ''};
     }
+}
+
+export class DotnetVersionResolutionError extends DotnetAcquisitionVersionError {
+    public readonly eventName = 'DotnetVersionResolutionError';
 }
 
 export class DotnetInstallationValidationError extends DotnetAcquisitionVersionError {

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -44,6 +44,7 @@ export class DotnetAcquisitionCompleted extends IEvent {
 
 export abstract class DotnetAcquisitionError extends IEvent {
     public readonly type = EventType.DotnetAcquisitionError;
+    public isError = true;
 
     constructor(public readonly error: Error) {
         super();

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -57,7 +57,6 @@ export abstract class DotnetAcquisitionError extends IEvent {
     }
 }
 
-
 export class DotnetInstallScriptAcquisitionError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetInstallScriptAcquisitionError';
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/IEvent.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/IEvent.ts
@@ -11,6 +11,8 @@ export abstract class IEvent {
 
     public abstract readonly eventName: string;
 
+    public isError = false;
+
     public abstract getProperties(telemetry?: boolean): { [key: string]: string } | undefined;
 
     public getSanitizedProperties(): { [key: string]: string } | undefined {

--- a/vscode-dotnet-runtime-library/src/EventStream/TelemetryObserver.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/TelemetryObserver.ts
@@ -11,6 +11,7 @@ const packageJson = require('../../package.json');
 
 export interface ITelemetryReporter {
     sendTelemetryEvent(eventName: string, properties?: { [key: string]: string }, measures?: { [key: string]: number }): void;
+    sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string }, measurements?: { [key: string]: number }, errorProps?: string[]): void;
     dispose(): Promise<any>;
 }
 
@@ -32,6 +33,8 @@ export class TelemetryObserver implements IEventStreamObserver {
         const properties = event.getSanitizedProperties(); // Get properties that don't contain personally identifiable data
         if (isNullOrUndefined(properties)) {
             this.telemetryReporter.sendTelemetryEvent(event.eventName);
+        } else if (event.isError) {
+            this.telemetryReporter.sendTelemetryErrorEvent(event.eventName, properties);
         } else {
             this.telemetryReporter.sendTelemetryEvent(event.eventName, properties);
         }

--- a/vscode-dotnet-runtime-library/src/Utils/IssueReporter.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/IssueReporter.ts
@@ -5,6 +5,8 @@
 import { isNullOrUndefined } from 'util';
 import { sanitize } from './ContentSantizer';
 import { IIssueContext } from './IIssueContext';
+// tslint:disable no-var-requires
+const packageJson = require('../../package.json');
 
 const issuesUrl = `https://github.com/dotnet/vscode-dotnet-runtime/issues`;
 
@@ -19,6 +21,7 @@ export function formatIssueUrl(error: Error | undefined, context: IIssueContext)
 
 1.
 
+**Extension Version:** ${ packageJson.version }
 ${ errorMessage }`;
 
     const issueMessage = `The issue text was copied to the clipboard.  Please paste it into this window.

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -145,6 +145,11 @@ export class MockTelemetryReporter implements ITelemetryReporter {
     public sendTelemetryEvent(eventName: string, properties?: { [key: string]: string; } | undefined, measures?: { [key: string]: number; } | undefined): void {
         MockTelemetryReporter.telemetryEvents = MockTelemetryReporter.telemetryEvents.concat({eventName, properties, measures});
     }
+
+    public sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string }, measures?: { [key: string]: number }, errorProps?: string[]): void {
+        eventName = `[ERROR]:${eventName}`;
+        MockTelemetryReporter.telemetryEvents = MockTelemetryReporter.telemetryEvents.concat({eventName, properties, measures});
+    }
 }
 
 export class MockInstallationValidator extends IInstallationValidator {


### PR DESCRIPTION
- d5692ae Switching to sending error messages with the proper library function 
- c21ea66 Updating to use proper error format for timeouts (Fixes the 'keeps display error message' part of #68)
- 3cb506b Fixing bug that leaves extension version out of error reporting
- 111a23a Adding the extension version to the issue template when reporting issues on GitHub