### PR TITLE
Add logic to handle local preinstalled SDKs

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -116,7 +116,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         const dotnetPath = path.join(dotnetInstallDir, this.dotnetExecutable);
 
         if (fs.existsSync(dotnetPath) && installedVersions.length === 0) {
-            // A local install already exists, add it to our managed installs
+            // The education bundle already laid down a local install, add it to our managed installs
             installedVersions = await this.managePreinstalledVersion(dotnetInstallDir, installedVersions);
         }
 

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -83,6 +83,10 @@ export class WebRequestError extends DotnetAcquisitionError {
     public readonly eventName = 'WebRequestError';
 }
 
+export class DotnetPreinstallDetectionError extends DotnetAcquisitionError {
+    public readonly eventName = 'DotnetPreinstallDetectionError';
+}
+
 export class DotnetCommandFailed extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetCommandFailed';
 
@@ -368,6 +372,15 @@ export class WebRequestSent extends DotnetAcquisitionMessage {
 
     public getProperties() {
         return {WebRequestUri : this.url};
+    }
+}
+
+export class DotnetPreinstallDetected extends DotnetAcquisitionMessage {
+    public readonly eventName = 'DotnetPreinstallDetected';
+    constructor(public readonly version: string) { super(); }
+
+    public getProperties() {
+        return {PreinstalledVersion : this.version};
     }
 }
 


### PR DESCRIPTION
Add logic to pick up offline, local SDK installs from the education bundle installer, located in `%AppData%/.dotnet` on windows and `$HOME/.vscode-dotnet-sdk` on other platforms. cc @mavasani 