### PR TITLE
Remove install script redirects

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallScriptAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallScriptAcquisitionWorker.ts
@@ -18,7 +18,7 @@ import { IInstallScriptAcquisitionWorker } from './IInstallScriptAcquisitionWork
 
 export class InstallScriptAcquisitionWorker implements IInstallScriptAcquisitionWorker {
     protected webWorker: WebRequestWorker;
-    private readonly scriptAcquisitionUrl: string = 'https://aka.ms/dotnet-install-script-';
+    private readonly scriptAcquisitionUrl: string = 'https://dot.net/v1/dotnet-install.';
     private readonly scriptFilePath: string;
 
     constructor(extensionState: IExtensionState, private readonly eventStream: IEventStream) {


### PR DESCRIPTION
Hopefully fixing https://github.com/dotnet/vscode-dotnet-runtime/issues/114 based on this suggestion: https://github.com/dotnet/vscode-dotnet-runtime/issues/114#issuecomment-898665972. This should be a no-risk fix since the install scripts team now have test coverage before they release updates to the scripts in this link. 