### PR TITLE
Install to user home on unix

### DIFF
--- a/vscode-dotnet-sdk-extension/src/ExtensionUninstall.ts
+++ b/vscode-dotnet-sdk-extension/src/ExtensionUninstall.ts
@@ -8,12 +8,18 @@ import * as path from 'path';
 import rimraf = require('rimraf');
 
 export function uninstallSDKExtension() {
+    const installFolderName = process.env._VSCODE_DOTNET_INSTALL_FOLDER || '.dotnet';
+    let installPath: string;
     if (os.platform() === 'win32' && process.env.APPDATA) {
-        const installFolderName = process.env._VSCODE_DOTNET_INSTALL_FOLDER || '.dotnet';
-        const installPath = path.join(process.env.APPDATA, installFolderName);
-        if (fs.existsSync(installPath)) {
-            rimraf.sync(installPath);
-        }
+        installPath = path.join(process.env.APPDATA, installFolderName);
+    } else if (os.platform() !== 'win32') {
+        installPath = path.join(os.homedir(), '.vscode-dotnet-sdk');
+    } else {
+        return;
+    }
+
+    if (fs.existsSync(installPath)) {
+        rimraf.sync(installPath);
     }
 }
 

--- a/vscode-dotnet-sdk-extension/src/extension.ts
+++ b/vscode-dotnet-sdk-extension/src/extension.ts
@@ -90,7 +90,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         // Install to %AppData% on windows to avoid running into long path errors
         storagePath = process.env.APPDATA ? process.env.APPDATA : context.globalStoragePath;
     } else {
-        storagePath = context.globalStoragePath;
+        storagePath = path.join(os.homedir(), '.vscode-dotnet-sdk');
         if (!fs.existsSync(storagePath)) {
             fs.mkdirSync(storagePath);
         }

--- a/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -118,14 +118,12 @@ suite('DotnetCoreAcquisitionExtension End to End', function() {
     await vscode.commands.executeCommand('dotnet-sdk.uninstallAll');
   }).timeout(600000);
 
-  test('Extension Uninstall Removes SDKs on Windows', async () => {
-    if (os.platform() === 'win32') {
-      const context: IDotnetAcquireContext = { version: '5.0' };
-      const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet-sdk.acquire', context);
-      assert.exists(result);
-      assert.exists(result!.dotnetPath);
-      uninstallSDKExtension();
-      assert.isFalse(fs.existsSync(result!.dotnetPath));
-    }
+  test('Extension Uninstall Removes SDKs', async () => {
+    const context: IDotnetAcquireContext = { version: '5.0' };
+    const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet-sdk.acquire', context);
+    assert.exists(result);
+    assert.exists(result!.dotnetPath);
+    uninstallSDKExtension();
+    assert.isFalse(fs.existsSync(result!.dotnetPath));
   }).timeout(100000);
 });


### PR DESCRIPTION
Changing install location to 'match' windows installing to AppData. We won't have the path length problems on mac but when we have to eventually work with a offline bundled SDK we won't be able to do so from the vscode extension storage location. 