### PR TITLE
Bundling backup install script on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ dist
 install.*
 .vscode-test/
 *.vsix
+vscode-dotnet-runtime-library/install scripts/dotnet-install.*

--- a/Documentation/contributing-workflow.md
+++ b/Documentation/contributing-workflow.md
@@ -33,7 +33,7 @@ Note: It is OK to create your PR as "[WIP]" on the upstream repo before the impl
 
 ## Building and Testing Locally
 
-Before making a pull request, be sure to build and test your changes locally with the build script ([windows](https://github.com/dotnet/vscode-dotnet-runtime/blob/master/build.cmd), [mac](https://github.com/dotnet/vscode-dotnet-runtime/blob/master/build.sh)) and test script ([windows](https://github.com/dotnet/vscode-dotnet-runtime/blob/master/test.cmd), [mac](https://github.com/dotnet/vscode-dotnet-runtime/blob/master/test.sh)).
+Before making a pull request, be sure to build and test your changes locally with the build script ([windows](https://github.com/dotnet/vscode-dotnet-runtime/blob/master/build.cmd), [mac](https://github.com/dotnet/vscode-dotnet-runtime/blob/master/build.sh)) and test script ([windows](https://github.com/dotnet/vscode-dotnet-runtime/blob/master/test.cmd), [mac](https://github.com/dotnet/vscode-dotnet-runtime/blob/master/test.sh)). To lint your changes, run the test script with the parameter `--tslint`
 
 ## PR - CI Process
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,36 +38,30 @@ stages:
       inputs:
         versionSpec: '12.x'
       displayName: 'Install Node.js'
+    - script: build.cmd
+      displayName: Build Windows
+      condition: eq(variables['Agent.OS'], 'Windows_NT')
+    - script: test.cmd
+      displayName: Test Windows
+      condition: eq(variables['Agent.OS'], 'Windows_NT')
     - bash: |
         /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
         echo ">>> Started xvfb"
       displayName: Start xvfb
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-    - bash: |
-        npm install
-        npm run compile
-        npm run test
-      workingDirectory: 'vscode-dotnet-runtime-library'
-      displayName: Build and Test vscode-dotnet-runtime-library
-    - bash: |
-        npm install
-        npm run compile
-        npm run test
-      workingDirectory: 'vscode-dotnet-runtime-extension'
-      displayName: Build and Test vscode-dotnet-runtime-extension
-      env:
-        DISPLAY: ':99.0'
+    - script: ./build.sh
+      displayName: Build Mac and Linux
+      condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
+    - script: ./test.sh
+      displayName: Test Mac and Linux
+      env: { DISPLAY: ':99.0' }
+      condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
     - task: PublishBuildArtifacts@1
       inputs:
         pathtoPublish: '$(Build.SourcesDirectory)/vscode-dotnet-runtime-extension/out/test/functional/logs'
         artifactName: 'logs'
       displayName: Publish Logs
       condition: always()
-    - bash: |
-        npm install
-        npm run compile
-      workingDirectory: 'sample'
-      displayName: Build Sample
   ##### TSLint #####
   - job: TSLint
     displayName: 'TSLint'

--- a/build.ps1
+++ b/build.ps1
@@ -1,15 +1,28 @@
 $errorColor = "Red"
 $successColor = "Green"
 
-Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile "./vscode-dotnet-runtime-library/install scripts/dotnet-install.ps1"
-Invoke-WebRequest https://dot.net/v1/dotnet-install.sh -OutFile "./vscode-dotnet-runtime-library/install scripts/dotnet-install.sh"
-icacls "./vscode-dotnet-runtime-library/install scripts/dotnet-install.ps1" /grant:r "users:(RX)" /C
-icacls "./vscode-dotnet-runtime-library/install scripts/dotnet-install.sh" /grant:r "users:(RX)" /C
+function DownloadInstallScripts() {
+    Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile "./vscode-dotnet-runtime-library/install scripts/dotnet-install.ps1"
+    Invoke-WebRequest https://dot.net/v1/dotnet-install.sh -OutFile "./vscode-dotnet-runtime-library/install scripts/dotnet-install.sh"
+}
+
+try
+{
+    DownloadInstallScripts
+}
+catch
+{
+    $exceptionMessage = $_.Exception.Message
+    Write-Host "Failed to install scripts, retrying: $exceptionMessage"
+    DownloadInstallScripts
+}
 if ($?) {
     Write-Host "`nBundled dotnet-install scripts" -ForegroundColor $successColor
 } else {
     Write-Host "`nFailed to bundle dotnet-install scripts" -ForegroundColor $errorColor
 }
+icacls "./vscode-dotnet-runtime-library/install scripts/dotnet-install.ps1" /grant:r "users:(RX)" /C
+icacls "./vscode-dotnet-runtime-library/install scripts/dotnet-install.sh" /grant:r "users:(RX)" /C
 
 pushd vscode-dotnet-runtime-library
 if (Test-Path node_modules) { rm -r -force node_modules }

--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,16 @@
 $errorColor = "Red"
 $successColor = "Green"
 
+Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile "./vscode-dotnet-runtime-library/install scripts/dotnet-install.ps1"
+Invoke-WebRequest https://dot.net/v1/dotnet-install.sh -OutFile "./vscode-dotnet-runtime-library/install scripts/dotnet-install.sh"
+icacls "./vscode-dotnet-runtime-library/install scripts/dotnet-install.ps1" /grant:r "users:(RX)" /C
+icacls "./vscode-dotnet-runtime-library/install scripts/dotnet-install.sh" /grant:r "users:(RX)" /C
+if ($?) {
+    Write-Host "`nBundled dotnet-install scripts" -ForegroundColor $successColor
+} else {
+    Write-Host "`nFailed to bundle dotnet-install scripts" -ForegroundColor $errorColor
+}
+
 pushd vscode-dotnet-runtime-library
 if (Test-Path node_modules) { rm -r -force node_modules }
 npm install

--- a/build.sh
+++ b/build.sh
@@ -5,10 +5,8 @@ NC=`tput sgr0`
 echo ""
 echo "----------- Bundling Install Scripts -----------"
 echo ""
-curl https://dot.net/v1/dotnet-install.ps1 -o "./vscode-dotnet-runtime-library/install scripts/dotnet-install.ps1"
-curl https://dot.net/v1/dotnet-install.sh -o "./vscode-dotnet-runtime-library/install scripts/dotnet-install.sh"
-chmod +x "./vscode-dotnet-runtime-library/install scripts/dotnet-install.ps1"
-chmod +x "./vscode-dotnet-runtime-library/install scripts/dotnet-install.sh"
+curl https://dot.net/v1/dotnet-install.ps1 --retry 2 -o "./vscode-dotnet-runtime-library/install scripts/dotnet-install.ps1"
+curl https://dot.net/v1/dotnet-install.sh --retry 2 -o "./vscode-dotnet-runtime-library/install scripts/dotnet-install.sh"
 if [ $? -eq 0 ];
 then
     echo ""
@@ -17,6 +15,8 @@ else
     echo ""
     echo "${RED}Unable to bundle install scripts${NC}"
 fi
+chmod +x "./vscode-dotnet-runtime-library/install scripts/dotnet-install.ps1"
+chmod +x "./vscode-dotnet-runtime-library/install scripts/dotnet-install.sh"
 
 echo ""
 echo "----------- Compiling vscode-dotnet-runtime-library -----------"

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,22 @@ GREEN=`tput setaf 2`
 NC=`tput sgr0`
 
 echo ""
+echo "----------- Bundling Install Scripts -----------"
+echo ""
+curl https://dot.net/v1/dotnet-install.ps1 -o "./vscode-dotnet-runtime-library/install scripts/dotnet-install.ps1"
+curl https://dot.net/v1/dotnet-install.sh -o "./vscode-dotnet-runtime-library/install scripts/dotnet-install.sh"
+chmod +x "./vscode-dotnet-runtime-library/install scripts/dotnet-install.ps1"
+chmod +x "./vscode-dotnet-runtime-library/install scripts/dotnet-install.sh"
+if [ $? -eq 0 ];
+then
+    echo ""
+    echo "${GREEN}Bundled install scripts${NC}"
+else
+    echo ""
+    echo "${RED}Unable to bundle install scripts${NC}"
+fi
+
+echo ""
 echo "----------- Compiling vscode-dotnet-runtime-library -----------"
 echo ""
 pushd vscode-dotnet-runtime-library

--- a/package-lock.json
+++ b/package-lock.json
@@ -248,6 +248,12 @@
 			"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
 			"dev": true
 		},
+		"ansi-colors": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+			"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+			"dev": true
+		},
 		"ansi-regex": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -409,6 +415,21 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
+			"requires": {
+				"array-uniq": "^1.0.1"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
 			"dev": true
 		},
 		"array-unique": {
@@ -1596,6 +1617,26 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
+		"copy-webpack-plugin": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
+			"integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
+			"dev": true,
+			"requires": {
+				"cacache": "^12.0.3",
+				"find-cache-dir": "^2.1.0",
+				"glob-parent": "^3.1.0",
+				"globby": "^7.1.1",
+				"is-glob": "^4.0.1",
+				"loader-utils": "^1.2.3",
+				"minimatch": "^3.0.4",
+				"normalize-path": "^3.0.0",
+				"p-limit": "^2.2.1",
+				"schema-utils": "^1.0.0",
+				"serialize-javascript": "^2.1.2",
+				"webpack-log": "^2.0.0"
+			}
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1785,6 +1826,15 @@
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
 				"randombytes": "^2.0.0"
+			}
+		},
+		"dir-glob": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+			"integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+			"dev": true,
+			"requires": {
+				"path-type": "^3.0.0"
 			}
 		},
 		"dns-packet": {
@@ -2392,6 +2442,28 @@
 				"which": "^1.2.14"
 			}
 		},
+		"globby": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+			"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+			"dev": true,
+			"requires": {
+				"array-union": "^1.0.1",
+				"dir-glob": "^2.0.0",
+				"glob": "^7.1.2",
+				"ignore": "^3.3.5",
+				"pify": "^3.0.0",
+				"slash": "^1.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
+			}
+		},
 		"got": {
 			"version": "9.6.0",
 			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -2535,6 +2607,12 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
 			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+			"dev": true
+		},
+		"ignore": {
+			"version": "3.3.10",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
 			"dev": true
 		},
 		"import-local": {
@@ -3428,6 +3506,23 @@
 			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
 			"dev": true
 		},
+		"path-type": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
+			}
+		},
 		"pbkdf2": {
 			"version": "3.0.17",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -3954,6 +4049,12 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
 			"dev": true
 		},
 		"snapdragon": {
@@ -4541,6 +4642,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 			"dev": true
 		},
 		"v8-compile-cache": {
@@ -11564,6 +11671,16 @@
 						"has-flag": "^3.0.0"
 					}
 				}
+			}
+		},
+		"webpack-log": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+			"integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "^3.0.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -61,13 +61,14 @@
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile-all && npm install && webpack --mode production",
-		"compile-all": "cd vscode-dotnet-runtime-library && npm install &&  npm run compile && cd .. && cd vscode-dotnet-runtime-extension && npm install &&  npm run compile && cd .."
+		"compile-all": "build.cmd"
 	},
 	"dependencies": {
 		"p-retry": "^4.2.0",
 		"vscode-dotnet-runtime-extension": "file:./vscode-dotnet-runtime-extension"
 	},
 	"devDependencies": {
+		"copy-webpack-plugin": "^5.1.1",
 		"ts-loader": "^6.2.1",
 		"typescript": "3.4.5",
 		"webpack": "^4.41.5",

--- a/test.ps1
+++ b/test.ps1
@@ -2,18 +2,20 @@ $result = 0
 $errorColor = "Red"
 $successColor = "Green"
 
-pushd vscode-dotnet-runtime-extension
-npm run lint
-if ($LASTEXITCODE -ne 0)
-{
-    Write-Host "`nTSLint Failed.`n" -ForegroundColor $errorColor
-    $result = 1
+if ($args[1] -eq '--tslint') {
+    pushd vscode-dotnet-runtime-extension
+    npm run lint
+    if ($LASTEXITCODE -ne 0)
+    {
+        Write-Host "`nTSLint Failed.`n" -ForegroundColor $errorColor
+        $result = 1
+    }
+    else 
+    {
+        Write-Host "`nTSLint Succeeded.`n" -ForegroundColor $successColor
+    }
+    popd
 }
-else 
-{
-    Write-Host "`nTSLint Succeeded.`n" -ForegroundColor $successColor
-}
-popd
 
 pushd vscode-dotnet-runtime-library
 if (Test-Path node_modules) { rm -r -force node_modules }

--- a/test.sh
+++ b/test.sh
@@ -3,20 +3,23 @@ RED=`tput setaf 1`
 GREEN=`tput setaf 2`
 NC=`tput sgr0`
 
-pushd vscode-dotnet-runtime-extension
-npm run lint
-if [ $? -ne 0 ];
+if [ "$1" = "--tslint" ];
 then
-    echo ""
-    echo "${RED}TSLint Failed.${NC}"
-    echo ""
-    RESULT=1
-else
-    echo ""
-    echo "${GREEN}TSLint Succeeded.${NC}"
-    echo ""
+    pushd vscode-dotnet-runtime-extension
+    npm run lint
+    if [ $? -ne 0 ];
+    then
+        echo ""
+        echo "${RED}TSLint Failed.${NC}"
+        echo ""
+        RESULT=1
+    else
+        echo ""
+        echo "${GREEN}TSLint Succeeded.${NC}"
+        echo ""
+    fi
+    popd
 fi
-popd
 
 echo ""
 echo "----------- Testing vscode-dotnet-runtime-library -----------"

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreDependencyInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreDependencyInstaller.ts
@@ -38,7 +38,7 @@ export class DotnetCoreDependencyInstaller {
     }
 
     public async installLinuxDependencies(additionalLibs: IAdditionalLibs = {}, skipDotNetCore = false): Promise<number> {
-        const scriptRoot = path.join(__dirname, '..', 'scripts');
+        const scriptRoot = path.join(__dirname, '..', 'install scripts');
         const shellCommand = this.getShellCommand();
 
         // Determine the distro

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallScriptAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallScriptAcquisitionWorker.ts
@@ -51,6 +51,7 @@ export class InstallScriptAcquisitionWorker implements IInstallScriptAcquisition
         }
     }
 
+    // Protected for testing purposes
     protected writeScriptAsFile(scriptContent: string, filePath: string) {
         if (!fs.existsSync(path.dirname(filePath))) {
             fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -59,6 +60,7 @@ export class InstallScriptAcquisitionWorker implements IInstallScriptAcquisition
         fs.chmodSync(filePath, 0o777);
     }
 
+    // Protected for testing purposes
     protected getFallbackScriptPath(): string {
         return this.scriptFilePath;
     }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -199,6 +199,10 @@ export class DotnetAcquisitionDeletion extends DotnetAcquisitionMessage {
     }
 }
 
+export class DotnetFallbackInstallScriptUsed extends DotnetAcquisitionMessage {
+    public readonly eventName = 'DotnetFallbackInstallScriptUsed';
+}
+
 export class DotnetAcquisitionPartialInstallation extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetAcquisitionPartialInstallation';
     constructor(public readonly version: string) { super(); }

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -121,11 +121,19 @@ export class MockVersionResolver extends VersionResolver {
 }
 
 export class MockInstallScriptWorker extends InstallScriptAcquisitionWorker {
-    constructor(extensionState: Memento, eventStream: IEventStream, failing: boolean) {
+    constructor(extensionState: Memento, eventStream: IEventStream, failing: boolean, private fallback = false) {
         super(extensionState, eventStream);
         this.webWorker = failing ?
             new FailingWebRequestWorker(extensionState, eventStream, '', '') :
             new MockWebRequestWorker(extensionState, eventStream, '', '');
+    }
+
+    protected getFallbackScriptPath(): string {
+        if (this.fallback) {
+            return path.join(__dirname, '..');
+        } else {
+            return super.getFallbackScriptPath();
+        }
     }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const path = require('path');
+const CopyPlugin = require('copy-webpack-plugin');
 
 /**@type {import('webpack').Configuration}*/
 const config = {
@@ -40,6 +41,11 @@ const config = {
         ]
       }
     ]
-  }
+  },
+  plugins: [
+    new CopyPlugin([
+      { from: path.resolve(__dirname, './vscode-dotnet-runtime-library/install scripts'), to: path.resolve(__dirname, 'dist', 'install scripts') }
+  ]),
+  ]
 };
 module.exports = config;


### PR DESCRIPTION
- 960d32e: Updating azdo pipeline to use build and test scripts (instead of npm scripts)
- 8cfbc7b: Adding install script download to build scripts, copying it to dist in webpack
- fee2414: Adding logic and test coverage for using fallback script