### PR TITLE
Bump extension versions

### DIFF
--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -29,7 +29,7 @@
 		},
 		"../vscode-dotnet-runtime-extension": {
 			"name": "vscode-dotnet-runtime",
-			"version": "1.3.0",
+			"version": "1.4.0",
 			"license": "MIT",
 			"dependencies": {
 				"chai": "^4.2.0",
@@ -9421,7 +9421,7 @@
 		},
 		"../vscode-dotnet-sdk-extension": {
 			"name": "vscode-dotnet-sdk",
-			"version": "0.8.0",
+			"version": "0.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/chai": "^4.2.7",

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-dotnet-runtime",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-dotnet-runtime",
-			"version": "1.3.0",
+			"version": "1.4.0",
 			"license": "MIT",
 			"dependencies": {
 				"chai": "^4.2.0",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -13,7 +13,7 @@
 	"description": "Allows acquisition of the .NET runtime specifically for VS Code extension authors.",
 	"appInsightsKey": "02dc18e0-7494-43b2-b2a3-18ada5fcb522",
 	"icon": "images/dotnetIcon.png",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"publisher": "ms-dotnettools",
 	"engines": {
 		"vscode": "^1.41.0"

--- a/vscode-dotnet-sdk-extension/package-lock.json
+++ b/vscode-dotnet-sdk-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-dotnet-sdk",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-dotnet-sdk",
-			"version": "0.8.0",
+			"version": "0.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/chai": "^4.2.7",

--- a/vscode-dotnet-sdk-extension/package.json
+++ b/vscode-dotnet-sdk-extension/package.json
@@ -13,7 +13,7 @@
 	"description": "Allows acquisition of the .NET SDK.",
 	"appInsightsKey": "02dc18e0-7494-43b2-b2a3-18ada5fcb522",
 	"icon": "images/dotnetIcon.png",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"publisher": "ms-dotnettools",
 	"engines": {
 		"vscode": "^1.41.0"


### PR DESCRIPTION
Finally got around to releasing new versions of the extensions with the latest changes (https://github.com/dotnet/vscode-dotnet-runtime/pull/284 and lots of dependency updates), bumping version numbers