### PR TITLE
Moving SDK to install directly to .dotnet folder

### DIFF
--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -32,6 +32,7 @@ import {
     IIssueContext,
     InstallationValidator,
     registerEventStream,
+    RuntimeInstallationDirectoryProvider,
     VersionResolver,
     WindowDisplayWorker,
 } from 'vscode-dotnet-runtime-library';
@@ -100,6 +101,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         acquisitionInvoker: new AcquisitionInvoker(context.globalState, eventStream),
         installationValidator: new InstallationValidator(eventStream),
         timeoutValue: timeoutValue === undefined ? defaultTimeoutValue : timeoutValue,
+        installDirectoryProvider: new RuntimeInstallationDirectoryProvider(),
     });
     const existingPathResolver = new ExistingPathResolver();
     const versionResolver = new VersionResolver(context.globalState, eventStream);

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -101,7 +101,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         acquisitionInvoker: new AcquisitionInvoker(context.globalState, eventStream),
         installationValidator: new InstallationValidator(eventStream),
         timeoutValue: timeoutValue === undefined ? defaultTimeoutValue : timeoutValue,
-        installDirectoryProvider: new RuntimeInstallationDirectoryProvider(),
+        installDirectoryProvider: new RuntimeInstallationDirectoryProvider(context.globalStoragePath),
     });
     const existingPathResolver = new ExistingPathResolver();
     const versionResolver = new VersionResolver(context.globalState, eventStream);

--- a/vscode-dotnet-runtime-library/src/Acquisition/IAcquisitionWorkerContext.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IAcquisitionWorkerContext.ts
@@ -5,6 +5,7 @@
 import { IEventStream } from '../EventStream/EventStream';
 import { IExtensionState } from '../IExtensionState';
 import { IAcquisitionInvoker } from './IAcquisitionInvoker';
+import { IInstallationDirectoryProvider } from './IInstallationDirectoryProvider';
 import { IInstallationValidator } from './IInstallationValidator';
 
 export interface IAcquisitionWorkerContext {
@@ -14,4 +15,5 @@ export interface IAcquisitionWorkerContext {
     acquisitionInvoker: IAcquisitionInvoker;
     installationValidator: IInstallationValidator;
     timeoutValue: number;
+    installDirectoryProvider: IInstallationDirectoryProvider;
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/IInstallationDirectoryProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IInstallationDirectoryProvider.ts
@@ -1,0 +1,12 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { IExtensionState } from '../IExtensionState';
+
+export interface IInstallationDirectoryProvider {
+    getDotnetInstallDir(version: string, installDir: string): string;
+
+    isBundleInstalled(dotnetPath: string, version: string, extensionState: IExtensionState, installingVersionsKey: string): boolean;
+}

--- a/vscode-dotnet-runtime-library/src/Acquisition/IInstallationDirectoryProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IInstallationDirectoryProvider.ts
@@ -2,11 +2,15 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
+import * as path from 'path';
 
-import { IExtensionState } from '../IExtensionState';
+export abstract class IInstallationDirectoryProvider {
+    constructor(protected storagePath: string) { }
 
-export interface IInstallationDirectoryProvider {
-    getDotnetInstallDir(version: string, installDir: string): string;
+    public abstract getInstallDir(version: string): string;
 
-    isBundleInstalled(dotnetPath: string, version: string, extensionState: IExtensionState, installingVersionsKey: string): boolean;
+    public getStoragePath(): string {
+        const installFolderName = process.env._VSCODE_DOTNET_INSTALL_FOLDER || '.dotnet';
+        return path.join(this.storagePath, installFolderName);
+    }
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/RuntimeInstallationDirectoryProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RuntimeInstallationDirectoryProvider.ts
@@ -3,18 +3,12 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as fs from 'fs';
 import * as path from 'path';
-import { IExtensionState } from '../IExtensionState';
 import { IInstallationDirectoryProvider } from './IInstallationDirectoryProvider';
 
-export class RuntimeInstallationDirectoryProvider implements IInstallationDirectoryProvider {
-    public getDotnetInstallDir(version: string, installDir: string): string {
-        const dotnetInstallDir = path.join(installDir, version);
+export class RuntimeInstallationDirectoryProvider extends IInstallationDirectoryProvider {
+    public getInstallDir(version: string): string {
+        const dotnetInstallDir = path.join(this.getStoragePath(), version);
         return dotnetInstallDir;
-    }
-
-    public isBundleInstalled(dotnetPath: string, version: string, extensionState: IExtensionState, installingVersionsKey: string): boolean {
-        return fs.existsSync(dotnetPath);
     }
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/RuntimeInstallationDirectoryProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RuntimeInstallationDirectoryProvider.ts
@@ -1,0 +1,20 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { IExtensionState } from '../IExtensionState';
+import { IInstallationDirectoryProvider } from './IInstallationDirectoryProvider';
+
+export class RuntimeInstallationDirectoryProvider implements IInstallationDirectoryProvider {
+    public getDotnetInstallDir(version: string, installDir: string): string {
+        const dotnetInstallDir = path.join(installDir, version);
+        return dotnetInstallDir;
+    }
+
+    public isBundleInstalled(dotnetPath: string, version: string, extensionState: IExtensionState, installingVersionsKey: string): boolean {
+        return fs.existsSync(dotnetPath);
+    }
+}

--- a/vscode-dotnet-runtime-library/src/Acquisition/SdkInstallationDirectoryProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/SdkInstallationDirectoryProvider.ts
@@ -3,17 +3,10 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as fs from 'fs';
-import { IExtensionState } from '../IExtensionState';
 import { IInstallationDirectoryProvider } from './IInstallationDirectoryProvider';
 
-export class SdkInstallationDirectoryProvider implements IInstallationDirectoryProvider {
-    public getDotnetInstallDir(version: string, installDir: string): string {
-        return installDir;
-    }
-
-    public isBundleInstalled(dotnetPath: string, version: string, extensionState: IExtensionState, installingVersionsKey: string): boolean {
-        const installingVersions = extensionState.get<string[]>(installingVersionsKey, []);
-        return installingVersions.includes(version) && fs.existsSync(dotnetPath);
+export class SdkInstallationDirectoryProvider extends IInstallationDirectoryProvider {
+    public getInstallDir(version: string): string {
+        return this.getStoragePath();
     }
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/SdkInstallationDirectoryProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/SdkInstallationDirectoryProvider.ts
@@ -1,0 +1,19 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as fs from 'fs';
+import { IExtensionState } from '../IExtensionState';
+import { IInstallationDirectoryProvider } from './IInstallationDirectoryProvider';
+
+export class SdkInstallationDirectoryProvider implements IInstallationDirectoryProvider {
+    public getDotnetInstallDir(version: string, installDir: string): string {
+        return installDir;
+    }
+
+    public isBundleInstalled(dotnetPath: string, version: string, extensionState: IExtensionState, installingVersionsKey: string): boolean {
+        const installingVersions = extensionState.get<string[]>(installingVersionsKey, []);
+        return installingVersions.includes(version) && fs.existsSync(dotnetPath);
+    }
+}

--- a/vscode-dotnet-runtime-library/src/index.ts
+++ b/vscode-dotnet-runtime-library/src/index.ts
@@ -24,3 +24,5 @@ export * from './Acquisition/VersionResolver';
 export * from './Acquisition/DotnetCoreDependencyInstaller';
 export * from './Utils/ExtensionConfigurationWorker';
 export * from './Acquisition/ExistingPathResolver';
+export * from './Acquisition/SdkInstallationDirectoryProvider';
+export * from './Acquisition/RuntimeInstallationDirectoryProvider';

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -42,7 +42,7 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function() {
             acquisitionInvoker: new NoInstallAcquisitionInvoker(eventStream),
             installationValidator: new MockInstallationValidator(eventStream),
             timeoutValue: 10,
-            installDirectoryProvider: runtimeInstall ? new RuntimeInstallationDirectoryProvider() : new SdkInstallationDirectoryProvider(),
+            installDirectoryProvider: runtimeInstall ? new RuntimeInstallationDirectoryProvider('') : new SdkInstallationDirectoryProvider(''),
         });
         return [ acquisitionWorker, eventStream, context ];
     }
@@ -159,7 +159,7 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function() {
             acquisitionInvoker: new RejectingAcquisitionInvoker(eventStream),
             installationValidator: new MockInstallationValidator(eventStream),
             timeoutValue: 10,
-            installDirectoryProvider: new RuntimeInstallationDirectoryProvider(),
+            installDirectoryProvider: new RuntimeInstallationDirectoryProvider(''),
         });
 
         return assert.isRejected(acquisitionWorker.acquireRuntime('1.0'), '.NET Acquisition Failed: Installation failed: Rejecting message');

--- a/vscode-dotnet-runtime-library/src/test/unit/WebRequestWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WebRequestWorker.test.ts
@@ -40,7 +40,7 @@ suite('WebRequestWorker Unit Tests', () => {
             acquisitionInvoker: new ErrorAcquisitionInvoker(eventStream),
             installationValidator: new MockInstallationValidator(eventStream),
             timeoutValue: 10,
-            installDirectoryProvider: new RuntimeInstallationDirectoryProvider(),
+            installDirectoryProvider: new RuntimeInstallationDirectoryProvider(''),
         });
         return assert.isRejected(acquisitionWorker.acquireRuntime('1.0'), Error, '.NET Acquisition Failed');
     });

--- a/vscode-dotnet-runtime-library/src/test/unit/WebRequestWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WebRequestWorker.test.ts
@@ -7,6 +7,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as path from 'path';
 import { DotnetCoreAcquisitionWorker } from '../../Acquisition/DotnetCoreAcquisitionWorker';
 import { IInstallScriptAcquisitionWorker } from '../../Acquisition/IInstallScriptAcquisitionWorker';
+import { RuntimeInstallationDirectoryProvider } from '../../Acquisition/RuntimeInstallationDirectoryProvider';
 import {
     DotnetFallbackInstallScriptUsed,
     DotnetInstallScriptAcquisitionError,
@@ -39,6 +40,7 @@ suite('WebRequestWorker Unit Tests', () => {
             acquisitionInvoker: new ErrorAcquisitionInvoker(eventStream),
             installationValidator: new MockInstallationValidator(eventStream),
             timeoutValue: 10,
+            installDirectoryProvider: new RuntimeInstallationDirectoryProvider(),
         });
         return assert.isRejected(acquisitionWorker.acquireRuntime('1.0'), Error, '.NET Acquisition Failed');
     });

--- a/vscode-dotnet-sdk-extension/src/extension.ts
+++ b/vscode-dotnet-sdk-extension/src/extension.ts
@@ -27,6 +27,7 @@ import {
     IIssueContext,
     InstallationValidator,
     registerEventStream,
+    SdkInstallationDirectoryProvider,
     VersionResolver,
     WindowDisplayWorker,
 } from 'vscode-dotnet-runtime-library';
@@ -103,6 +104,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         acquisitionInvoker: new AcquisitionInvoker(context.globalState, eventStream),
         installationValidator: new InstallationValidator(eventStream),
         timeoutValue: timeoutValue === undefined ? defaultTimeoutValue : timeoutValue,
+        installDirectoryProvider: new SdkInstallationDirectoryProvider(),
     });
     const versionResolver = new VersionResolver(context.globalState, eventStream);
 

--- a/vscode-dotnet-sdk-extension/src/extension.ts
+++ b/vscode-dotnet-sdk-extension/src/extension.ts
@@ -104,7 +104,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         acquisitionInvoker: new AcquisitionInvoker(context.globalState, eventStream),
         installationValidator: new InstallationValidator(eventStream),
         timeoutValue: timeoutValue === undefined ? defaultTimeoutValue : timeoutValue,
-        installDirectoryProvider: new SdkInstallationDirectoryProvider(),
+        installDirectoryProvider: new SdkInstallationDirectoryProvider(storagePath),
     });
     const versionResolver = new VersionResolver(context.globalState, eventStream);
 

--- a/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -57,7 +57,8 @@ suite('DotnetCoreAcquisitionExtension End to End', function() {
     assert.exists(result);
     assert.exists(result!.dotnetPath);
     assert.include(result!.dotnetPath, '.dotnet');
-    assert.include(result!.dotnetPath, context.version);
+    const sdkDir = fs.readdirSync(path.join(path.dirname(result!.dotnetPath), 'sdk'))[0];
+    assert.include(sdkDir, context.version);
     if (os.platform() === 'win32') {
       assert.include(result!.dotnetPath, process.env.APPDATA!);
     }
@@ -92,28 +93,35 @@ suite('DotnetCoreAcquisitionExtension End to End', function() {
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet-sdk.acquire', context);
     assert.exists(result);
     assert.exists(result!.dotnetPath);
-    assert.include(result!.dotnetPath, context.version);
+    const sdkDir = fs.readdirSync(path.join(path.dirname(result!.dotnetPath), 'sdk'))[0];
+    assert.include(sdkDir, context.version);
     assert.isTrue(fs.existsSync(result!.dotnetPath!));
     await vscode.commands.executeCommand('dotnet-sdk.uninstallAll');
     assert.isFalse(fs.existsSync(result!.dotnetPath));
   }).timeout(100000);
 
   test('Install Multiple Versions', async () => {
-    const versions = ['3.1', '5.0'];
-    let dotnetPaths: string[] = [];
-    for (const version of versions) {
-      const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet-sdk.acquire', { version });
-      assert.exists(result);
-      assert.exists(result!.dotnetPath);
-      assert.include(result!.dotnetPath, version);
-      if (result!.dotnetPath) {
-        dotnetPaths = dotnetPaths.concat(result!.dotnetPath);
-      }
-    }
-    // All versions are still there after all installs are completed
-    for (const dotnetPath of dotnetPaths) {
-      assert.isTrue(fs.existsSync(dotnetPath));
-    }
+    // Install 3.1
+    let version = '3.1';
+    let result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet-sdk.acquire', { version });
+    assert.exists(result);
+    assert.exists(result!.dotnetPath);
+    let sdkDirs = fs.readdirSync(path.join(path.dirname(result!.dotnetPath), 'sdk'));
+    assert.isNotEmpty(sdkDirs.filter(dir => dir.includes(version)));
+
+    // Install 5.0
+    version = '5.0';
+    result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet-sdk.acquire', { version });
+    assert.exists(result);
+    assert.exists(result!.dotnetPath);
+    sdkDirs = fs.readdirSync(path.join(path.dirname(result!.dotnetPath), 'sdk'));
+    assert.isNotEmpty(sdkDirs.filter(dir => dir.includes(version)));
+
+    // 5.0 and 3.1 SDKs should still be installed
+    sdkDirs = fs.readdirSync(path.join(path.dirname(result!.dotnetPath), 'sdk'));
+    assert.isNotEmpty(sdkDirs.filter(dir => dir.includes('3.1')));
+    assert.isNotEmpty(sdkDirs.filter(dir => dir.includes('5.0')));
+
     // Clean up storage
     await vscode.commands.executeCommand('dotnet-sdk.uninstallAll');
   }).timeout(600000);


### PR DESCRIPTION
Based on our discussion in https://github.com/dotnet/vscode-dotnet-runtime/issues/178, I think we should remove the prefix version from the SDK install path (instead of installing to `%AppData%\.dotnet\{version}`, install directly to `%AppData%\.dotnet`). This will have 2 main benefits: it will allow us to only have to add to the PATH once, regardless of how many SDK installations/ updates we make. With the current model we have to add a new directory to the path with every update, including patch updates, which will quickly get out of hand. Changing the install location will also allow some sharing across SDK versions, for example, if there are multiple SDKs installed they will all use the same dotnet.exe. 