### PR TITLE
Separate extension state installation records

### DIFF
--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -32,6 +32,7 @@ chai.use(chaiAsPromised);
 
 suite('DotnetCoreAcquisitionWorker Unit Tests', function() {
     const installingVersionsKey = 'installing';
+    const installedVersionsKey = 'installed';
     const dotnetFolderName = `.dotnet O'Hare O'Donald`;
 
     function getTestAcquisitionWorker(runtimeInstall: boolean): [ DotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext ] {
@@ -66,7 +67,9 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function() {
         assert.equal(exePath, expectedPath);
 
         // Should be finished installing
-        assert.isEmpty(context.get(installingVersionsKey));
+        assert.isEmpty(context.get<string[]>(installingVersionsKey, []));
+        assert.isNotEmpty(context.get<string[]>(installedVersionsKey, []));
+        assert.include(context.get<string[]>(installedVersionsKey, []), version);
 
         //  No errors in event stream
         assert.notExists(eventStream.events.find(event => event.type === EventType.DotnetAcquisitionError));
@@ -158,6 +161,8 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function() {
         await acquisitionWorker.uninstallAll();
         assert.exists(eventStream.events.find(event => event instanceof DotnetUninstallAllStarted));
         assert.exists(eventStream.events.find(event => event instanceof DotnetUninstallAllCompleted));
+        assert.isEmpty(context.get<string[]>(installingVersionsKey, []));
+        assert.isEmpty(context.get<string[]>(installedVersionsKey, []));
     });
 
     test('Acquire Runtime and UninstallAll', async () => {
@@ -169,6 +174,8 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function() {
         await acquisitionWorker.uninstallAll();
         assert.exists(eventStream.events.find(event => event instanceof DotnetUninstallAllStarted));
         assert.exists(eventStream.events.find(event => event instanceof DotnetUninstallAllCompleted));
+        assert.isEmpty(context.get<string[]>(installingVersionsKey, []));
+        assert.isEmpty(context.get<string[]>(installedVersionsKey, []));
     });
 
     test('Repeated Acquisition', async () => {


### PR DESCRIPTION
It looks like the bug reported [here ](https://github.com/dotnet/vscode-dotnet-runtime/pull/335#issuecomment-967717720)was a mix up with how we record installation versions. We were using installingVersions extension state to check if a version was installed but that state actually represented which versions were in the process of being installed. To fix this, I've added a new extension state item to keep track of which versions we have installed. 