### PR TITLE
Correcting version for existingDotnetPath type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,7 @@
 					"description": "Timeout for installing .NET in seconds."
 				},
 				"dotnetAcquisitionExtension.existingDotnetPath": {
-					"type": {
-						"version": "string",
-						"path": "string"
-					},
+					"type": "array",
 					"description": "File Path to an existing installation of .NET."
 				}
 			}


### PR DESCRIPTION
This does not change extension behavior at all but it ensures that users don't get a wrong type warning when editing this setting in their settings.json. Fixes https://github.com/dotnet/vscode-dotnet-runtime/issues/139.