### PR TITLE
Writing manual path config to global settings

### DIFF
--- a/vscode-dotnet-runtime-library/src/IExtensionContext.ts
+++ b/vscode-dotnet-runtime-library/src/IExtensionContext.ts
@@ -13,7 +13,7 @@ export interface IExtensionContext {
 
 export interface IExtensionConfiguration {
     get<T>(name: string): T | undefined;
-    update<T>(section: string, value: T): Thenable<void>;
+    update<T>(section: string, value: T, globalSettings: boolean): Thenable<void>;
 }
 
 export namespace ExistingPathKeys {

--- a/vscode-dotnet-runtime-library/src/Utils/ExtensionConfigurationWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ExtensionConfigurationWorker.ts
@@ -14,6 +14,6 @@ export class ExtensionConfigurationWorker implements IExtensionConfigurationWork
     }
 
     public async setPathConfigurationValue(configValue: IExistingPath[]): Promise<void> {
-        await this.extensionConfiguration.update<IExistingPath[]>(this.pathConfigValueName, configValue);
+        await this.extensionConfiguration.update<IExistingPath[]>(this.pathConfigValueName, configValue, true);
     }
 }


### PR DESCRIPTION
Fixing a bug found by the manual testers where configuring the manual path will fail if workspace settings don't exist. The fix is to write to the global settings instead.