### PR TITLE
Add .NPMRC and fix outstanding build issues 

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,16 +35,10 @@ stages:
         Windows:
           imageName: 'windows-latest'
     steps:
-    - task: npmAuthenticate@0
+    - task: NodeTool@0
       inputs:
         versionSpec: '15.x'
-        workingFile: .npmrc
       displayName: 'Install Node.js'
-    - task: npmAuthenticate@0
-      inputs:
-        versionSpec: '15.x'
-        workingFile: 'vscode-dotnet-runtime-library/.npmrc'
-      displayName: 'Auth runtime-library'
     - script: build.cmd
       displayName: Build Windows
       condition: eq(variables['Agent.OS'], 'Windows_NT')
@@ -75,12 +69,14 @@ stages:
     pool:
       vmImage: 'windows-latest'
     steps:
-    - task: npmAuthenticate@0
+    - task: NodeTool@0
       inputs:
-        workingFile: .npmrc
-        displayName: 'Authenticate NPM and Run Lint'
-    - script: npm install tslint 
-    - script: npm run lint
+        versionSpec: '15.x'
+      displayName: 'Install Node.js'
+    - bash: |
+        npm install -g tslint
+        npm run lint
+      displayName: Run Lint
   ##### Package and Publish #####
   - job: Package
     displayName: 'Package and Publish'
@@ -99,7 +95,7 @@ stages:
           dir-name: 'vscode-dotnet-sdk-extension'
           package-name: 'vscode-dotnet-sdk'
     steps:
-    - task: npmAuthenticate@0
+    - task: NodeTool@0
       inputs:
         versionSpec: '15.x'
       displayName: 'Install Node.js'
@@ -115,9 +111,10 @@ stages:
       name: GetVersion
       displayName: 'Get Version'
       workingDirectory: $(dir-name)
-    - script: npm install -g rimraf
-    - script: npm install -g vsce
-    - script: vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn
+    - bash: |
+          npm install -g rimraf
+          npm install -g vsce
+          vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn
       displayName: Package Artifact
       workingDirectory: $(dir-name)
     - task: CopyFiles@2
@@ -149,10 +146,9 @@ stages:
     pool:
       vmImage: 'windows-latest'
     steps:
-    - task: npmAuthenticate@0
+    - task: NodeTool@0
       inputs:
         versionSpec: '15.x'
-        workingFile: .npmrc
       displayName: 'Install Node.js'
     - bash: |
         VERSION=`node -p "require('./package.json').version"`
@@ -176,13 +172,13 @@ stages:
       displayName: 'Download Packaged Extension'
       inputs:
         path: '$(System.ArtifactsDirectory)'
-    - task: npmAuthenticate@0
+    - task: NodeTool@0
       inputs:
         versionSpec: '15.x'
-        workingFile: .npmrc
       displayName: 'Install Node.js'
-    - script: npm install vsce
-    - script: vsce publish --packagePath vscode-dotnet-runtime-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
+    - bash: |
+        npm install -g vsce
+        vsce publish --packagePath vscode-dotnet-runtime-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
       displayName: 'Publish to Marketplace'
       workingDirectory: '$(System.ArtifactsDirectory)/vscode-dotnet-runtime-extension'
 
@@ -203,10 +199,9 @@ stages:
     pool:
       vmImage: 'windows-latest'
     steps:
-    - task: npmAuthenticate@0
+    - task: NodeTool@0
       inputs:
         versionSpec: '15.x'
-        workingFile: .npmrc
       displayName: 'Install Node.js'
     - bash: |
         VERSION=`node -p "require('./package.json').version"`
@@ -230,13 +225,12 @@ stages:
       displayName: 'Download Packaged Extension'
       inputs:
         path: '$(System.ArtifactsDirectory)'
-    - task: npmAuthenticate@0
+    - task: NodeTool@0
       inputs:
         versionSpec: '15.x'
-        workingFile: .npmrc
       displayName: 'Install Node.js'
     - bash: |
-        npm install vsce
+        npm install -g vsce
         vsce publish --packagePath vscode-dotnet-sdk-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
       displayName: 'Publish to Marketplace'
       workingDirectory: '$(System.ArtifactsDirectory)/vscode-dotnet-sdk-extension'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,50 +19,50 @@ variables:
 
 stages:
 ##### Test and Build #####
-# - stage: Build
-#   jobs:
-#   ##### Build #####
-#   - job: Build
-#     displayName: 'Build and Test'
-#     pool:
-#       vmImage: $(imageName)
-#     strategy:
-#       matrix:
-#         Linux:
-#           imageName: 'ubuntu-latest'
-#         Mac:
-#           imageName: 'macOS-latest'
-#         Windows:
-#           imageName: 'windows-latest'
-#     steps:
-#     - task: NodeTool@0
-#       inputs:
-#         versionSpec: '15.x'
-#       displayName: 'Install Node.js'
-#     - script: build.cmd
-#       displayName: Build Windows
-#       condition: eq(variables['Agent.OS'], 'Windows_NT')
-#     - script: test.cmd
-#       displayName: Test Windows
-#       condition: eq(variables['Agent.OS'], 'Windows_NT')
-#     - bash: |
-#         /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-#         echo ">>> Started xvfb"
-#       displayName: Start xvfb
-#       condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-#     - script: ./build.sh
-#       displayName: Build Mac and Linux
-#       condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
-#     - script: ./test.sh
-#       displayName: Test Mac and Linux
-#       env: { DISPLAY: ':99.0' }
-#       condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
-#     - task: PublishBuildArtifacts@1
-#       inputs:
-#         pathtoPublish: '$(Build.SourcesDirectory)/vscode-dotnet-runtime-extension/dist/test/functional/logs'
-#         artifactName: 'logs'
-#       displayName: Publish Logs
-#       condition: always()
+- stage: Build
+  jobs:
+  ##### Build #####
+  - job: Build
+    displayName: 'Build and Test'
+    pool:
+      vmImage: $(imageName)
+    strategy:
+      matrix:
+        Linux:
+          imageName: 'ubuntu-latest'
+        Mac:
+          imageName: 'macOS-latest'
+        Windows:
+          imageName: 'windows-latest'
+    steps:
+    - task: NodeTool@0
+      inputs:
+        versionSpec: '15.x'
+      displayName: 'Install Node.js'
+    - script: build.cmd
+      displayName: Build Windows
+      condition: eq(variables['Agent.OS'], 'Windows_NT')
+    - script: test.cmd
+      displayName: Test Windows
+      condition: eq(variables['Agent.OS'], 'Windows_NT')
+    - bash: |
+        /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+        echo ">>> Started xvfb"
+      displayName: Start xvfb
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+    - script: ./build.sh
+      displayName: Build Mac and Linux
+      condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
+    - script: ./test.sh
+      displayName: Test Mac and Linux
+      env: { DISPLAY: ':99.0' }
+      condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathtoPublish: '$(Build.SourcesDirectory)/vscode-dotnet-runtime-extension/dist/test/functional/logs'
+        artifactName: 'logs'
+      displayName: Publish Logs
+      condition: always()
   ##### TSLint #####
   - job: TSLint
     displayName: 'TSLint'
@@ -78,159 +78,159 @@ stages:
         npm run lint
       displayName: Run Lint
   ##### Package and Publish #####
-#   - job: Package
-#     displayName: 'Package and Publish'
-#     dependsOn: 
-#     - Build
-#     - TSLint
-#     condition: and(succeeded(), notin(variables['Build.Reason'], 'PullRequest'))
-#     pool:
-#       vmImage: 'windows-latest'
-#     strategy:
-#       matrix:
-#         Runtime:
-#           dir-name: 'vscode-dotnet-runtime-extension'
-#           package-name: 'vscode-dotnet-runtime'
-#         SDK:
-#           dir-name: 'vscode-dotnet-sdk-extension'
-#           package-name: 'vscode-dotnet-sdk'
-#     steps:
-#     - task: NodeTool@0
-#       inputs:
-#         versionSpec: '15.x'
-#       displayName: 'Install Node.js'
-#     - bash: |
-#         if ([ $(is-sdk-release) = 'True' ] && [ $(package-name) = 'vscode-dotnet-sdk' ]) || ([ $(is-runtime-release) = 'True' ] && [ $(package-name) = 'vscode-dotnet-runtime' ]); then
-#           VERSION=`node -p "require('./package.json').version"`
-#         else
-#           VERSION_NUM=`node -p "require('./package.json').version"`
-#           VERSION="$VERSION_NUM-alpha-$(Build.BuildId)"
-#         fi
-#         npm version $VERSION --allow-same-version
-#         echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
-#       name: GetVersion
-#       displayName: 'Get Version'
-#       workingDirectory: $(dir-name)
-#     - bash: |
-#           npm install -g rimraf
-#           npm install -g vsce
-#           vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn
-#       displayName: Package Artifact
-#       workingDirectory: $(dir-name)
-#     - task: CopyFiles@2
-#       displayName: 'Copy Artifact'
-#       inputs:
-#         SourceFolder: '$(Build.SourcesDirectory)'
-#         Contents: '**\*.vsix'
-#         TargetFolder: '$(Build.ArtifactStagingDirectory)'
-#         flattenFolders: true
-#     - task: PublishPipelineArtifact@0
-#       inputs:
-#         targetPath: '$(Build.ArtifactStagingDirectory)'
-#         artifactName: '$(dir-name)'
+  - job: Package
+    displayName: 'Package and Publish'
+    dependsOn: 
+    - Build
+    - TSLint
+    condition: and(succeeded(), notin(variables['Build.Reason'], 'PullRequest'))
+    pool:
+      vmImage: 'windows-latest'
+    strategy:
+      matrix:
+        Runtime:
+          dir-name: 'vscode-dotnet-runtime-extension'
+          package-name: 'vscode-dotnet-runtime'
+        SDK:
+          dir-name: 'vscode-dotnet-sdk-extension'
+          package-name: 'vscode-dotnet-sdk'
+    steps:
+    - task: NodeTool@0
+      inputs:
+        versionSpec: '15.x'
+      displayName: 'Install Node.js'
+    - bash: |
+        if ([ $(is-sdk-release) = 'True' ] && [ $(package-name) = 'vscode-dotnet-sdk' ]) || ([ $(is-runtime-release) = 'True' ] && [ $(package-name) = 'vscode-dotnet-runtime' ]); then
+          VERSION=`node -p "require('./package.json').version"`
+        else
+          VERSION_NUM=`node -p "require('./package.json').version"`
+          VERSION="$VERSION_NUM-alpha-$(Build.BuildId)"
+        fi
+        npm version $VERSION --allow-same-version
+        echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
+      name: GetVersion
+      displayName: 'Get Version'
+      workingDirectory: $(dir-name)
+    - bash: |
+          npm install -g rimraf
+          npm install -g vsce
+          vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn
+      displayName: Package Artifact
+      workingDirectory: $(dir-name)
+    - task: CopyFiles@2
+      displayName: 'Copy Artifact'
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)'
+        Contents: '**\*.vsix'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)'
+        flattenFolders: true
+    - task: PublishPipelineArtifact@0
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+        artifactName: '$(dir-name)'
 
-# ##### Deploy and Release Runtime Extension #####
-# - stage: DeployAndReleaseRuntime
-#   dependsOn: Build
-#   condition: and(succeeded(), eq(variables['is-runtime-release'], 'true'))
-#   jobs:
-#   ##### Deploy to our release environment #####
-#   # Note: This step requires approval, allows for manual smoke testing the artifact before release
-#   - deployment: Deploy
-#     pool:
-#       vmImage: 'windows-latest'
-#     environment: 'vscode-dotnetcore-extension-releases'
-#   ##### Determine version to publish #####
-#   - job: GetVersion
-#     displayName: 'Get Version'
-#     pool:
-#       vmImage: 'windows-latest'
-#     steps:
-#     - task: NodeTool@0
-#       inputs:
-#         versionSpec: '15.x'
-#       displayName: 'Install Node.js'
-#     - bash: |
-#         VERSION=`node -p "require('./package.json').version"`
-#         echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
-#       name: GetVersion
-#       workingDirectory: 'vscode-dotnet-runtime-extension'
-#       displayName: 'Get Version'
-#   ##### Publish to marketplace #####
-#   - job: Publish
-#     displayName: 'Publish to Marketplace'
-#     dependsOn: 
-#     - Deploy
-#     - GetVersion
-#     pool:
-#       vmImage: 'windows-latest'
-#     variables:
-#       version: $[ dependencies.GetVersion.outputs['GetVersion.version'] ]
-#     steps:
-#     - checkout: none # Skip checking out repo
-#     - task: DownloadPipelineArtifact@2
-#       displayName: 'Download Packaged Extension'
-#       inputs:
-#         path: '$(System.ArtifactsDirectory)'
-#     - task: NodeTool@0
-#       inputs:
-#         versionSpec: '15.x'
-#       displayName: 'Install Node.js'
-#     - bash: |
-#         npm install -g vsce
-#         vsce publish --packagePath vscode-dotnet-runtime-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
-#       displayName: 'Publish to Marketplace'
-#       workingDirectory: '$(System.ArtifactsDirectory)/vscode-dotnet-runtime-extension'
+##### Deploy and Release Runtime Extension #####
+- stage: DeployAndReleaseRuntime
+  dependsOn: Build
+  condition: and(succeeded(), eq(variables['is-runtime-release'], 'true'))
+  jobs:
+  ##### Deploy to our release environment #####
+  # Note: This step requires approval, allows for manual smoke testing the artifact before release
+  - deployment: Deploy
+    pool:
+      vmImage: 'windows-latest'
+    environment: 'vscode-dotnetcore-extension-releases'
+  ##### Determine version to publish #####
+  - job: GetVersion
+    displayName: 'Get Version'
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    - task: NodeTool@0
+      inputs:
+        versionSpec: '15.x'
+      displayName: 'Install Node.js'
+    - bash: |
+        VERSION=`node -p "require('./package.json').version"`
+        echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
+      name: GetVersion
+      workingDirectory: 'vscode-dotnet-runtime-extension'
+      displayName: 'Get Version'
+  ##### Publish to marketplace #####
+  - job: Publish
+    displayName: 'Publish to Marketplace'
+    dependsOn: 
+    - Deploy
+    - GetVersion
+    pool:
+      vmImage: 'windows-latest'
+    variables:
+      version: $[ dependencies.GetVersion.outputs['GetVersion.version'] ]
+    steps:
+    - checkout: none # Skip checking out repo
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download Packaged Extension'
+      inputs:
+        path: '$(System.ArtifactsDirectory)'
+    - task: NodeTool@0
+      inputs:
+        versionSpec: '15.x'
+      displayName: 'Install Node.js'
+    - bash: |
+        npm install -g vsce
+        vsce publish --packagePath vscode-dotnet-runtime-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
+      displayName: 'Publish to Marketplace'
+      workingDirectory: '$(System.ArtifactsDirectory)/vscode-dotnet-runtime-extension'
 
-# ##### Deploy and Release SDK Extension #####
-# - stage: DeployAndReleaseSDK
-#   dependsOn: Build
-#   condition: and(succeeded(), eq(variables['is-sdk-release'], 'true'))
-#   jobs:
-#   ##### Deploy to our release environment #####
-#   # Note: This step requires approval, allows for manual smoke testing the artifact before release
-#   - deployment: Deploy
-#     pool:
-#       vmImage: 'windows-latest'
-#     environment: 'vscode-dotnetcore-extension-releases'
-#   ##### Determine version to publish #####
-#   - job: GetVersion
-#     displayName: 'Get Version'
-#     pool:
-#       vmImage: 'windows-latest'
-#     steps:
-#     - task: NodeTool@0
-#       inputs:
-#         versionSpec: '15.x'
-#       displayName: 'Install Node.js'
-#     - bash: |
-#         VERSION=`node -p "require('./package.json').version"`
-#         echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
-#       name: GetVersion
-#       workingDirectory: 'vscode-dotnet-sdk-extension'
-#       displayName: 'Get Version'
-#   ##### Publish to marketplace #####
-#   - job: Publish
-#     displayName: 'Publish to Marketplace'
-#     dependsOn: 
-#     - Deploy
-#     - GetVersion
-#     pool:
-#       vmImage: 'windows-latest'
-#     variables:
-#       version: $[ dependencies.GetVersion.outputs['GetVersion.version'] ]
-#     steps:
-#     - checkout: none # Skip checking out repo
-#     - task: DownloadPipelineArtifact@2
-#       displayName: 'Download Packaged Extension'
-#       inputs:
-#         path: '$(System.ArtifactsDirectory)'
-#     - task: NodeTool@0
-#       inputs:
-#         versionSpec: '15.x'
-#       displayName: 'Install Node.js'
-#     - bash: |
-#         npm install -g vsce
-#         vsce publish --packagePath vscode-dotnet-sdk-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
-#       displayName: 'Publish to Marketplace'
-#       workingDirectory: '$(System.ArtifactsDirectory)/vscode-dotnet-sdk-extension'
+##### Deploy and Release SDK Extension #####
+- stage: DeployAndReleaseSDK
+  dependsOn: Build
+  condition: and(succeeded(), eq(variables['is-sdk-release'], 'true'))
+  jobs:
+  ##### Deploy to our release environment #####
+  # Note: This step requires approval, allows for manual smoke testing the artifact before release
+  - deployment: Deploy
+    pool:
+      vmImage: 'windows-latest'
+    environment: 'vscode-dotnetcore-extension-releases'
+  ##### Determine version to publish #####
+  - job: GetVersion
+    displayName: 'Get Version'
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    - task: NodeTool@0
+      inputs:
+        versionSpec: '15.x'
+      displayName: 'Install Node.js'
+    - bash: |
+        VERSION=`node -p "require('./package.json').version"`
+        echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
+      name: GetVersion
+      workingDirectory: 'vscode-dotnet-sdk-extension'
+      displayName: 'Get Version'
+  ##### Publish to marketplace #####
+  - job: Publish
+    displayName: 'Publish to Marketplace'
+    dependsOn: 
+    - Deploy
+    - GetVersion
+    pool:
+      vmImage: 'windows-latest'
+    variables:
+      version: $[ dependencies.GetVersion.outputs['GetVersion.version'] ]
+    steps:
+    - checkout: none # Skip checking out repo
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download Packaged Extension'
+      inputs:
+        path: '$(System.ArtifactsDirectory)'
+    - task: NodeTool@0
+      inputs:
+        versionSpec: '15.x'
+      displayName: 'Install Node.js'
+    - bash: |
+        npm install -g vsce
+        vsce publish --packagePath vscode-dotnet-sdk-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
+      displayName: 'Publish to Marketplace'
+      workingDirectory: '$(System.ArtifactsDirectory)/vscode-dotnet-sdk-extension'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,50 +19,50 @@ variables:
 
 stages:
 ##### Test and Build #####
-- stage: Build
-  jobs:
-  ##### Build #####
-  - job: Build
-    displayName: 'Build and Test'
-    pool:
-      vmImage: $(imageName)
-    strategy:
-      matrix:
-        Linux:
-          imageName: 'ubuntu-latest'
-        Mac:
-          imageName: 'macOS-latest'
-        Windows:
-          imageName: 'windows-latest'
-    steps:
-    - task: NodeTool@0
-      inputs:
-        versionSpec: '15.x'
-      displayName: 'Install Node.js'
-    - script: build.cmd
-      displayName: Build Windows
-      condition: eq(variables['Agent.OS'], 'Windows_NT')
-    - script: test.cmd
-      displayName: Test Windows
-      condition: eq(variables['Agent.OS'], 'Windows_NT')
-    - bash: |
-        /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-        echo ">>> Started xvfb"
-      displayName: Start xvfb
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-    - script: ./build.sh
-      displayName: Build Mac and Linux
-      condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
-    - script: ./test.sh
-      displayName: Test Mac and Linux
-      env: { DISPLAY: ':99.0' }
-      condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
-    - task: PublishBuildArtifacts@1
-      inputs:
-        pathtoPublish: '$(Build.SourcesDirectory)/vscode-dotnet-runtime-extension/dist/test/functional/logs'
-        artifactName: 'logs'
-      displayName: Publish Logs
-      condition: always()
+# - stage: Build
+#   jobs:
+#   ##### Build #####
+#   - job: Build
+#     displayName: 'Build and Test'
+#     pool:
+#       vmImage: $(imageName)
+#     strategy:
+#       matrix:
+#         Linux:
+#           imageName: 'ubuntu-latest'
+#         Mac:
+#           imageName: 'macOS-latest'
+#         Windows:
+#           imageName: 'windows-latest'
+#     steps:
+#     - task: NodeTool@0
+#       inputs:
+#         versionSpec: '15.x'
+#       displayName: 'Install Node.js'
+#     - script: build.cmd
+#       displayName: Build Windows
+#       condition: eq(variables['Agent.OS'], 'Windows_NT')
+#     - script: test.cmd
+#       displayName: Test Windows
+#       condition: eq(variables['Agent.OS'], 'Windows_NT')
+#     - bash: |
+#         /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+#         echo ">>> Started xvfb"
+#       displayName: Start xvfb
+#       condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+#     - script: ./build.sh
+#       displayName: Build Mac and Linux
+#       condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
+#     - script: ./test.sh
+#       displayName: Test Mac and Linux
+#       env: { DISPLAY: ':99.0' }
+#       condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
+#     - task: PublishBuildArtifacts@1
+#       inputs:
+#         pathtoPublish: '$(Build.SourcesDirectory)/vscode-dotnet-runtime-extension/dist/test/functional/logs'
+#         artifactName: 'logs'
+#       displayName: Publish Logs
+#       condition: always()
   ##### TSLint #####
   - job: TSLint
     displayName: 'TSLint'
@@ -78,159 +78,159 @@ stages:
         npm run lint
       displayName: Run Lint
   ##### Package and Publish #####
-  - job: Package
-    displayName: 'Package and Publish'
-    dependsOn: 
-    - Build
-    - TSLint
-    condition: and(succeeded(), notin(variables['Build.Reason'], 'PullRequest'))
-    pool:
-      vmImage: 'windows-latest'
-    strategy:
-      matrix:
-        Runtime:
-          dir-name: 'vscode-dotnet-runtime-extension'
-          package-name: 'vscode-dotnet-runtime'
-        SDK:
-          dir-name: 'vscode-dotnet-sdk-extension'
-          package-name: 'vscode-dotnet-sdk'
-    steps:
-    - task: NodeTool@0
-      inputs:
-        versionSpec: '15.x'
-      displayName: 'Install Node.js'
-    - bash: |
-        if ([ $(is-sdk-release) = 'True' ] && [ $(package-name) = 'vscode-dotnet-sdk' ]) || ([ $(is-runtime-release) = 'True' ] && [ $(package-name) = 'vscode-dotnet-runtime' ]); then
-          VERSION=`node -p "require('./package.json').version"`
-        else
-          VERSION_NUM=`node -p "require('./package.json').version"`
-          VERSION="$VERSION_NUM-alpha-$(Build.BuildId)"
-        fi
-        npm version $VERSION --allow-same-version
-        echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
-      name: GetVersion
-      displayName: 'Get Version'
-      workingDirectory: $(dir-name)
-    - bash: |
-          npm install -g rimraf
-          npm install -g vsce
-          vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn
-      displayName: Package Artifact
-      workingDirectory: $(dir-name)
-    - task: CopyFiles@2
-      displayName: 'Copy Artifact'
-      inputs:
-        SourceFolder: '$(Build.SourcesDirectory)'
-        Contents: '**\*.vsix'
-        TargetFolder: '$(Build.ArtifactStagingDirectory)'
-        flattenFolders: true
-    - task: PublishPipelineArtifact@0
-      inputs:
-        targetPath: '$(Build.ArtifactStagingDirectory)'
-        artifactName: '$(dir-name)'
+#   - job: Package
+#     displayName: 'Package and Publish'
+#     dependsOn: 
+#     - Build
+#     - TSLint
+#     condition: and(succeeded(), notin(variables['Build.Reason'], 'PullRequest'))
+#     pool:
+#       vmImage: 'windows-latest'
+#     strategy:
+#       matrix:
+#         Runtime:
+#           dir-name: 'vscode-dotnet-runtime-extension'
+#           package-name: 'vscode-dotnet-runtime'
+#         SDK:
+#           dir-name: 'vscode-dotnet-sdk-extension'
+#           package-name: 'vscode-dotnet-sdk'
+#     steps:
+#     - task: NodeTool@0
+#       inputs:
+#         versionSpec: '15.x'
+#       displayName: 'Install Node.js'
+#     - bash: |
+#         if ([ $(is-sdk-release) = 'True' ] && [ $(package-name) = 'vscode-dotnet-sdk' ]) || ([ $(is-runtime-release) = 'True' ] && [ $(package-name) = 'vscode-dotnet-runtime' ]); then
+#           VERSION=`node -p "require('./package.json').version"`
+#         else
+#           VERSION_NUM=`node -p "require('./package.json').version"`
+#           VERSION="$VERSION_NUM-alpha-$(Build.BuildId)"
+#         fi
+#         npm version $VERSION --allow-same-version
+#         echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
+#       name: GetVersion
+#       displayName: 'Get Version'
+#       workingDirectory: $(dir-name)
+#     - bash: |
+#           npm install -g rimraf
+#           npm install -g vsce
+#           vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn
+#       displayName: Package Artifact
+#       workingDirectory: $(dir-name)
+#     - task: CopyFiles@2
+#       displayName: 'Copy Artifact'
+#       inputs:
+#         SourceFolder: '$(Build.SourcesDirectory)'
+#         Contents: '**\*.vsix'
+#         TargetFolder: '$(Build.ArtifactStagingDirectory)'
+#         flattenFolders: true
+#     - task: PublishPipelineArtifact@0
+#       inputs:
+#         targetPath: '$(Build.ArtifactStagingDirectory)'
+#         artifactName: '$(dir-name)'
 
-##### Deploy and Release Runtime Extension #####
-- stage: DeployAndReleaseRuntime
-  dependsOn: Build
-  condition: and(succeeded(), eq(variables['is-runtime-release'], 'true'))
-  jobs:
-  ##### Deploy to our release environment #####
-  # Note: This step requires approval, allows for manual smoke testing the artifact before release
-  - deployment: Deploy
-    pool:
-      vmImage: 'windows-latest'
-    environment: 'vscode-dotnetcore-extension-releases'
-  ##### Determine version to publish #####
-  - job: GetVersion
-    displayName: 'Get Version'
-    pool:
-      vmImage: 'windows-latest'
-    steps:
-    - task: NodeTool@0
-      inputs:
-        versionSpec: '15.x'
-      displayName: 'Install Node.js'
-    - bash: |
-        VERSION=`node -p "require('./package.json').version"`
-        echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
-      name: GetVersion
-      workingDirectory: 'vscode-dotnet-runtime-extension'
-      displayName: 'Get Version'
-  ##### Publish to marketplace #####
-  - job: Publish
-    displayName: 'Publish to Marketplace'
-    dependsOn: 
-    - Deploy
-    - GetVersion
-    pool:
-      vmImage: 'windows-latest'
-    variables:
-      version: $[ dependencies.GetVersion.outputs['GetVersion.version'] ]
-    steps:
-    - checkout: none # Skip checking out repo
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download Packaged Extension'
-      inputs:
-        path: '$(System.ArtifactsDirectory)'
-    - task: NodeTool@0
-      inputs:
-        versionSpec: '15.x'
-      displayName: 'Install Node.js'
-    - bash: |
-        npm install -g vsce
-        vsce publish --packagePath vscode-dotnet-runtime-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
-      displayName: 'Publish to Marketplace'
-      workingDirectory: '$(System.ArtifactsDirectory)/vscode-dotnet-runtime-extension'
+# ##### Deploy and Release Runtime Extension #####
+# - stage: DeployAndReleaseRuntime
+#   dependsOn: Build
+#   condition: and(succeeded(), eq(variables['is-runtime-release'], 'true'))
+#   jobs:
+#   ##### Deploy to our release environment #####
+#   # Note: This step requires approval, allows for manual smoke testing the artifact before release
+#   - deployment: Deploy
+#     pool:
+#       vmImage: 'windows-latest'
+#     environment: 'vscode-dotnetcore-extension-releases'
+#   ##### Determine version to publish #####
+#   - job: GetVersion
+#     displayName: 'Get Version'
+#     pool:
+#       vmImage: 'windows-latest'
+#     steps:
+#     - task: NodeTool@0
+#       inputs:
+#         versionSpec: '15.x'
+#       displayName: 'Install Node.js'
+#     - bash: |
+#         VERSION=`node -p "require('./package.json').version"`
+#         echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
+#       name: GetVersion
+#       workingDirectory: 'vscode-dotnet-runtime-extension'
+#       displayName: 'Get Version'
+#   ##### Publish to marketplace #####
+#   - job: Publish
+#     displayName: 'Publish to Marketplace'
+#     dependsOn: 
+#     - Deploy
+#     - GetVersion
+#     pool:
+#       vmImage: 'windows-latest'
+#     variables:
+#       version: $[ dependencies.GetVersion.outputs['GetVersion.version'] ]
+#     steps:
+#     - checkout: none # Skip checking out repo
+#     - task: DownloadPipelineArtifact@2
+#       displayName: 'Download Packaged Extension'
+#       inputs:
+#         path: '$(System.ArtifactsDirectory)'
+#     - task: NodeTool@0
+#       inputs:
+#         versionSpec: '15.x'
+#       displayName: 'Install Node.js'
+#     - bash: |
+#         npm install -g vsce
+#         vsce publish --packagePath vscode-dotnet-runtime-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
+#       displayName: 'Publish to Marketplace'
+#       workingDirectory: '$(System.ArtifactsDirectory)/vscode-dotnet-runtime-extension'
 
-##### Deploy and Release SDK Extension #####
-- stage: DeployAndReleaseSDK
-  dependsOn: Build
-  condition: and(succeeded(), eq(variables['is-sdk-release'], 'true'))
-  jobs:
-  ##### Deploy to our release environment #####
-  # Note: This step requires approval, allows for manual smoke testing the artifact before release
-  - deployment: Deploy
-    pool:
-      vmImage: 'windows-latest'
-    environment: 'vscode-dotnetcore-extension-releases'
-  ##### Determine version to publish #####
-  - job: GetVersion
-    displayName: 'Get Version'
-    pool:
-      vmImage: 'windows-latest'
-    steps:
-    - task: NodeTool@0
-      inputs:
-        versionSpec: '15.x'
-      displayName: 'Install Node.js'
-    - bash: |
-        VERSION=`node -p "require('./package.json').version"`
-        echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
-      name: GetVersion
-      workingDirectory: 'vscode-dotnet-sdk-extension'
-      displayName: 'Get Version'
-  ##### Publish to marketplace #####
-  - job: Publish
-    displayName: 'Publish to Marketplace'
-    dependsOn: 
-    - Deploy
-    - GetVersion
-    pool:
-      vmImage: 'windows-latest'
-    variables:
-      version: $[ dependencies.GetVersion.outputs['GetVersion.version'] ]
-    steps:
-    - checkout: none # Skip checking out repo
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download Packaged Extension'
-      inputs:
-        path: '$(System.ArtifactsDirectory)'
-    - task: NodeTool@0
-      inputs:
-        versionSpec: '15.x'
-      displayName: 'Install Node.js'
-    - bash: |
-        npm install -g vsce
-        vsce publish --packagePath vscode-dotnet-sdk-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
-      displayName: 'Publish to Marketplace'
-      workingDirectory: '$(System.ArtifactsDirectory)/vscode-dotnet-sdk-extension'
+# ##### Deploy and Release SDK Extension #####
+# - stage: DeployAndReleaseSDK
+#   dependsOn: Build
+#   condition: and(succeeded(), eq(variables['is-sdk-release'], 'true'))
+#   jobs:
+#   ##### Deploy to our release environment #####
+#   # Note: This step requires approval, allows for manual smoke testing the artifact before release
+#   - deployment: Deploy
+#     pool:
+#       vmImage: 'windows-latest'
+#     environment: 'vscode-dotnetcore-extension-releases'
+#   ##### Determine version to publish #####
+#   - job: GetVersion
+#     displayName: 'Get Version'
+#     pool:
+#       vmImage: 'windows-latest'
+#     steps:
+#     - task: NodeTool@0
+#       inputs:
+#         versionSpec: '15.x'
+#       displayName: 'Install Node.js'
+#     - bash: |
+#         VERSION=`node -p "require('./package.json').version"`
+#         echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
+#       name: GetVersion
+#       workingDirectory: 'vscode-dotnet-sdk-extension'
+#       displayName: 'Get Version'
+#   ##### Publish to marketplace #####
+#   - job: Publish
+#     displayName: 'Publish to Marketplace'
+#     dependsOn: 
+#     - Deploy
+#     - GetVersion
+#     pool:
+#       vmImage: 'windows-latest'
+#     variables:
+#       version: $[ dependencies.GetVersion.outputs['GetVersion.version'] ]
+#     steps:
+#     - checkout: none # Skip checking out repo
+#     - task: DownloadPipelineArtifact@2
+#       displayName: 'Download Packaged Extension'
+#       inputs:
+#         path: '$(System.ArtifactsDirectory)'
+#     - task: NodeTool@0
+#       inputs:
+#         versionSpec: '15.x'
+#       displayName: 'Install Node.js'
+#     - bash: |
+#         npm install -g vsce
+#         vsce publish --packagePath vscode-dotnet-sdk-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
+#       displayName: 'Publish to Marketplace'
+#       workingDirectory: '$(System.ArtifactsDirectory)/vscode-dotnet-sdk-extension'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ stages:
     - task: npmAuthenticate@0
       inputs:
         workingFile: .npmrc
-        displayName: 'Authenticate NPM'
+        displayName: 'Authenticate NPM and Run Lint'
     - script: npm install tslint 
     - script: npm run lint
   ##### Package and Publish #####

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ stages:
         versionSpec: '15.x'
       displayName: 'Install Node.js'
     - bash: |
-        npm install -g tslint
+        npm install -g tslint --verbose
         npm run lint
       displayName: Run Lint
   ##### Package and Publish #####

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,14 +69,12 @@ stages:
     pool:
       vmImage: 'vs2017-win2016'
     steps:
-    - task: NodeTool@0
-      inputs:
-        versionSpec: '15.x'
-      displayName: 'Install Node.js'
-    - bash: |
-        npm install -g tslint
-        npm run lint
-      displayName: Run Lint
+    - task: npmAuthenticate@0
+    inputs:
+      workingFile: .npmrc
+      displayName: 'Authenticate NPM'
+    - script: npm install tslint 
+    - script: npm run lint
   ##### Package and Publish #####
   - job: Package
     displayName: 'Package and Publish'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,8 @@ variables:
 
 stages:
 ##### Test and Build #####
-- stage: Build
-  jobs:
+# - stage: Build
+#   jobs:
 #   ##### Build #####
 #   - job: Build
 #     displayName: 'Build and Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,8 @@ variables:
 
 stages:
 ##### Test and Build #####
-# - stage: Build
-#   jobs:
+- stage: Build
+  jobs:
 #   ##### Build #####
 #   - job: Build
 #     displayName: 'Build and Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,9 +40,11 @@ stages:
         versionSpec: '15.x'
         workingFile: .npmrc
       displayName: 'Install Node.js'
-    - script: npm install
-    - script: npm install vsts-npm-auth
-    - script: vsts-npm-auth -config .npmrc
+    - task: npmAuthenticate@0
+      inputs:
+        versionSpec: '15.x'
+        workingFile: 'vscode-dotnet-runtime-library/.npmrc'
+      displayName: 'Auth runtime-library'
     - script: build.cmd
       displayName: Build Windows
       condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,9 +35,10 @@ stages:
         Windows:
           imageName: 'windows-latest'
     steps:
-    - task: NodeTool@0
+    - task: npmAuthenticate@0
       inputs:
         versionSpec: '15.x'
+        workingFile: .npmrc
       displayName: 'Install Node.js'
     - script: build.cmd
       displayName: Build Windows
@@ -93,7 +94,7 @@ stages:
           dir-name: 'vscode-dotnet-sdk-extension'
           package-name: 'vscode-dotnet-sdk'
     steps:
-    - task: NodeTool@0
+    - task: npmAuthenticate@0
       inputs:
         versionSpec: '15.x'
       displayName: 'Install Node.js'
@@ -109,10 +110,9 @@ stages:
       name: GetVersion
       displayName: 'Get Version'
       workingDirectory: $(dir-name)
-    - bash: |
-        npm install -g rimraf
-        npm install -g vsce
-        vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn
+    - script: npm install -g rimraf
+    - script: npm install -g vsce
+    - script: vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn
       displayName: Package Artifact
       workingDirectory: $(dir-name)
     - task: CopyFiles@2
@@ -144,9 +144,10 @@ stages:
     pool:
       vmImage: 'windows-latest'
     steps:
-    - task: NodeTool@0
+    - task: npmAuthenticate@0
       inputs:
         versionSpec: '15.x'
+        workingFile: .npmrc
       displayName: 'Install Node.js'
     - bash: |
         VERSION=`node -p "require('./package.json').version"`
@@ -170,13 +171,13 @@ stages:
       displayName: 'Download Packaged Extension'
       inputs:
         path: '$(System.ArtifactsDirectory)'
-    - task: NodeTool@0
+    - task: npmAuthenticate@0
       inputs:
         versionSpec: '15.x'
+        workingFile: .npmrc
       displayName: 'Install Node.js'
-    - bash: |
-        npm install -g vsce
-        vsce publish --packagePath vscode-dotnet-runtime-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
+    - script: npm install vsce
+    - script: vsce publish --packagePath vscode-dotnet-runtime-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
       displayName: 'Publish to Marketplace'
       workingDirectory: '$(System.ArtifactsDirectory)/vscode-dotnet-runtime-extension'
 
@@ -197,9 +198,10 @@ stages:
     pool:
       vmImage: 'windows-latest'
     steps:
-    - task: NodeTool@0
+    - task: npmAuthenticate@0
       inputs:
         versionSpec: '15.x'
+        workingFile: .npmrc
       displayName: 'Install Node.js'
     - bash: |
         VERSION=`node -p "require('./package.json').version"`
@@ -223,12 +225,13 @@ stages:
       displayName: 'Download Packaged Extension'
       inputs:
         path: '$(System.ArtifactsDirectory)'
-    - task: NodeTool@0
+    - task: npmAuthenticate@0
       inputs:
         versionSpec: '15.x'
+        workingFile: .npmrc
       displayName: 'Install Node.js'
     - bash: |
-        npm install -g vsce
+        npm install vsce
         vsce publish --packagePath vscode-dotnet-sdk-$(version).vsix -p $(VSCODE_MARKETPLACE_TOKEN)
       displayName: 'Publish to Marketplace'
       workingDirectory: '$(System.ArtifactsDirectory)/vscode-dotnet-sdk-extension'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ stages:
         versionSpec: '15.x'
       displayName: 'Install Node.js'
     - bash: |
-        npm install -g tslint --verbose
+        npm install -g tslint
         npm run lint
       displayName: Run Lint
   ##### Package and Publish #####

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ stages:
   - job: TSLint
     displayName: 'TSLint'
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
     steps:
     - task: npmAuthenticate@0
       inputs:
@@ -83,7 +83,7 @@ stages:
     - TSLint
     condition: and(succeeded(), notin(variables['Build.Reason'], 'PullRequest'))
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
     strategy:
       matrix:
         Runtime:
@@ -136,13 +136,13 @@ stages:
   # Note: This step requires approval, allows for manual smoke testing the artifact before release
   - deployment: Deploy
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
     environment: 'vscode-dotnetcore-extension-releases'
   ##### Determine version to publish #####
   - job: GetVersion
     displayName: 'Get Version'
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
     steps:
     - task: NodeTool@0
       inputs:
@@ -161,7 +161,7 @@ stages:
     - Deploy
     - GetVersion
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
     variables:
       version: $[ dependencies.GetVersion.outputs['GetVersion.version'] ]
     steps:
@@ -189,13 +189,13 @@ stages:
   # Note: This step requires approval, allows for manual smoke testing the artifact before release
   - deployment: Deploy
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
     environment: 'vscode-dotnetcore-extension-releases'
   ##### Determine version to publish #####
   - job: GetVersion
     displayName: 'Get Version'
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
     steps:
     - task: NodeTool@0
       inputs:
@@ -214,7 +214,7 @@ stages:
     - Deploy
     - GetVersion
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
     variables:
       version: $[ dependencies.GetVersion.outputs['GetVersion.version'] ]
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,9 @@ stages:
         versionSpec: '15.x'
         workingFile: .npmrc
       displayName: 'Install Node.js'
+    - script: npm install
+    - script: npm install vsts-npm-auth
+    - script: vsts-npm-auth -config .npmrc
     - script: build.cmd
       displayName: Build Windows
       condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,9 +70,9 @@ stages:
       vmImage: 'vs2017-win2016'
     steps:
     - task: npmAuthenticate@0
-    inputs:
-      workingFile: .npmrc
-      displayName: 'Authenticate NPM'
+      inputs:
+        workingFile: .npmrc
+        displayName: 'Authenticate NPM'
     - script: npm install tslint 
     - script: npm run lint
   ##### Package and Publish #####

--- a/sample/.npmrc
+++ b/sample/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -17,14 +17,14 @@
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"mocha": "^9.1.3",
 				"rimraf": "3.0.2",
 				"tslint": "5.20.1",
 				"typescript": "4.4.4"
 			},
 			"engines": {
-				"vscode": "^1.62.0"
+				"vscode": "1.62.0"
 			}
 		},
 		"../vscode-dotnet-runtime-extension": {
@@ -53,13 +53,13 @@
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"copy-webpack-plugin": "9.0.1",
 				"webpack": "5.63.0",
 				"webpack-cli": "4.9.1"
 			},
 			"engines": {
-				"vscode": "^1.62.0"
+				"vscode": "1.62.0"
 			}
 		},
 		"../vscode-dotnet-runtime-library": {
@@ -73,7 +73,7 @@
 				"@types/rimraf": "3.0.2",
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"chai": "^4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",
@@ -97,7 +97,7 @@
 				"glob": "^7.2.0"
 			},
 			"engines": {
-				"vscode": "^1.62.0"
+				"vscode": "1.62.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "^2.3.2"
@@ -113,7 +113,7 @@
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"chai": "^4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"child_process": "^1.0.2",
@@ -137,7 +137,7 @@
 				"webpack-cli": "4.9.1"
 			},
 			"engines": {
-				"vscode": "^1.62.0"
+				"vscode": "1.62.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -2532,7 +2532,7 @@
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"chai": "^4.3.4",
 				"child_process": "^1.0.2",
 				"copy-webpack-plugin": "9.0.1",
@@ -2564,7 +2564,7 @@
 				"@types/rimraf": "3.0.2",
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"chai": "^4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",
@@ -2594,7 +2594,7 @@
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"chai": "^4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"child_process": "^1.0.2",

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -28,11 +28,10 @@
 			}
 		},
 		"../vscode-dotnet-runtime-extension": {
-			"name": "vscode-dotnet-runtime",
 			"version": "1.6.0",
 			"license": "MIT",
 			"dependencies": {
-				"chai": "^4.3.4",
+				"chai": "4.3.4",
 				"child_process": "^1.0.2",
 				"diff": ">=5.0.0",
 				"glob": "^7.2.0",
@@ -49,7 +48,7 @@
 				"vscode-test": "^1.6.1"
 			},
 			"devDependencies": {
-				"@types/chai": "^4.2.22",
+				"@types/chai": "4.2.22",
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
@@ -74,7 +73,7 @@
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
 				"@types/vscode": "1.62.0",
-				"chai": "^4.3.4",
+				"chai": "4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",
 				"eol": "^0.9.1",
@@ -93,7 +92,7 @@
 				"vscode-test": "^1.6.1"
 			},
 			"devDependencies": {
-				"@types/chai": "^4.2.22",
+				"@types/chai": "4.2.22",
 				"glob": "^7.2.0"
 			},
 			"engines": {
@@ -104,17 +103,16 @@
 			}
 		},
 		"../vscode-dotnet-sdk-extension": {
-			"name": "vscode-dotnet-sdk",
 			"version": "0.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"@types/chai": "^4.2.22",
+				"@types/chai": "4.2.22",
 				"@types/chai-as-promised": "^7.1.4",
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
 				"@types/vscode": "1.62.0",
-				"chai": "^4.3.4",
+				"chai": "4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"child_process": "^1.0.2",
 				"diff": ">=5.0.0",
@@ -141,33 +139,36 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-			"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha1-OyXTjIlgC6otzCGe36iKdOssQno=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.16.0"
+				"@babel/highlight": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.15.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha1-nJfjDTGyuMcqHQiYTyyptXTXoHY=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-			"integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha1-gRWGAek+JWN5Wty/vfXWS+Py7N8=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -177,9 +178,10 @@
 		},
 		"node_modules/@babel/highlight/node_modules/ansi-styles": {
 			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -189,9 +191,10 @@
 		},
 		"node_modules/@babel/highlight/node_modules/chalk": {
 			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -203,42 +206,47 @@
 		},
 		"node_modules/@babel/highlight/node_modules/color-convert": {
 			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/color-name": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/has-flag": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/supports-color": {
 			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -248,9 +256,10 @@
 		},
 		"node_modules/@types/glob": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-vBtb86qS8lvV3TnzXFc2G9zlsus=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/minimatch": "*",
 				"@types/node": "*"
@@ -258,27 +267,31 @@
 		},
 		"node_modules/@types/minimatch": {
 			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/minimatch/-/minimatch-3.0.5.tgz",
+			"integrity": "sha1-EAHMXmo3BLg8I2An538vWOoBD0A=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/mocha": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-			"integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
-			"dev": true
+			"version": "9.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/mocha/-/mocha-9.1.1.tgz",
+			"integrity": "sha1-58TxAB7vpLivvR7uJ6I3/uO/KcQ=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "16.11.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-			"integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-16.11.7.tgz",
+			"integrity": "sha1-NoIJRQYTJpeMQqAeVrYc0iPf3EI=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-pj0XWzMXSOUiCtSMkB17vx9E7vg=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/glob": "*",
 				"@types/node": "*"
@@ -286,30 +299,44 @@
 		},
 		"node_modules/@types/vscode": {
 			"version": "1.62.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.62.0.tgz",
+			"integrity": "sha1-tNbRktWut16R0K3vaJw+zvmHnac=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@ungap/promise-all-settled": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+			"integrity": "sha1-qlgEJxHW4ydd033Fl+XTHowpCkQ=",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -322,9 +349,10 @@
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -335,30 +363,34 @@
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
+			"dev": true,
+			"license": "Python-2.0"
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -366,9 +398,10 @@
 		},
 		"node_modules/braces": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.0.1"
 			},
@@ -378,24 +411,27 @@
 		},
 		"node_modules/browser-stdout": {
 			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/builtin-modules": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/camelcase": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+			"version": "6.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -405,9 +441,10 @@
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -421,9 +458,10 @@
 		},
 		"node_modules/chalk/node_modules/supports-color": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -432,10 +470,17 @@
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha1-HPN8hwe5Mr0a8a4iwEMuKs0ZA70=",
 			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			],
+			"license": "MIT",
 			"dependencies": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -454,64 +499,22 @@
 		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
 			}
 		},
-		"node_modules/cliui/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cliui/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cliui/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cliui/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -521,27 +524,31 @@
 		},
 		"node_modules/color-name": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/commander": {
 			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -556,15 +563,17 @@
 		},
 		"node_modules/debug/node_modules/ms": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/decamelize": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -574,33 +583,37 @@
 		},
 		"node_modules/diff": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha1-ftatdthZ0DB4fsNYVfWx2vMdhSs=",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/escalade": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -610,9 +623,10 @@
 		},
 		"node_modules/esprima": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -623,9 +637,10 @@
 		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -635,9 +650,10 @@
 		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -651,25 +667,27 @@
 		},
 		"node_modules/flat": {
 			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE=",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"bin": {
 				"flat": "cli.js"
 			}
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
 			"dev": true,
-			"hasInstallScript": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -680,24 +698,27 @@
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
 		"node_modules/glob": {
-			"version": "7.1.7",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"version": "7.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -715,9 +736,10 @@
 		},
 		"node_modules/glob-parent": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
 			},
@@ -725,20 +747,35 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/growl": {
 			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.x"
 			}
 		},
 		"node_modules/has": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has/-/has-1.0.3.tgz",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.1"
 			},
@@ -748,27 +785,30 @@
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/he": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/he/-/he-1.2.0.tgz",
+			"integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"he": "bin/he"
 			}
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -776,15 +816,17 @@
 		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"binary-extensions": "^2.0.0"
 			},
@@ -793,10 +835,11 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-			"integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+			"version": "2.9.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha1-4cNEKc1Rxt2eCeB5njluJ7GanGk=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has": "^1.0.3"
 			},
@@ -806,18 +849,30 @@
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
 			},
@@ -827,27 +882,30 @@
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
 		},
 		"node_modules/is-plain-obj": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -857,21 +915,24 @@
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -881,9 +942,10 @@
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -896,9 +958,10 @@
 		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"is-unicode-supported": "^0.1.0"
@@ -911,62 +974,66 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "4.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-4.2.1.tgz",
+			"integrity": "sha1-QNnVEaRr3E5WPCLDCAzenA2CmbQ=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=10"
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
+			"version": "1.2.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			},
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			}
 		},
 		"node_modules/mocha": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-			"integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+			"version": "9.2.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mocha/-/mocha-9.2.2.tgz",
+			"integrity": "sha1-1w20a9uTyldALICTM+WoSXeoj7k=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.2",
-				"debug": "4.3.2",
+				"chokidar": "3.5.3",
+				"debug": "4.3.3",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
-				"glob": "7.1.7",
+				"glob": "7.2.0",
 				"growl": "1.10.5",
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
-				"minimatch": "3.0.4",
+				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
+				"nanoid": "3.3.1",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"workerpool": "6.1.5",
+				"workerpool": "6.2.0",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
@@ -985,15 +1052,17 @@
 		},
 		"node_modules/ms": {
 			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+			"version": "3.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha1-Y0ehjKyIr4j1ivCzWUtyPV6ZuzU=",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -1003,27 +1072,30 @@
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
 			}
 		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -1036,9 +1108,10 @@
 		},
 		"node_modules/p-locate": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -1051,33 +1124,37 @@
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+			"version": "2.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -1087,18 +1164,20 @@
 		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
 		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"picomatch": "^2.2.1"
 			},
@@ -1108,21 +1187,27 @@
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"version": "1.22.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha1-J8suu1P5GrtJRwqSi7p1WAZqwXc=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -1130,9 +1215,10 @@
 		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -1145,8 +1231,8 @@
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
 			"dev": true,
 			"funding": [
 				{
@@ -1161,37 +1247,70 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"license": "MIT"
 		},
 		"node_modules/semver": {
 			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
 			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+			"integrity": "sha1-765diPRdeSQUHai1w6en5mP+/rg=",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
 		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -1201,9 +1320,10 @@
 		},
 		"node_modules/supports-color": {
 			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -1214,11 +1334,25 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -1228,15 +1362,17 @@
 		},
 		"node_modules/tslib": {
 			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
+			"dev": true,
+			"license": "0BSD"
 		},
 		"node_modules/tslint": {
 			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslint/-/tslint-5.20.1.tgz",
+			"integrity": "sha1-5AHortoBUrxE3QfmFANPP4DGe30=",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
 				"builtin-modules": "^1.1.1",
@@ -1264,9 +1400,10 @@
 		},
 		"node_modules/tslint/node_modules/ansi-styles": {
 			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -1276,18 +1413,20 @@
 		},
 		"node_modules/tslint/node_modules/argparse": {
 			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
 		},
 		"node_modules/tslint/node_modules/chalk": {
 			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -1299,51 +1438,57 @@
 		},
 		"node_modules/tslint/node_modules/color-convert": {
 			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
 		},
 		"node_modules/tslint/node_modules/color-name": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tslint/node_modules/diff": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/tslint/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/tslint/node_modules/has-flag": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/tslint/node_modules/js-yaml": {
 			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -1352,11 +1497,25 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/tslint/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/tslint/node_modules/supports-color": {
 			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -1366,9 +1525,10 @@
 		},
 		"node_modules/tslint/node_modules/tsutils": {
 			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "^1.8.1"
 			},
@@ -1378,9 +1538,10 @@
 		},
 		"node_modules/typescript": {
 			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha1-LNAaGh8WBwTTEB/VpY/w+fy4Aww=",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -1403,9 +1564,10 @@
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
+			"integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -1417,16 +1579,18 @@
 			}
 		},
 		"node_modules/workerpool": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-			"integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
-			"dev": true
+			"version": "6.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/workerpool/-/workerpool-6.2.0.tgz",
+			"integrity": "sha1-gn2Tyboj7iAZw/+v9cJ/zOoonos=",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -1439,70 +1603,29 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/wrap-ansi/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
@@ -1518,18 +1641,20 @@
 		},
 		"node_modules/yargs-parser": {
 			"version": "20.2.4",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-parser/-/yargs-parser-20.2.4.tgz",
+			"integrity": "sha1-tCiQ8UVmeW+Fro46JSkNIF8VSlQ=",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/yargs-unparser": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"camelcase": "^6.0.0",
 				"decamelize": "^4.0.0",
@@ -1540,55 +1665,12 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/yargs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/yargs/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/yargs/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/yargs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1599,35 +1681,35 @@
 	},
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-			"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha1-OyXTjIlgC6otzCGe36iKdOssQno=",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.16.0"
+				"@babel/highlight": "^7.18.6"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.15.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha1-nJfjDTGyuMcqHQiYTyyptXTXoHY=",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-			"integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha1-gRWGAek+JWN5Wty/vfXWS+Py7N8=",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -1635,8 +1717,8 @@
 				},
 				"chalk": {
 					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
@@ -1646,8 +1728,8 @@
 				},
 				"color-convert": {
 					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
 					"dev": true,
 					"requires": {
 						"color-name": "1.1.3"
@@ -1655,26 +1737,26 @@
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 					"dev": true
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -1684,8 +1766,8 @@
 		},
 		"@types/glob": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-vBtb86qS8lvV3TnzXFc2G9zlsus=",
 			"dev": true,
 			"requires": {
 				"@types/minimatch": "*",
@@ -1694,26 +1776,26 @@
 		},
 		"@types/minimatch": {
 			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/minimatch/-/minimatch-3.0.5.tgz",
+			"integrity": "sha1-EAHMXmo3BLg8I2An538vWOoBD0A=",
 			"dev": true
 		},
 		"@types/mocha": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-			"integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
+			"version": "9.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/mocha/-/mocha-9.1.1.tgz",
+			"integrity": "sha1-58TxAB7vpLivvR7uJ6I3/uO/KcQ=",
 			"dev": true
 		},
 		"@types/node": {
 			"version": "16.11.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-			"integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-16.11.7.tgz",
+			"integrity": "sha1-NoIJRQYTJpeMQqAeVrYc0iPf3EI=",
 			"dev": true
 		},
 		"@types/rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-pj0XWzMXSOUiCtSMkB17vx9E7vg=",
 			"dev": true,
 			"requires": {
 				"@types/glob": "*",
@@ -1722,26 +1804,32 @@
 		},
 		"@types/vscode": {
 			"version": "1.62.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.62.0.tgz",
+			"integrity": "sha1-tNbRktWut16R0K3vaJw+zvmHnac=",
 			"dev": true
 		},
 		"@ungap/promise-all-settled": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+			"integrity": "sha1-qlgEJxHW4ydd033Fl+XTHowpCkQ=",
 			"dev": true
 		},
 		"ansi-colors": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g=",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
 			"dev": true
 		},
 		"ansi-styles": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
 			"dev": true,
 			"requires": {
 				"color-convert": "^2.0.1"
@@ -1749,8 +1837,8 @@
 		},
 		"anymatch": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
 			"dev": true,
 			"requires": {
 				"normalize-path": "^3.0.0",
@@ -1759,26 +1847,26 @@
 		},
 		"argparse": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
 			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
 			"dev": true
 		},
 		"binary-extensions": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0=",
 			"dev": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
 			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
@@ -1787,8 +1875,8 @@
 		},
 		"braces": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
 			"dev": true,
 			"requires": {
 				"fill-range": "^7.0.1"
@@ -1796,26 +1884,26 @@
 		},
 		"browser-stdout": {
 			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
 			"dev": true
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
 		},
 		"camelcase": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+			"version": "6.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
 			"dev": true
 		},
 		"chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^4.1.0",
@@ -1824,8 +1912,8 @@
 			"dependencies": {
 				"supports-color": {
 					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -1834,9 +1922,9 @@
 			}
 		},
 		"chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha1-HPN8hwe5Mr0a8a4iwEMuKs0ZA70=",
 			"dev": true,
 			"requires": {
 				"anymatch": "~3.1.2",
@@ -1851,53 +1939,19 @@
 		},
 		"cliui": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
 			"dev": true,
 			"requires": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.1"
-					}
-				}
 			}
 		},
 		"color-convert": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
 			"dev": true,
 			"requires": {
 				"color-name": "~1.1.4"
@@ -1905,26 +1959,26 @@
 		},
 		"color-name": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
 			"dev": true
 		},
 		"commander": {
 			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
 			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
 		"debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
 			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
@@ -1932,52 +1986,52 @@
 			"dependencies": {
 				"ms": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
 					"dev": true
 				}
 			}
 		},
 		"decamelize": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
 			"dev": true
 		},
 		"diff": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha1-ftatdthZ0DB4fsNYVfWx2vMdhSs=",
 			"dev": true
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
 			"dev": true
 		},
 		"escalade": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
 			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
 			"dev": true
 		},
 		"esprima": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
 			"dev": true
 		},
 		"fill-range": {
 			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
 			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"
@@ -1985,8 +2039,8 @@
 		},
 		"find-up": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
 			"dev": true,
 			"requires": {
 				"locate-path": "^6.0.0",
@@ -1995,39 +2049,39 @@
 		},
 		"flat": {
 			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE=",
 			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
 		"fsevents": {
 			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
 			"dev": true,
 			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
 			"dev": true
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.7",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"version": "7.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -2036,12 +2090,23 @@
 				"minimatch": "^3.0.4",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
+			},
+			"dependencies": {
+				"minimatch": {
+					"version": "3.1.2",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+					"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				}
 			}
 		},
 		"glob-parent": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
@@ -2049,14 +2114,14 @@
 		},
 		"growl": {
 			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
 			"dev": true
 		},
 		"has": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has/-/has-1.0.3.tgz",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
@@ -2064,19 +2129,19 @@
 		},
 		"has-flag": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
 			"dev": true
 		},
 		"he": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/he/-/he-1.2.0.tgz",
+			"integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
 			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
@@ -2086,23 +2151,23 @@
 		},
 		"inherits": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
 			"dev": true
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
 			}
 		},
 		"is-core-module": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-			"integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+			"version": "2.9.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha1-4cNEKc1Rxt2eCeB5njluJ7GanGk=",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -2110,14 +2175,20 @@
 		},
 		"is-extglob": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
 			"dev": true
 		},
 		"is-glob": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
 			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
@@ -2125,38 +2196,38 @@
 		},
 		"is-number": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
 			"dev": true
 		},
 		"is-plain-obj": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc=",
 			"dev": true
 		},
 		"is-unicode-supported": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
 			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
 			"dev": true
 		},
 		"js-yaml": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
 			"dev": true,
 			"requires": {
 				"argparse": "^2.0.1"
@@ -2164,8 +2235,8 @@
 		},
 		"locate-path": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
 			"dev": true,
 			"requires": {
 				"p-locate": "^5.0.0"
@@ -2173,8 +2244,8 @@
 		},
 		"log-symbols": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0",
@@ -2182,56 +2253,56 @@
 			}
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "4.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-4.2.1.tgz",
+			"integrity": "sha1-QNnVEaRr3E5WPCLDCAzenA2CmbQ=",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"version": "1.2.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q=",
 			"dev": true
 		},
 		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
 			"dev": true,
 			"requires": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			}
 		},
 		"mocha": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-			"integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+			"version": "9.2.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mocha/-/mocha-9.2.2.tgz",
+			"integrity": "sha1-1w20a9uTyldALICTM+WoSXeoj7k=",
 			"dev": true,
 			"requires": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.2",
-				"debug": "4.3.2",
+				"chokidar": "3.5.3",
+				"debug": "4.3.3",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
-				"glob": "7.1.7",
+				"glob": "7.2.0",
 				"growl": "1.10.5",
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
-				"minimatch": "3.0.4",
+				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
+				"nanoid": "3.3.1",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"workerpool": "6.1.5",
+				"workerpool": "6.2.0",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
@@ -2239,25 +2310,25 @@
 		},
 		"ms": {
 			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+			"version": "3.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha1-Y0ehjKyIr4j1ivCzWUtyPV6ZuzU=",
 			"dev": true
 		},
 		"normalize-path": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
 			"dev": true
 		},
 		"once": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
@@ -2266,8 +2337,8 @@
 		},
 		"p-limit": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
 			"dev": true,
 			"requires": {
 				"yocto-queue": "^0.1.0"
@@ -2275,8 +2346,8 @@
 		},
 		"p-locate": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
 			"dev": true,
 			"requires": {
 				"p-limit": "^3.0.2"
@@ -2284,32 +2355,32 @@
 		},
 		"path-exists": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
 			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
 			"dev": true
 		},
 		"picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+			"version": "2.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
 			"dev": true
 		},
 		"randombytes": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
@@ -2317,8 +2388,8 @@
 		},
 		"readdirp": {
 			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
 			"dev": true,
 			"requires": {
 				"picomatch": "^2.2.1"
@@ -2326,24 +2397,25 @@
 		},
 		"require-directory": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"version": "1.22.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha1-J8suu1P5GrtJRwqSi7p1WAZqwXc=",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
 		"rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
@@ -2351,20 +2423,20 @@
 		},
 		"safe-buffer": {
 			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
 			"dev": true
 		},
 		"semver": {
 			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
 			"dev": true
 		},
 		"serialize-javascript": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+			"integrity": "sha1-765diPRdeSQUHai1w6en5mP+/rg=",
 			"dev": true,
 			"requires": {
 				"randombytes": "^2.1.0"
@@ -2372,29 +2444,55 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
+		"string-width": {
+			"version": "4.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+			"dev": true,
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			}
+		},
+		"strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^5.0.1"
+			}
+		},
 		"strip-json-comments": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
 			"dev": true
 		},
 		"supports-color": {
 			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
 			"dev": true,
 			"requires": {
 				"has-flag": "^4.0.0"
 			}
 		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+			"dev": true
+		},
 		"to-regex-range": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
 			"dev": true,
 			"requires": {
 				"is-number": "^7.0.0"
@@ -2402,14 +2500,14 @@
 		},
 		"tslib": {
 			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
 			"dev": true
 		},
 		"tslint": {
 			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslint/-/tslint-5.20.1.tgz",
+			"integrity": "sha1-5AHortoBUrxE3QfmFANPP4DGe30=",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -2429,8 +2527,8 @@
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -2438,8 +2536,8 @@
 				},
 				"argparse": {
 					"version": "1.0.10",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
 					"dev": true,
 					"requires": {
 						"sprintf-js": "~1.0.2"
@@ -2447,8 +2545,8 @@
 				},
 				"chalk": {
 					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
@@ -2458,8 +2556,8 @@
 				},
 				"color-convert": {
 					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
 					"dev": true,
 					"requires": {
 						"color-name": "1.1.3"
@@ -2467,42 +2565,51 @@
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
 				"diff": {
 					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
 					"dev": true
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 					"dev": true
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 					"dev": true
 				},
 				"js-yaml": {
 					"version": "3.14.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
 					"dev": true,
 					"requires": {
 						"argparse": "^1.0.7",
 						"esprima": "^4.0.0"
 					}
 				},
+				"minimatch": {
+					"version": "3.1.2",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+					"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
 				"supports-color": {
 					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -2510,8 +2617,8 @@
 				},
 				"tsutils": {
 					"version": "2.29.0",
-					"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-					"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tsutils/-/tsutils-2.29.0.tgz",
+					"integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
 					"dev": true,
 					"requires": {
 						"tslib": "^1.8.1"
@@ -2521,19 +2628,19 @@
 		},
 		"typescript": {
 			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha1-LNAaGh8WBwTTEB/VpY/w+fy4Aww=",
 			"dev": true
 		},
 		"vscode-dotnet-runtime": {
 			"version": "file:../vscode-dotnet-runtime-extension",
 			"requires": {
-				"@types/chai": "^4.2.22",
+				"@types/chai": "4.2.22",
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
 				"@types/vscode": "1.62.0",
-				"chai": "^4.3.4",
+				"chai": "4.3.4",
 				"child_process": "^1.0.2",
 				"copy-webpack-plugin": "9.0.1",
 				"diff": ">=5.0.0",
@@ -2556,7 +2663,7 @@
 		"vscode-dotnet-runtime-library": {
 			"version": "file:../vscode-dotnet-runtime-library",
 			"requires": {
-				"@types/chai": "^4.2.22",
+				"@types/chai": "4.2.22",
 				"@types/chai-as-promised": "^7.1.4",
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
@@ -2565,7 +2672,7 @@
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
 				"@types/vscode": "1.62.0",
-				"chai": "^4.3.4",
+				"chai": "4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",
 				"eol": "^0.9.1",
@@ -2589,13 +2696,13 @@
 		"vscode-dotnet-sdk": {
 			"version": "file:../vscode-dotnet-sdk-extension",
 			"requires": {
-				"@types/chai": "^4.2.22",
+				"@types/chai": "4.2.22",
 				"@types/chai-as-promised": "^7.1.4",
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
 				"@types/vscode": "1.62.0",
-				"chai": "^4.3.4",
+				"chai": "4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"child_process": "^1.0.2",
 				"copy-webpack-plugin": "^9.0.1",
@@ -2618,80 +2725,46 @@
 		},
 		"which": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
+			"integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
 			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
 		},
 		"workerpool": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-			"integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+			"version": "6.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/workerpool/-/workerpool-6.2.0.tgz",
+			"integrity": "sha1-gn2Tyboj7iAZw/+v9cJ/zOoonos=",
 			"dev": true
 		},
 		"wrap-ansi": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.1"
-					}
-				}
 			}
 		},
 		"wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
 		},
 		"y18n": {
 			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
 			"dev": true
 		},
 		"yargs": {
 			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
 			"dev": true,
 			"requires": {
 				"cliui": "^7.0.2",
@@ -2701,52 +2774,18 @@
 				"string-width": "^4.2.0",
 				"y18n": "^5.0.5",
 				"yargs-parser": "^20.2.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.1"
-					}
-				}
 			}
 		},
 		"yargs-parser": {
 			"version": "20.2.4",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-parser/-/yargs-parser-20.2.4.tgz",
+			"integrity": "sha1-tCiQ8UVmeW+Fro46JSkNIF8VSlQ=",
 			"dev": true
 		},
 		"yargs-unparser": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
 			"dev": true,
 			"requires": {
 				"camelcase": "^6.0.0",
@@ -2757,8 +2796,8 @@
 		},
 		"yocto-queue": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
 			"dev": true
 		}
 	}

--- a/sample/package.json
+++ b/sample/package.json
@@ -10,7 +10,7 @@
 	"version": "0.0.1",
 	"publisher": "ms-dotnettools",
 	"engines": {
-		"vscode": "^1.62.0"
+		"vscode": "1.62.0"
 	},
 	"categories": [
 		"Other"
@@ -101,7 +101,7 @@
 		"@types/mocha": "^9.0.0",
 		"@types/node": "16.11.7",
 		"@types/rimraf": "3.0.2",
-		"@types/vscode": "^1.62.0",
+		"@types/vscode": "1.62.0",
 		"mocha": "^9.1.3",
 		"rimraf": "3.0.2",
 		"tslint": "5.20.1",

--- a/vscode-dotnet-runtime-extension/.npmrc
+++ b/vscode-dotnet-runtime-extension/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.6.0",
 			"license": "MIT",
 			"dependencies": {
-				"chai": "^4.3.4",
+				"chai": "4.3.4",
 				"child_process": "^1.0.2",
 				"diff": ">=5.0.0",
 				"glob": "^7.2.0",
@@ -26,7 +26,7 @@
 				"vscode-test": "^1.6.1"
 			},
 			"devDependencies": {
-				"@types/chai": "^4.2.22",
+				"@types/chai": "4.2.22",
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
@@ -51,7 +51,7 @@
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
 				"@types/vscode": "1.62.0",
-				"chai": "^4.3.4",
+				"chai": "4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",
 				"eol": "^0.9.1",
@@ -70,7 +70,7 @@
 				"vscode-test": "^1.6.1"
 			},
 			"devDependencies": {
-				"@types/chai": "^4.2.22",
+				"@types/chai": "4.2.22",
 				"glob": "^7.2.0"
 			},
 			"engines": {
@@ -81,30 +81,33 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-			"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha1-OyXTjIlgC6otzCGe36iKdOssQno=",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.16.0"
+				"@babel/highlight": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.15.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha1-nJfjDTGyuMcqHQiYTyyptXTXoHY=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-			"integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha1-gRWGAek+JWN5Wty/vfXWS+Py7N8=",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -114,8 +117,9 @@
 		},
 		"node_modules/@babel/highlight/node_modules/ansi-styles": {
 			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -125,8 +129,9 @@
 		},
 		"node_modules/@babel/highlight/node_modules/chalk": {
 			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -138,37 +143,42 @@
 		},
 		"node_modules/@babel/highlight/node_modules/color-convert": {
 			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/color-name": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"license": "MIT"
 		},
 		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/has-flag": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/supports-color": {
 			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -177,24 +187,85 @@
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
-			"integrity": "sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==",
+			"version": "0.5.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+			"integrity": "sha1-HVcr+74Ut3BOC6Dzm3SBW4SHDXA=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
 			}
 		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+			"integrity": "sha1-wa7cYehT8rufXf5tRELTtWWyU7k=",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+			"integrity": "sha1-IgOxGMFXchrd/mnUe3BGVGMGbXg=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"integrity": "sha1-fGz5mNbSC5FMClWpGuko/yWWXnI=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+			"integrity": "sha1-9FNRqu1FJ6KYUS7HL4EEDJmFgPs=",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha1-rdTJjTQUcqKJGQtCTvvbCWmRuyQ=",
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.14",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+			"integrity": "sha1-sjGggdj2Z5bkda1Yih70cxEnAe0=",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"node_modules/@leichtgewicht/ip-codec": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
-			"integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+			"version": "2.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+			"integrity": "sha1-sqxibWy5yHGKtFkWbUu0Bbj/p4s=",
+			"license": "MIT"
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
 				"run-parallel": "^1.1.9"
@@ -205,18 +276,20 @@
 		},
 		"node_modules/@nodelib/fs.stat": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
 			}
 		},
 		"node_modules/@nodelib/fs.walk": {
 			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
@@ -226,9 +299,10 @@
 			}
 		},
 		"node_modules/@sindresorhus/is": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-			"integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==",
+			"version": "4.6.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha1-PHycRuZ4/u/nouW7YJ09vWZf+z8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -238,8 +312,9 @@
 		},
 		"node_modules/@szmarczak/http-timer": {
 			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac=",
+			"license": "MIT",
 			"dependencies": {
 				"defer-to-connect": "^2.0.0"
 			},
@@ -249,16 +324,18 @@
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
 			}
 		},
 		"node_modules/@types/cacheable-request": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
-			"integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+			"integrity": "sha1-wyTaAZfeCpiiMSFWU2riYkKf9rk=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/http-cache-semantics": "*",
 				"@types/keyv": "*",
@@ -268,23 +345,26 @@
 		},
 		"node_modules/@types/chai": {
 			"version": "4.2.22",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
-			"integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai/-/chai-4.2.22.tgz",
+			"integrity": "sha1-RwINfkzxkZTUO1IC8191vSrTXOc=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/eslint": {
-			"version": "7.28.2",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
-			"integrity": "sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==",
+			"version": "8.4.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/eslint/-/eslint-8.4.5.tgz",
+			"integrity": "sha1-rN+33Ta5HMXYEtfAk4Eajz2bMeQ=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
 			}
 		},
 		"node_modules/@types/eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+			"version": "3.7.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+			"integrity": "sha1-N/wSI/B4bDlicGihLpTW5vxh3hY=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -292,14 +372,16 @@
 		},
 		"node_modules/@types/estree": {
 			"version": "0.0.50",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/estree/-/estree-0.0.50.tgz",
+			"integrity": "sha1-Hgyqk2TT/M0pMcPtlv2+ql1MyoM=",
+			"license": "MIT"
 		},
 		"node_modules/@types/glob": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-vBtb86qS8lvV3TnzXFc2G9zlsus=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/minimatch": "*",
 				"@types/node": "*"
@@ -307,52 +389,66 @@
 		},
 		"node_modules/@types/http-cache-semantics": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+			"integrity": "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI=",
+			"license": "MIT"
+		},
+		"node_modules/@types/json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-hcH/DwlI/BWYENS1vjW/jCCHX2Q=",
+			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+			"version": "7.0.11",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha1-1CG2xSejA398hEM/0sQingFoY9M=",
+			"license": "MIT"
 		},
 		"node_modules/@types/keyv": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.3.tgz",
-			"integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
+			"version": "3.1.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha1-PM2xxnUbDH5SMAvNrNW8v4+qdbY=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/minimatch": {
 			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/minimatch/-/minimatch-3.0.5.tgz",
+			"integrity": "sha1-EAHMXmo3BLg8I2An538vWOoBD0A=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/mocha": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-			"integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
-			"dev": true
+			"version": "9.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/mocha/-/mocha-9.1.1.tgz",
+			"integrity": "sha1-58TxAB7vpLivvR7uJ6I3/uO/KcQ=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "16.11.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-			"integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-16.11.7.tgz",
+			"integrity": "sha1-NoIJRQYTJpeMQqAeVrYc0iPf3EI=",
+			"license": "MIT"
 		},
 		"node_modules/@types/responselike": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha1-JR9P59FU0rrRJavhtCmyOv0mLik=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-pj0XWzMXSOUiCtSMkB17vx9E7vg=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/glob": "*",
 				"@types/node": "*"
@@ -360,19 +456,22 @@
 		},
 		"node_modules/@types/vscode": {
 			"version": "1.62.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.62.0.tgz",
+			"integrity": "sha1-tNbRktWut16R0K3vaJw+zvmHnac=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@ungap/promise-all-settled": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+			"integrity": "sha1-qlgEJxHW4ydd033Fl+XTHowpCkQ=",
+			"license": "ISC"
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+			"integrity": "sha1-K/12fq4aaZb0Mv9+jX/HVnnAtqc=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -380,23 +479,27 @@
 		},
 		"node_modules/@webassemblyjs/floating-point-hex-parser": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+			"integrity": "sha1-9sYacF8P16auyqToGY8j2dwXnk8=",
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+			"integrity": "sha1-GmMZLYeI5cASgAump6RscFKI/RY=",
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+			"integrity": "sha1-gyqQDrREiEzemnytRn+BUA9eWrU=",
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+			"integrity": "sha1-ZNgdohn7u6HjvRv8dPboxOEKYq4=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -405,13 +508,15 @@
 		},
 		"node_modules/@webassemblyjs/helper-wasm-bytecode": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+			"integrity": "sha1-8ygkHkHnsZnQsgwY6IQpxEMyleE=",
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+			"integrity": "sha1-Ie4GWntjXzGec48N1zv72igcCXo=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -421,29 +526,33 @@
 		},
 		"node_modules/@webassemblyjs/ieee754": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+			"integrity": "sha1-ljkp6bvQVwnn4SJDoJkYCBKZJhQ=",
+			"license": "MIT",
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"node_modules/@webassemblyjs/leb128": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+			"integrity": "sha1-zoFLRVdOk9drrh+yZEq5zdlSeqU=",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"node_modules/@webassemblyjs/utf8": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+			"integrity": "sha1-0fi3ZDaefG5rrjUOhU3smlnwo/8=",
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+			"integrity": "sha1-rSBuv0v5WgWM6YgKjAksXeyBk9Y=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -457,8 +566,9 @@
 		},
 		"node_modules/@webassemblyjs/wasm-gen": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+			"integrity": "sha1-hsXqMEhJdZt9iMR6MvTwOa48j3Y=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -469,8 +579,9 @@
 		},
 		"node_modules/@webassemblyjs/wasm-opt": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+			"integrity": "sha1-ZXtMIgL0zzs0X4pMZGHIwkGJhfI=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -480,8 +591,9 @@
 		},
 		"node_modules/@webassemblyjs/wasm-parser": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+			"integrity": "sha1-hspzRTT0F+m9PGfHocddi+QfsZk=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -493,63 +605,31 @@
 		},
 		"node_modules/@webassemblyjs/wast-printer": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+			"integrity": "sha1-0Mc77ajuxUJvEK6O9VzuXnCEwvA=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@xtuc/long": "4.2.2"
 			}
 		},
-		"node_modules/@webpack-cli/configtest": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-			"dev": true,
-			"peerDependencies": {
-				"webpack": "4.x.x || 5.x.x",
-				"webpack-cli": "4.x.x"
-			}
-		},
-		"node_modules/@webpack-cli/info": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-			"integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
-			"dev": true,
-			"dependencies": {
-				"envinfo": "^7.7.3"
-			},
-			"peerDependencies": {
-				"webpack-cli": "4.x.x"
-			}
-		},
-		"node_modules/@webpack-cli/serve": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-			"dev": true,
-			"peerDependencies": {
-				"webpack-cli": "4.x.x"
-			},
-			"peerDependenciesMeta": {
-				"webpack-dev-server": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@xtuc/ieee754": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+			"integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@xtuc/long": {
 			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
+			"license": "Apache-2.0"
 		},
 		"node_modules/acorn": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-			"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+			"version": "8.7.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn/-/acorn-8.7.1.tgz",
+			"integrity": "sha1-AZcSLIQ9G/bQpegyIKeI8nj2PDA=",
+			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -559,16 +639,18 @@
 		},
 		"node_modules/acorn-import-assertions": {
 			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+			"integrity": "sha1-uitZOc5iwjjbbZPYHJsRGym4Vek=",
+			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8"
 			}
 		},
 		"node_modules/agent-base": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+			"license": "MIT",
 			"dependencies": {
 				"debug": "4"
 			},
@@ -578,8 +660,9 @@
 		},
 		"node_modules/aggregate-error": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+			"license": "MIT",
 			"dependencies": {
 				"clean-stack": "^2.0.0",
 				"indent-string": "^4.0.0"
@@ -590,8 +673,9 @@
 		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -605,32 +689,36 @@
 		},
 		"node_modules/ajv-keywords": {
 			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+			"integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
+			"license": "MIT",
 			"peerDependencies": {
 				"ajv": "^6.9.1"
 			}
 		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -643,8 +731,9 @@
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
+			"license": "ISC",
 			"dependencies": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -655,68 +744,74 @@
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
+			"license": "Python-2.0"
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/assertion-error": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+			"license": "MIT"
 		},
 		"node_modules/big-integer": {
-			"version": "1.6.50",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
-			"integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ==",
+			"version": "1.6.51",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/big-integer/-/big-integer-1.6.51.tgz",
+			"integrity": "sha1-DfkqXZiAVg0/8tX9ICRciJ0TBoY=",
+			"license": "Unlicense",
 			"engines": {
 				"node": ">=0.6"
 			}
 		},
 		"node_modules/binary": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary/-/binary-0.3.0.tgz",
 			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+			"license": "MIT",
 			"dependencies": {
 				"buffers": "~0.1.1",
 				"chainsaw": "~0.1.0"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/bluebird": {
 			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bluebird/-/bluebird-3.4.7.tgz",
+			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -724,8 +819,9 @@
 		},
 		"node_modules/braces": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.0.1"
 			},
@@ -735,47 +831,56 @@
 		},
 		"node_modules/browser-stdout": {
 			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+			"license": "ISC"
 		},
 		"node_modules/browserslist": {
-			"version": "4.17.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.6.tgz",
-			"integrity": "sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==",
+			"version": "4.21.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browserslist/-/browserslist-4.21.2.tgz",
+			"integrity": "sha1-WaQAdXRlU1lUlGpAC4Qe034rTs8=",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				}
+			],
+			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001274",
-				"electron-to-chromium": "^1.3.886",
-				"escalade": "^3.1.1",
-				"node-releases": "^2.0.1",
-				"picocolors": "^1.0.0"
+				"caniuse-lite": "^1.0.30001366",
+				"electron-to-chromium": "^1.4.188",
+				"node-releases": "^2.0.6",
+				"update-browserslist-db": "^1.0.4"
 			},
 			"bin": {
 				"browserslist": "cli.js"
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/browserslist"
 			}
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
+			"license": "MIT"
 		},
 		"node_modules/buffer-indexof-polyfill": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+			"integrity": "sha1-0nMhNcWZnGSyd/z5savjSYJUcpw=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10"
 			}
 		},
 		"node_modules/buffers": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffers/-/buffers-0.1.1.tgz",
 			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
 			"engines": {
 				"node": ">=0.2.0"
@@ -783,24 +888,27 @@
 		},
 		"node_modules/builtin-modules": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/cacheable-lookup": {
 			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha1-WmuGWyxENXvj1evCpGewMnGacAU=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.6.0"
 			}
 		},
 		"node_modules/cacheable-request": {
 			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-7.0.2.tgz",
+			"integrity": "sha1-6g0LiJNkolhUdXMByhKy2nf5HSc=",
+			"license": "MIT",
 			"dependencies": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -815,9 +923,10 @@
 			}
 		},
 		"node_modules/camelcase": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+			"version": "6.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -826,18 +935,26 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001279",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-			"integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/browserslist"
-			}
+			"version": "1.0.30001366",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001366.tgz",
+			"integrity": "sha1-xzNSyDgwqery3qD/cftLmku6qJw=",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				}
+			],
+			"license": "CC-BY-4.0"
 		},
 		"node_modules/chai": {
 			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chai/-/chai-4.3.4.tgz",
+			"integrity": "sha1-tV5lWzHh6scJm+TAjCGWT84ubEk=",
+			"license": "MIT",
 			"dependencies": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
@@ -852,19 +969,18 @@
 		},
 		"node_modules/chainsaw": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chainsaw/-/chainsaw-0.1.0.tgz",
 			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+			"license": "MIT/X11",
 			"dependencies": {
 				"traverse": ">=0.3.0 <0.4"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -878,8 +994,9 @@
 		},
 		"node_modules/chalk/node_modules/supports-color": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -889,21 +1006,30 @@
 		},
 		"node_modules/check-error": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/check-error/-/check-error-1.0.2.tgz",
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/child_process": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-			"integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/child_process/-/child_process-1.0.2.tgz",
+			"integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o=",
+			"license": "ISC"
 		},
 		"node_modules/chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha1-HPN8hwe5Mr0a8a4iwEMuKs0ZA70=",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			],
+			"license": "MIT",
 			"dependencies": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -922,8 +1048,9 @@
 		},
 		"node_modules/chokidar/node_modules/glob-parent": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
+			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
 			},
@@ -933,24 +1060,27 @@
 		},
 		"node_modules/chrome-trace-event": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
-			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+			"integrity": "sha1-EBXs7UdB4V0GZkqVfbv1DQQeJqw=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.0"
 			}
 		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
+			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
@@ -959,9 +1089,10 @@
 		},
 		"node_modules/clone-deep": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clone-deep/-/clone-deep-4.0.1.tgz",
+			"integrity": "sha1-wZ/Zvbv4WUK0/ZechNz31fB8I4c=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-plain-object": "^2.0.4",
 				"kind-of": "^6.0.2",
@@ -973,16 +1104,18 @@
 		},
 		"node_modules/clone-response": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^1.0.0"
 			}
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -992,30 +1125,48 @@
 		},
 		"node_modules/color-name": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+			"license": "MIT"
 		},
 		"node_modules/colorette": {
-			"version": "2.0.16",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
-			"dev": true
+			"version": "2.0.19",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/colorette/-/colorette-2.0.19.tgz",
+			"integrity": "sha1-zfBE9HrUGg9LVrOg1bTm4aLVp5g=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/commander": {
 			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+			"license": "MIT"
+		},
+		"node_modules/compress-brotli": {
+			"version": "1.3.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/compress-brotli/-/compress-brotli-1.3.8.tgz",
+			"integrity": "sha1-DApgyXqYkUUxTsOB6E4maC57ONs=",
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-buffer": "~3.0.0",
+				"json-buffer": "~3.0.1"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"license": "MIT"
 		},
 		"node_modules/copy-webpack-plugin": {
 			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
-			"integrity": "sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
+			"integrity": "sha1-tx0hmRWZ9hpO4AunkIe4uiebu1k=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-glob": "^3.2.5",
 				"glob-parent": "^6.0.0",
@@ -1038,14 +1189,16 @@
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
+			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -1056,9 +1209,10 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
+			"license": "MIT",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -1073,13 +1227,15 @@
 		},
 		"node_modules/debug/node_modules/ms": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+			"license": "MIT"
 		},
 		"node_modules/decamelize": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1089,8 +1245,9 @@
 		},
 		"node_modules/decompress-response": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha1-yjh2Et234QS9FthaqwDV7PCcZvw=",
+			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^3.1.0"
 			},
@@ -1103,8 +1260,9 @@
 		},
 		"node_modules/decompress-response/node_modules/mimic-response": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1114,8 +1272,9 @@
 		},
 		"node_modules/deep-eql": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+			"license": "MIT",
 			"dependencies": {
 				"type-detect": "^4.0.0"
 			},
@@ -1125,33 +1284,37 @@
 		},
 		"node_modules/defer-to-connect": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/define-lazy-prop": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/diff": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"version": "5.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.1.0.tgz",
+			"integrity": "sha1-vFLSmMXqjfkZSAAiREXtQ//IfkA=",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-type": "^4.0.0"
 			},
@@ -1160,9 +1323,10 @@
 			}
 		},
 		"node_modules/dns-packet": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.0.tgz",
-			"integrity": "sha512-Nce7YLu6YCgWRvOmDBsJMo9M5/jV3lEZ5vUWnWXYmwURvPylHvq7nkDWhNmk1ZQoZZOP7oQh/S0lSxbisKOfHg==",
+			"version": "5.4.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dns-packet/-/dns-packet-5.4.0.tgz",
+			"integrity": "sha1-H4hHfPnyfniiE/ttEYrjjnWah5s=",
+			"license": "MIT",
 			"dependencies": {
 				"@leichtgewicht/ip-codec": "^2.0.1"
 			},
@@ -1172,8 +1336,9 @@
 		},
 		"node_modules/dns-socket": {
 			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.2.tgz",
-			"integrity": "sha512-BDeBd8najI4/lS00HSKpdFia+OvUMytaVjfzR9n5Lq8MlZRSvtbI+uLtx1+XmQFls5wFU9dssccTmQQ6nfpjdg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dns-socket/-/dns-socket-4.2.2.tgz",
+			"integrity": "sha1-WLAYbsBT6gcx/rBng8furEuVthY=",
+			"license": "MIT",
 			"dependencies": {
 				"dns-packet": "^5.2.4"
 			},
@@ -1183,39 +1348,45 @@
 		},
 		"node_modules/duplexer2": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer2/-/duplexer2-0.1.4.tgz",
 			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"readable-stream": "^2.0.2"
 			}
 		},
 		"node_modules/duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+			"version": "0.1.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer3/-/duplexer3-0.1.5.tgz",
+			"integrity": "sha1-C15Ne61d6JAepEQGJMjh0gCZIX4=",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.893",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.893.tgz",
-			"integrity": "sha512-ChtwF7qB03INq1SyMpue08wc6cve+ktj2UC/Y7se9vB+JryfzziJeYwsgb8jLaCA5GMkHCdn5M62PfSMWhifZg=="
+			"version": "1.4.191",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.191.tgz",
+			"integrity": "sha1-Ad1L8yUCpIziS/OJC1VTocX5NTk=",
+			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+			"license": "MIT"
 		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-			"integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+			"version": "5.10.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+			"integrity": "sha1-DcV5w7sqEDLjV6xFuPOm861PseY=",
+			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
 				"tapable": "^2.2.0"
@@ -1226,9 +1397,10 @@
 		},
 		"node_modules/envinfo": {
 			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
-			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/envinfo/-/envinfo-7.8.1.tgz",
+			"integrity": "sha1-Bjd+Pl9NN5/qesWS1a2JJ+DE1HU=",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"envinfo": "dist/cli.js"
 			},
@@ -1238,21 +1410,24 @@
 		},
 		"node_modules/es-module-lexer": {
 			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+			"integrity": "sha1-bxPbAMw4QXE32vdDZvU1yOtDjxk=",
+			"license": "MIT"
 		},
 		"node_modules/escalade": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1262,8 +1437,9 @@
 		},
 		"node_modules/eslint-scope": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
@@ -1274,8 +1450,9 @@
 		},
 		"node_modules/esprima": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+			"license": "BSD-2-Clause",
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -1286,8 +1463,9 @@
 		},
 		"node_modules/esrecurse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -1297,33 +1475,37 @@
 		},
 		"node_modules/esrecurse/node_modules/estraverse": {
 			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
 			}
 		},
 		"node_modules/estraverse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
 			}
 		},
 		"node_modules/events": {
 			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/events/-/events-3.3.0.tgz",
+			"integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.x"
 			}
 		},
 		"node_modules/execa": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cross-spawn": "^7.0.3",
 				"get-stream": "^6.0.0",
@@ -1344,9 +1526,10 @@
 		},
 		"node_modules/execa/node_modules/get-stream": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1356,14 +1539,16 @@
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-			"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+			"version": "3.2.11",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-glob/-/fast-glob-3.2.11.tgz",
+			"integrity": "sha1-oRcq2VzrihbiDKpcXlZIDlEpwdk=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -1372,14 +1557,15 @@
 				"micromatch": "^4.0.4"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=8.6.0"
 			}
 		},
 		"node_modules/fast-glob/node_modules/glob-parent": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
 			},
@@ -1389,28 +1575,32 @@
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+			"license": "MIT"
 		},
 		"node_modules/fastest-levenshtein": {
 			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
-			"integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+			"integrity": "sha1-mZD306iMxan/0fF0V0UlFwDUl+I=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fastq": {
 			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fastq/-/fastq-1.13.0.tgz",
+			"integrity": "sha1-YWdg+Ip1Jr38WWt8q4wYk4w2uYw=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
 			}
 		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -1420,8 +1610,9 @@
 		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
+			"license": "MIT",
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -1435,22 +1626,24 @@
 		},
 		"node_modules/flat": {
 			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE=",
+			"license": "BSD-3-Clause",
 			"bin": {
 				"flat": "cli.js"
 			}
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"license": "ISC"
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"hasInstallScript": true,
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1461,8 +1654,9 @@
 		},
 		"node_modules/fstream": {
 			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
+			"license": "ISC",
 			"dependencies": {
 				"graceful-fs": "^4.1.2",
 				"inherits": "~2.0.0",
@@ -1475,8 +1669,9 @@
 		},
 		"node_modules/fstream/node_modules/rimraf": {
 			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+			"license": "ISC",
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -1486,29 +1681,33 @@
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+			"license": "MIT"
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
 		"node_modules/get-func-name": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-func-name/-/get-func-name-2.0.0.tgz",
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/get-stream": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
+			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0"
 			},
@@ -1520,14 +1719,15 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+			"version": "7.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			},
@@ -1540,9 +1740,10 @@
 		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -1552,20 +1753,22 @@
 		},
 		"node_modules/glob-to-regexp": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+			"integrity": "sha1-x1KXCHyFG5pXi9IX3VmpL1n+VG4=",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/globby": {
-			"version": "11.0.4",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-			"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+			"version": "11.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha1-vUvpi7BC+D15b344EZkfvoKg00s=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.1.1",
-				"ignore": "^5.1.4",
-				"merge2": "^1.3.0",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -1576,16 +1779,17 @@
 			}
 		},
 		"node_modules/got": {
-			"version": "11.8.2",
-			"resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-			"integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+			"version": "11.8.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz",
+			"integrity": "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY=",
+			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/is": "^4.0.0",
 				"@szmarczak/http-timer": "^4.0.5",
 				"@types/cacheable-request": "^6.0.1",
 				"@types/responselike": "^1.0.0",
 				"cacheable-lookup": "^5.0.3",
-				"cacheable-request": "^7.0.1",
+				"cacheable-request": "^7.0.2",
 				"decompress-response": "^6.0.0",
 				"http2-wrapper": "^1.0.0-beta.5.2",
 				"lowercase-keys": "^2.0.0",
@@ -1600,22 +1804,25 @@
 			}
 		},
 		"node_modules/graceful-fs": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+			"version": "4.2.10",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha1-FH06AG2kyjzhRyjHrvwofDZ9emw=",
+			"license": "ISC"
 		},
 		"node_modules/growl": {
 			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.x"
 			}
 		},
 		"node_modules/has": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has/-/has-1.0.3.tgz",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.1"
 			},
@@ -1625,16 +1832,18 @@
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/hash.js": {
 			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -1642,16 +1851,18 @@
 		},
 		"node_modules/he": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/he/-/he-1.2.0.tgz",
+			"integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
+			"license": "MIT",
 			"bin": {
 				"he": "bin/he"
 			}
 		},
 		"node_modules/hmac-drbg": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"license": "MIT",
 			"dependencies": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -1660,13 +1871,15 @@
 		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+			"integrity": "sha1-SekcXL82yblLz81xwj1SSex045A=",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
+			"license": "MIT",
 			"dependencies": {
 				"@tootallnate/once": "1",
 				"agent-base": "6",
@@ -1678,8 +1891,9 @@
 		},
 		"node_modules/http2-wrapper": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha1-uPVeDB8l1OvQizsMLAeflZCACz0=",
+			"license": "MIT",
 			"dependencies": {
 				"quick-lru": "^5.1.1",
 				"resolve-alpn": "^1.0.0"
@@ -1689,9 +1903,10 @@
 			}
 		},
 		"node_modules/https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+			"license": "MIT",
 			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
@@ -1702,27 +1917,30 @@
 		},
 		"node_modules/human-signals": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.17.0"
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-			"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+			"version": "5.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ignore/-/ignore-5.2.0.tgz",
+			"integrity": "sha1-bTusj6f+DUXZ+b57rC/CeVd+NFo=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
 		},
 		"node_modules/import-local": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
-			"integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
+			"version": "3.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/import-local/-/import-local-3.1.0.tgz",
+			"integrity": "sha1-tEed+KX9RPbNziQHBnVnYGPJXLQ=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"pkg-dir": "^4.2.0",
 				"resolve-cwd": "^3.0.0"
@@ -1732,20 +1950,25 @@
 			},
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/indent-string": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"license": "ISC",
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1753,29 +1976,33 @@
 		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+			"license": "ISC"
 		},
 		"node_modules/interpret": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/interpret/-/interpret-1.4.0.tgz",
+			"integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
 			}
 		},
 		"node_modules/ip-regex": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-			"integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ip-regex/-/ip-regex-4.3.0.tgz",
+			"integrity": "sha1-aHJ1qw9X+naXj/j03dyKI9WZDbU=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+			"license": "MIT",
 			"dependencies": {
 				"binary-extensions": "^2.0.0"
 			},
@@ -1784,9 +2011,10 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-			"integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+			"version": "2.9.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha1-4cNEKc1Rxt2eCeB5njluJ7GanGk=",
+			"license": "MIT",
 			"dependencies": {
 				"has": "^1.0.3"
 			},
@@ -1796,8 +2024,9 @@
 		},
 		"node_modules/is-docker": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=",
+			"license": "MIT",
 			"bin": {
 				"is-docker": "cli.js"
 			},
@@ -1810,24 +2039,27 @@
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
+			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
 			},
@@ -1837,8 +2069,9 @@
 		},
 		"node_modules/is-ip": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-ip/-/is-ip-3.1.0.tgz",
+			"integrity": "sha1-KuXd+vrwXLgAimIJPPKXNPZXxdg=",
+			"license": "MIT",
 			"dependencies": {
 				"ip-regex": "^4.0.0"
 			},
@@ -1848,16 +2081,18 @@
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
 		},
 		"node_modules/is-online": {
 			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/is-online/-/is-online-9.0.1.tgz",
-			"integrity": "sha512-+08dRW0dcFOtleR2N3rHRVxDyZtQitUp9cC+KpKTds0mXibbQyW5js7xX0UGyQXkaLUJObe0w6uQ4ex34lX9LA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-9.0.1.tgz",
+			"integrity": "sha1-caNCAvqCa65vP/i+pCDFZXNEil8=",
+			"license": "MIT",
 			"dependencies": {
 				"got": "^11.8.0",
 				"p-any": "^3.0.0",
@@ -1873,17 +2108,19 @@
 		},
 		"node_modules/is-plain-obj": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/is-plain-object": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"isobject": "^3.0.1"
 			},
@@ -1893,9 +2130,10 @@
 		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -1905,8 +2143,9 @@
 		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1916,8 +2155,9 @@
 		},
 		"node_modules/is-wsl": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+			"license": "MIT",
 			"dependencies": {
 				"is-docker": "^2.0.0"
 			},
@@ -1927,27 +2167,31 @@
 		},
 		"node_modules/isarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"license": "MIT"
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"license": "ISC"
 		},
 		"node_modules/isobject": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/jest-worker": {
-			"version": "27.3.1",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
-			"integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
+			"version": "27.5.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jest-worker/-/jest-worker-27.5.1.tgz",
+			"integrity": "sha1-jRRvCQDolzsQa29zzB6ajLhvjbA=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -1959,13 +2203,15 @@
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
+			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -1975,53 +2221,62 @@
 		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
+			"license": "MIT"
 		},
 		"node_modules/json-parse-better-errors": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+			"license": "MIT"
 		},
 		"node_modules/keyv": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
-			"integrity": "sha512-vqNHbAc8BBsxk+7QBYLW0Y219rWcClspR6WSeoHYKG5mnsSoOH+BL1pWq02DDCVdvvuUny5rkBlzMRzoqc+GIg==",
+			"version": "4.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.3.2.tgz",
+			"integrity": "sha1-6DnfZ2oMfuWUyINefByDdCVY5cI=",
+			"license": "MIT",
 			"dependencies": {
+				"compress-brotli": "^1.3.8",
 				"json-buffer": "3.0.1"
 			}
 		},
 		"node_modules/kind-of": {
 			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/listenercount": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/listenercount/-/listenercount-1.0.1.tgz",
+			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+			"license": "ISC"
 		},
 		"node_modules/loader-runner": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
-			"integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
+			"version": "4.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/loader-runner/-/loader-runner-4.3.0.tgz",
+			"integrity": "sha1-wbShY7mfYUgwNTsWdV5xSawjFOE=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.11.5"
 			}
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
+			"license": "MIT",
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -2034,8 +2289,9 @@
 		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
+			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"is-unicode-supported": "^0.1.0"
@@ -2049,16 +2305,18 @@
 		},
 		"node_modules/lowercase-keys": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+			"license": "ISC",
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -2068,44 +2326,49 @@
 		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+			"license": "MIT"
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"version": "4.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/micromatch/-/micromatch-4.0.5.tgz",
+			"integrity": "sha1-vImZp8u/d83InxMvbkZwUbSQkMY=",
+			"license": "MIT",
 			"dependencies": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
+				"braces": "^3.0.2",
+				"picomatch": "^2.3.1"
 			},
 			"engines": {
 				"node": ">=8.6"
 			}
 		},
 		"node_modules/mime-db": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-			"integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+			"version": "1.52.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mime-types": {
-			"version": "2.1.34",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-			"integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+			"version": "2.1.35",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
+			"license": "MIT",
 			"dependencies": {
-				"mime-db": "1.51.0"
+				"mime-db": "1.52.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
@@ -2113,35 +2376,40 @@
 		},
 		"node_modules/mimic-fn": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/mimic-response": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/minimalistic-assert": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+			"license": "ISC"
 		},
 		"node_modules/minimalistic-crypto-utils": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+			"license": "MIT"
 		},
 		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -2150,47 +2418,50 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q=",
+			"license": "MIT"
 		},
 		"node_modules/mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
+			"license": "MIT",
 			"dependencies": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			},
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			}
 		},
 		"node_modules/mocha": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-			"integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+			"version": "9.2.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mocha/-/mocha-9.2.2.tgz",
+			"integrity": "sha1-1w20a9uTyldALICTM+WoSXeoj7k=",
+			"license": "MIT",
 			"dependencies": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.2",
-				"debug": "4.3.2",
+				"chokidar": "3.5.3",
+				"debug": "4.3.3",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
-				"glob": "7.1.7",
+				"glob": "7.2.0",
 				"growl": "1.10.5",
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
-				"minimatch": "3.0.4",
+				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
+				"nanoid": "3.3.1",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"workerpool": "6.1.5",
+				"workerpool": "6.2.0",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
@@ -2207,10 +2478,20 @@
 				"url": "https://opencollective.com/mochajs"
 			}
 		},
+		"node_modules/mocha/node_modules/diff": {
+			"version": "5.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha1-ftatdthZ0DB4fsNYVfWx2vMdhSs=",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/mocha/node_modules/glob": {
-			"version": "7.1.7",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"version": "7.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
+			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -2226,15 +2507,41 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/mocha/node_modules/minimatch": {
+			"version": "4.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-4.2.1.tgz",
+			"integrity": "sha1-QNnVEaRr3E5WPCLDCAzenA2CmbQ=",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+			"version": "3.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha1-Y0ehjKyIr4j1ivCzWUtyPV6ZuzU=",
+			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -2244,26 +2551,30 @@
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
+			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+			"version": "2.0.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-releases/-/node-releases-2.0.6.tgz",
+			"integrity": "sha1-inCIxjpV5JOEVoPr88go2MUcVQM=",
+			"license": "MIT"
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/normalize-url": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -2273,9 +2584,10 @@
 		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.0.0"
 			},
@@ -2285,17 +2597,19 @@
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
 			}
 		},
 		"node_modules/onetime": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"mimic-fn": "^2.1.0"
 			},
@@ -2308,8 +2622,9 @@
 		},
 		"node_modules/open": {
 			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-			"integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-8.4.0.tgz",
+			"integrity": "sha1-NFMhrhj4E4+CVlqRD9xrOejCRPg=",
+			"license": "MIT",
 			"dependencies": {
 				"define-lazy-prop": "^2.0.0",
 				"is-docker": "^2.1.1",
@@ -2324,8 +2639,9 @@
 		},
 		"node_modules/p-any": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-any/-/p-any-3.0.0.tgz",
-			"integrity": "sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-3.0.0.tgz",
+			"integrity": "sha1-eYR67tcLXToQ6mJSlsDD0ukKh7k=",
+			"license": "MIT",
 			"dependencies": {
 				"p-cancelable": "^2.0.0",
 				"p-some": "^5.0.0"
@@ -2339,24 +2655,27 @@
 		},
 		"node_modules/p-cancelable": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/p-finally": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
+			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -2369,8 +2688,9 @@
 		},
 		"node_modules/p-locate": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
+			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -2383,8 +2703,9 @@
 		},
 		"node_modules/p-some": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
-			"integrity": "sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-5.0.0.tgz",
+			"integrity": "sha1-i3MMdLT+UWnXJkokCtAQtuvGhqQ=",
+			"license": "MIT",
 			"dependencies": {
 				"aggregate-error": "^3.0.0",
 				"p-cancelable": "^2.0.0"
@@ -2398,8 +2719,9 @@
 		},
 		"node_modules/p-timeout": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
+			"license": "MIT",
 			"dependencies": {
 				"p-finally": "^1.0.0"
 			},
@@ -2409,69 +2731,78 @@
 		},
 		"node_modules/p-try": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
+			"license": "MIT"
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/pathval": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha1-hTTnenfOesWiUS6iHg/bj89sPY0=",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw=",
+			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+			"version": "2.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -2481,9 +2812,10 @@
 		},
 		"node_modules/pkg-dir": {
 			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"find-up": "^4.0.0"
 			},
@@ -2493,9 +2825,10 @@
 		},
 		"node_modules/pkg-dir/node_modules/find-up": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
@@ -2506,9 +2839,10 @@
 		},
 		"node_modules/pkg-dir/node_modules/locate-path": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-locate": "^4.1.0"
 			},
@@ -2518,9 +2852,10 @@
 		},
 		"node_modules/pkg-dir/node_modules/p-limit": {
 			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-try": "^2.0.0"
 			},
@@ -2533,9 +2868,10 @@
 		},
 		"node_modules/pkg-dir/node_modules/p-locate": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^2.2.0"
 			},
@@ -2545,21 +2881,24 @@
 		},
 		"node_modules/prepend-http": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prepend-http/-/prepend-http-2.0.0.tgz",
 			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+			"license": "MIT"
 		},
 		"node_modules/public-ip": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/public-ip/-/public-ip-4.0.4.tgz",
-			"integrity": "sha512-EJ0VMV2vF6Cu7BIPo3IMW1Maq6ME+fbR0NcPmqDfpfNGIRPue1X8QrGjrg/rfjDkOsIkKHIf2S5FlEa48hFMTA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-4.0.4.tgz",
+			"integrity": "sha1-s3hKWh/xuB0BW5oYRQvmX/2SnrM=",
+			"license": "MIT",
 			"dependencies": {
 				"dns-socket": "^4.2.2",
 				"got": "^9.6.0",
@@ -2574,16 +2913,18 @@
 		},
 		"node_modules/public-ip/node_modules/@sindresorhus/is": {
 			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-0.14.0.tgz",
+			"integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/public-ip/node_modules/@szmarczak/http-timer": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+			"integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
+			"license": "MIT",
 			"dependencies": {
 				"defer-to-connect": "^1.0.1"
 			},
@@ -2593,8 +2934,9 @@
 		},
 		"node_modules/public-ip/node_modules/cacheable-request": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-6.1.0.tgz",
+			"integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
+			"license": "MIT",
 			"dependencies": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -2610,8 +2952,9 @@
 		},
 		"node_modules/public-ip/node_modules/decompress-response": {
 			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-3.3.0.tgz",
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^1.0.0"
 			},
@@ -2621,13 +2964,15 @@
 		},
 		"node_modules/public-ip/node_modules/defer-to-connect": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+			"integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE=",
+			"license": "MIT"
 		},
 		"node_modules/public-ip/node_modules/got": {
 			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-9.6.0.tgz",
+			"integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
+			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/is": "^0.14.0",
 				"@szmarczak/http-timer": "^1.1.2",
@@ -2647,8 +2992,9 @@
 		},
 		"node_modules/public-ip/node_modules/got/node_modules/get-stream": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0"
 			},
@@ -2658,61 +3004,69 @@
 		},
 		"node_modules/public-ip/node_modules/got/node_modules/lowercase-keys": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/public-ip/node_modules/json-buffer": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+			"license": "MIT"
 		},
 		"node_modules/public-ip/node_modules/keyv": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-3.1.0.tgz",
+			"integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
+			"license": "MIT",
 			"dependencies": {
 				"json-buffer": "3.0.0"
 			}
 		},
 		"node_modules/public-ip/node_modules/normalize-url": {
 			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-4.5.1.tgz",
+			"integrity": "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/public-ip/node_modules/p-cancelable": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-1.1.0.tgz",
+			"integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/public-ip/node_modules/responselike": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-1.0.2.tgz",
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"license": "MIT",
 			"dependencies": {
 				"lowercase-keys": "^1.0.0"
 			}
 		},
 		"node_modules/public-ip/node_modules/responselike/node_modules/lowercase-keys": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -2720,174 +3074,17 @@
 		},
 		"node_modules/punycode": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/quick-lru": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
-		"node_modules/readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/readable-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-		},
-		"node_modules/readdirp": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-			"dependencies": {
-				"picomatch": "^2.2.1"
-			},
-			"engines": {
-				"node": ">=8.10.0"
-			}
-		},
-		"node_modules/rechoir": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-			"dependencies": {
-				"resolve": "^1.1.6"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dependencies": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/resolve-alpn": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
-		},
-		"node_modules/resolve-cwd": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-			"dev": true,
-			"dependencies": {
-				"resolve-from": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/responselike": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-			"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
-			"dependencies": {
-				"lowercase-keys": "^2.0.0"
-			}
-		},
-		"node_modules/reusify": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-			"dev": true,
-			"engines": {
-				"iojs": ">=1.0.0",
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/run-parallel": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
 			"dev": true,
 			"funding": [
 				{
@@ -2903,14 +3100,168 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
+			"license": "MIT"
+		},
+		"node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha1-NmST5rPkKjpoheLpnRj4D7eoyTI=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+		"node_modules/randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/readable-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+			"license": "MIT"
+		},
+		"node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
+			"license": "MIT",
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dependencies": {
+				"resolve": "^1.1.6"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.22.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha1-J8suu1P5GrtJRwqSi7p1WAZqwXc=",
+			"license": "MIT",
+			"dependencies": {
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve-alpn": {
+			"version": "1.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha1-t629rDVGqq7CC0Xn2CZZJwcnJvk=",
+			"license": "MIT"
+		},
+		"node_modules/resolve-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/responselike": {
+			"version": "2.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-2.0.0.tgz",
+			"integrity": "sha1-JjkbzDF091D5p56sxAoSpcQtdyM=",
+			"license": "MIT",
+			"dependencies": {
+				"lowercase-keys": "^2.0.0"
+			}
+		},
+		"node_modules/reusify": {
+			"version": "1.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2924,12 +3275,37 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"license": "MIT",
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/schema-utils": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/schema-utils/-/schema-utils-3.1.1.tgz",
+			"integrity": "sha1-vHTEtraZXB2I92qLd76nIZ4MgoE=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/json-schema": "^7.0.8",
 				"ajv": "^6.12.5",
@@ -2944,9 +3320,10 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha1-EsW2Sa/b+QSXB3luIqQCiBTOUj8=",
+			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -2959,22 +3336,25 @@
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+			"integrity": "sha1-765diPRdeSQUHai1w6en5mP+/rg=",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
 		},
 		"node_modules/setimmediate": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"license": "MIT"
 		},
 		"node_modules/shallow-clone": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shallow-clone/-/shallow-clone-3.0.1.tgz",
+			"integrity": "sha1-jymBrZJTH1UDWwH7IwdppA4C76M=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"kind-of": "^6.0.2"
 			},
@@ -2984,9 +3364,10 @@
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -2996,17 +3377,19 @@
 		},
 		"node_modules/shebang-regex": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/shelljs": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-			"integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+			"version": "0.8.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
+			"integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -3020,32 +3403,36 @@
 			}
 		},
 		"node_modules/signal-exit": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-			"integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
-			"dev": true
+			"version": "3.0.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/source-map-support": {
-			"version": "0.5.20",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-			"integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+			"version": "0.5.21",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha1-BP58f54e0tZiIzwoyys1ufY/bk8=",
+			"license": "MIT",
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -3053,26 +3440,30 @@
 		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/string_decoder/node_modules/safe-buffer": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+			"license": "MIT"
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -3084,8 +3475,9 @@
 		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -3095,17 +3487,19 @@
 		},
 		"node_modules/strip-final-newline": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -3115,8 +3509,9 @@
 		},
 		"node_modules/supports-color": {
 			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -3127,21 +3522,36 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/tapable": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha1-GWenPvQGCoLxKrlq+G1S/bdu7KA=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.9.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
-			"integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
+			"version": "5.14.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/terser/-/terser-5.14.2.tgz",
+			"integrity": "sha1-msnyKwaZTXNhdPQJGqNo24lvHBA=",
+			"license": "BSD-2-Clause",
 			"dependencies": {
+				"@jridgewell/source-map": "^0.3.2",
+				"acorn": "^8.5.0",
 				"commander": "^2.20.0",
-				"source-map": "~0.7.2",
 				"source-map-support": "~0.5.20"
 			},
 			"bin": {
@@ -3151,59 +3561,20 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/terser-webpack-plugin": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz",
-			"integrity": "sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==",
-			"dependencies": {
-				"jest-worker": "^27.0.6",
-				"schema-utils": "^3.1.1",
-				"serialize-javascript": "^6.0.0",
-				"source-map": "^0.6.1",
-				"terser": "^5.7.2"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "^5.1.0"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"esbuild": {
-					"optional": true
-				},
-				"uglify-js": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/terser/node_modules/source-map": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-			"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/to-readable-stream": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+			"integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -3213,16 +3584,15 @@
 		},
 		"node_modules/traverse": {
 			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/traverse/-/traverse-0.3.9.tgz",
 			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
-			"engines": {
-				"node": "*"
-			}
+			"license": "MIT/X11"
 		},
 		"node_modules/ts-loader": {
-			"version": "9.2.6",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
-			"integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
+			"version": "9.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ts-loader/-/ts-loader-9.3.1.tgz",
+			"integrity": "sha1-/iXMpW4+ccEIf+SNxn9N+MWbItQ=",
+			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"enhanced-resolve": "^5.0.0",
@@ -3239,13 +3609,15 @@
 		},
 		"node_modules/tslib": {
 			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
+			"license": "0BSD"
 		},
 		"node_modules/tslint": {
 			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslint/-/tslint-5.20.1.tgz",
+			"integrity": "sha1-5AHortoBUrxE3QfmFANPP4DGe30=",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
 				"builtin-modules": "^1.1.1",
@@ -3273,8 +3645,9 @@
 		},
 		"node_modules/tslint/node_modules/ansi-styles": {
 			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -3284,16 +3657,18 @@
 		},
 		"node_modules/tslint/node_modules/argparse": {
 			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+			"license": "MIT",
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
 		},
 		"node_modules/tslint/node_modules/chalk": {
 			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -3305,45 +3680,51 @@
 		},
 		"node_modules/tslint/node_modules/color-convert": {
 			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
 		},
 		"node_modules/tslint/node_modules/color-name": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"license": "MIT"
 		},
 		"node_modules/tslint/node_modules/diff": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/tslint/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/tslint/node_modules/has-flag": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/tslint/node_modules/js-yaml": {
 			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
+			"license": "MIT",
 			"dependencies": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -3354,16 +3735,18 @@
 		},
 		"node_modules/tslint/node_modules/semver": {
 			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
 			}
 		},
 		"node_modules/tslint/node_modules/supports-color": {
 			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -3371,10 +3754,11 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/tsutils": {
+		"node_modules/tslint/node_modules/tsutils": {
 			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "^1.8.1"
 			},
@@ -3384,16 +3768,18 @@
 		},
 		"node_modules/type-detect": {
 			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/typescript": {
 			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha1-LNAaGh8WBwTTEB/VpY/w+fy4Aww=",
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3404,8 +3790,9 @@
 		},
 		"node_modules/unzipper": {
 			"version": "0.10.11",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unzipper/-/unzipper-0.10.11.tgz",
+			"integrity": "sha1-C0mRRGRyy9uS7nQDkJ8mwkGceC4=",
+			"license": "MIT",
 			"dependencies": {
 				"big-integer": "^1.6.17",
 				"binary": "~0.3.0",
@@ -3419,18 +3806,46 @@
 				"setimmediate": "~1.0.4"
 			}
 		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
+			"integrity": "sha1-2/xaeJyqJrHbiZB5bCyOu84wSCQ=",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			},
+			"bin": {
+				"browserslist-lint": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
 		},
 		"node_modules/url-parse-lax": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+			"license": "MIT",
 			"dependencies": {
 				"prepend-http": "^2.0.0"
 			},
@@ -3440,8 +3855,9 @@
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"license": "MIT"
 		},
 		"node_modules/vscode-dotnet-runtime-library": {
 			"resolved": "../vscode-dotnet-runtime-library",
@@ -3449,8 +3865,9 @@
 		},
 		"node_modules/vscode-test": {
 			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vscode-test/-/vscode-test-1.6.1.tgz",
+			"integrity": "sha1-RCVMZwNt6SsA/dcvas5fGFThpWM=",
+			"license": "MIT",
 			"dependencies": {
 				"http-proxy-agent": "^4.0.1",
 				"https-proxy-agent": "^5.0.0",
@@ -3462,9 +3879,10 @@
 			}
 		},
 		"node_modules/watchpack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-			"integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+			"version": "2.4.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/watchpack/-/watchpack-2.4.0.tgz",
+			"integrity": "sha1-+jMDI3SWLHgRP5PH8vtMVMmGKl0=",
+			"license": "MIT",
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -3475,8 +3893,9 @@
 		},
 		"node_modules/webpack": {
 			"version": "5.63.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.63.0.tgz",
-			"integrity": "sha512-HYrw6bkj/MDmphAXvqLEvn2fVoDZsYu6O638WjK6lSNgIpjb5jl/KtOrqJyU9EC/ZV9mLUmZW5h4mASB+CVA4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack/-/webpack-5.63.0.tgz",
+			"integrity": "sha1-SwdBFYAOBSbYURKYXkbGS5XgSq8=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.0",
 				"@types/estree": "^0.0.50",
@@ -3521,9 +3940,10 @@
 		},
 		"node_modules/webpack-cli": {
 			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-			"integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-cli/-/webpack-cli-4.9.1.tgz",
+			"integrity": "sha1-tkvoJeLRsTDyhcMUyqOxuppGMrM=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^1.1.0",
@@ -3562,29 +3982,71 @@
 				}
 			}
 		},
+		"node_modules/webpack-cli/node_modules/@webpack-cli/configtest": {
+			"version": "1.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+			"integrity": "sha1-eyDOHBJTORLDshfqaCYjZfoppvU=",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"webpack": "4.x.x || 5.x.x",
+				"webpack-cli": "4.x.x"
+			}
+		},
+		"node_modules/webpack-cli/node_modules/@webpack-cli/info": {
+			"version": "1.5.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webpack-cli/info/-/info-1.5.0.tgz",
+			"integrity": "sha1-bHjBPFh0hS1uLdF/CKQfP+TCYbE=",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"envinfo": "^7.7.3"
+			},
+			"peerDependencies": {
+				"webpack-cli": "4.x.x"
+			}
+		},
+		"node_modules/webpack-cli/node_modules/@webpack-cli/serve": {
+			"version": "1.7.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webpack-cli/serve/-/serve-1.7.0.tgz",
+			"integrity": "sha1-4Zk2iaxC0rFukZQ3bPtnU/YlTbE=",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"webpack-cli": "4.x.x"
+			},
+			"peerDependenciesMeta": {
+				"webpack-dev-server": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/webpack-cli/node_modules/commander": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha1-o2y1fQtQHOEI5NIFWaFQo5HZerc=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 10"
 			}
 		},
 		"node_modules/webpack-cli/node_modules/interpret": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-			"integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/interpret/-/interpret-2.2.0.tgz",
+			"integrity": "sha1-GnigtZZcQKVBbQB61vUK0nxBffk=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
 			}
 		},
 		"node_modules/webpack-cli/node_modules/rechoir": {
 			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-			"integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rechoir/-/rechoir-0.7.1.tgz",
+			"integrity": "sha1-lHipahyhNbXoj8An8D7pLWxkVoY=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"resolve": "^1.9.0"
 			},
@@ -3594,9 +4056,10 @@
 		},
 		"node_modules/webpack-merge": {
 			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-			"integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-merge/-/webpack-merge-5.8.0.tgz",
+			"integrity": "sha1-Kznb8ir4d3atdEw5AiNzHTCmj2E=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"clone-deep": "^4.0.1",
 				"wildcard": "^2.0.0"
@@ -3606,17 +4069,53 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-			"integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
+			"version": "3.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-sources/-/webpack-sources-3.2.3.tgz",
+			"integrity": "sha1-LU2quEUf1LJAzCcFX/agwszqDN4=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/webpack/node_modules/terser-webpack-plugin": {
+			"version": "5.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
+			"integrity": "sha1-gDPbh23Vh1SHIT6Hxie8oyPl7ZA=",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.7",
+				"jest-worker": "^27.4.5",
+				"schema-utils": "^3.1.1",
+				"serialize-javascript": "^6.0.0",
+				"terser": "^5.7.2"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"uglify-js": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
+			"integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -3629,19 +4128,22 @@
 		},
 		"node_modules/wildcard": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-			"integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wildcard/-/wildcard-2.0.0.tgz",
+			"integrity": "sha1-p30g5SAMb6qsl55LOq3Hs91/j+w=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/workerpool": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-			"integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw=="
+			"version": "6.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/workerpool/-/workerpool-6.2.0.tgz",
+			"integrity": "sha1-gn2Tyboj7iAZw/+v9cJ/zOoonos=",
+			"license": "Apache-2.0"
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -3656,26 +4158,30 @@
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"license": "ISC"
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
+			"license": "ISC",
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+			"license": "ISC"
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
+			"license": "MIT",
 			"dependencies": {
 				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
@@ -3691,16 +4197,18 @@
 		},
 		"node_modules/yargs-parser": {
 			"version": "20.2.4",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-parser/-/yargs-parser-20.2.4.tgz",
+			"integrity": "sha1-tCiQ8UVmeW+Fro46JSkNIF8VSlQ=",
+			"license": "ISC",
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/yargs-unparser": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
+			"license": "MIT",
 			"dependencies": {
 				"camelcase": "^6.0.0",
 				"decamelize": "^4.0.0",
@@ -3713,8 +4221,9 @@
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -3725,40 +4234,40 @@
 	},
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-			"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha1-OyXTjIlgC6otzCGe36iKdOssQno=",
 			"requires": {
-				"@babel/highlight": "^7.16.0"
+				"@babel/highlight": "^7.18.6"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.15.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha1-nJfjDTGyuMcqHQiYTyyptXTXoHY="
 		},
 		"@babel/highlight": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-			"integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha1-gRWGAek+JWN5Wty/vfXWS+Py7N8=",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
 					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -3767,31 +4276,31 @@
 				},
 				"color-convert": {
 					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
 					"requires": {
 						"color-name": "1.1.3"
 					}
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -3799,20 +4308,63 @@
 			}
 		},
 		"@discoveryjs/json-ext": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
-			"integrity": "sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==",
+			"version": "0.5.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+			"integrity": "sha1-HVcr+74Ut3BOC6Dzm3SBW4SHDXA=",
 			"dev": true
 		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+			"integrity": "sha1-wa7cYehT8rufXf5tRELTtWWyU7k=",
+			"requires": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+			"integrity": "sha1-IgOxGMFXchrd/mnUe3BGVGMGbXg="
+		},
+		"@jridgewell/set-array": {
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"integrity": "sha1-fGz5mNbSC5FMClWpGuko/yWWXnI="
+		},
+		"@jridgewell/source-map": {
+			"version": "0.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+			"integrity": "sha1-9FNRqu1FJ6KYUS7HL4EEDJmFgPs=",
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha1-rdTJjTQUcqKJGQtCTvvbCWmRuyQ="
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.14",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+			"integrity": "sha1-sjGggdj2Z5bkda1Yih70cxEnAe0=",
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"@leichtgewicht/ip-codec": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
-			"integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+			"version": "2.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+			"integrity": "sha1-sqxibWy5yHGKtFkWbUu0Bbj/p4s="
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "2.0.5",
@@ -3821,14 +4373,14 @@
 		},
 		"@nodelib/fs.stat": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
 			"dev": true
 		},
 		"@nodelib/fs.walk": {
 			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.5",
@@ -3836,27 +4388,27 @@
 			}
 		},
 		"@sindresorhus/is": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-			"integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
+			"version": "4.6.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha1-PHycRuZ4/u/nouW7YJ09vWZf+z8="
 		},
 		"@szmarczak/http-timer": {
 			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac=",
 			"requires": {
 				"defer-to-connect": "^2.0.0"
 			}
 		},
 		"@tootallnate/once": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I="
 		},
 		"@types/cacheable-request": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
-			"integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+			"integrity": "sha1-wyTaAZfeCpiiMSFWU2riYkKf9rk=",
 			"requires": {
 				"@types/http-cache-semantics": "*",
 				"@types/keyv": "*",
@@ -3866,23 +4418,23 @@
 		},
 		"@types/chai": {
 			"version": "4.2.22",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
-			"integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai/-/chai-4.2.22.tgz",
+			"integrity": "sha1-RwINfkzxkZTUO1IC8191vSrTXOc=",
 			"dev": true
 		},
 		"@types/eslint": {
-			"version": "7.28.2",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
-			"integrity": "sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==",
+			"version": "8.4.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/eslint/-/eslint-8.4.5.tgz",
+			"integrity": "sha1-rN+33Ta5HMXYEtfAk4Eajz2bMeQ=",
 			"requires": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
 			}
 		},
 		"@types/eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+			"version": "3.7.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+			"integrity": "sha1-N/wSI/B4bDlicGihLpTW5vxh3hY=",
 			"requires": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -3890,13 +4442,13 @@
 		},
 		"@types/estree": {
 			"version": "0.0.50",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/estree/-/estree-0.0.50.tgz",
+			"integrity": "sha1-Hgyqk2TT/M0pMcPtlv2+ql1MyoM="
 		},
 		"@types/glob": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-vBtb86qS8lvV3TnzXFc2G9zlsus=",
 			"dev": true,
 			"requires": {
 				"@types/minimatch": "*",
@@ -3905,51 +4457,56 @@
 		},
 		"@types/http-cache-semantics": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+			"integrity": "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI="
+		},
+		"@types/json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-hcH/DwlI/BWYENS1vjW/jCCHX2Q="
 		},
 		"@types/json-schema": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+			"version": "7.0.11",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha1-1CG2xSejA398hEM/0sQingFoY9M="
 		},
 		"@types/keyv": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.3.tgz",
-			"integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
+			"version": "3.1.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha1-PM2xxnUbDH5SMAvNrNW8v4+qdbY=",
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@types/minimatch": {
 			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/minimatch/-/minimatch-3.0.5.tgz",
+			"integrity": "sha1-EAHMXmo3BLg8I2An538vWOoBD0A=",
 			"dev": true
 		},
 		"@types/mocha": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-			"integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
+			"version": "9.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/mocha/-/mocha-9.1.1.tgz",
+			"integrity": "sha1-58TxAB7vpLivvR7uJ6I3/uO/KcQ=",
 			"dev": true
 		},
 		"@types/node": {
 			"version": "16.11.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-			"integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-16.11.7.tgz",
+			"integrity": "sha1-NoIJRQYTJpeMQqAeVrYc0iPf3EI="
 		},
 		"@types/responselike": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha1-JR9P59FU0rrRJavhtCmyOv0mLik=",
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@types/rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-pj0XWzMXSOUiCtSMkB17vx9E7vg=",
 			"dev": true,
 			"requires": {
 				"@types/glob": "*",
@@ -3958,19 +4515,19 @@
 		},
 		"@types/vscode": {
 			"version": "1.62.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.62.0.tgz",
+			"integrity": "sha1-tNbRktWut16R0K3vaJw+zvmHnac=",
 			"dev": true
 		},
 		"@ungap/promise-all-settled": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+			"integrity": "sha1-qlgEJxHW4ydd033Fl+XTHowpCkQ="
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+			"integrity": "sha1-K/12fq4aaZb0Mv9+jX/HVnnAtqc=",
 			"requires": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -3978,23 +4535,23 @@
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+			"integrity": "sha1-9sYacF8P16auyqToGY8j2dwXnk8="
 		},
 		"@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+			"integrity": "sha1-GmMZLYeI5cASgAump6RscFKI/RY="
 		},
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+			"integrity": "sha1-gyqQDrREiEzemnytRn+BUA9eWrU="
 		},
 		"@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+			"integrity": "sha1-ZNgdohn7u6HjvRv8dPboxOEKYq4=",
 			"requires": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -4003,13 +4560,13 @@
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+			"integrity": "sha1-8ygkHkHnsZnQsgwY6IQpxEMyleE="
 		},
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+			"integrity": "sha1-Ie4GWntjXzGec48N1zv72igcCXo=",
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -4019,29 +4576,29 @@
 		},
 		"@webassemblyjs/ieee754": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+			"integrity": "sha1-ljkp6bvQVwnn4SJDoJkYCBKZJhQ=",
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+			"integrity": "sha1-zoFLRVdOk9drrh+yZEq5zdlSeqU=",
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+			"integrity": "sha1-0fi3ZDaefG5rrjUOhU3smlnwo/8="
 		},
 		"@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+			"integrity": "sha1-rSBuv0v5WgWM6YgKjAksXeyBk9Y=",
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -4055,8 +4612,8 @@
 		},
 		"@webassemblyjs/wasm-gen": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+			"integrity": "sha1-hsXqMEhJdZt9iMR6MvTwOa48j3Y=",
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -4067,8 +4624,8 @@
 		},
 		"@webassemblyjs/wasm-opt": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+			"integrity": "sha1-ZXtMIgL0zzs0X4pMZGHIwkGJhfI=",
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -4078,8 +4635,8 @@
 		},
 		"@webassemblyjs/wasm-parser": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+			"integrity": "sha1-hspzRTT0F+m9PGfHocddi+QfsZk=",
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -4091,69 +4648,46 @@
 		},
 		"@webassemblyjs/wast-printer": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+			"integrity": "sha1-0Mc77ajuxUJvEK6O9VzuXnCEwvA=",
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@xtuc/long": "4.2.2"
 			}
 		},
-		"@webpack-cli/configtest": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-			"dev": true,
-			"requires": {}
-		},
-		"@webpack-cli/info": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-			"integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
-			"dev": true,
-			"requires": {
-				"envinfo": "^7.7.3"
-			}
-		},
-		"@webpack-cli/serve": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-			"dev": true,
-			"requires": {}
-		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+			"integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A="
 		},
 		"@xtuc/long": {
 			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0="
 		},
 		"acorn": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-			"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
+			"version": "8.7.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn/-/acorn-8.7.1.tgz",
+			"integrity": "sha1-AZcSLIQ9G/bQpegyIKeI8nj2PDA="
 		},
 		"acorn-import-assertions": {
 			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+			"integrity": "sha1-uitZOc5iwjjbbZPYHJsRGym4Vek=",
 			"requires": {}
 		},
 		"agent-base": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
 			"requires": {
 				"debug": "4"
 			}
 		},
 		"aggregate-error": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
 			"requires": {
 				"clean-stack": "^2.0.0",
 				"indent-string": "^4.0.0"
@@ -4161,8 +4695,8 @@
 		},
 		"ajv": {
 			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -4172,32 +4706,32 @@
 		},
 		"ajv-keywords": {
 			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+			"integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
 			"requires": {}
 		},
 		"ansi-colors": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g="
 		},
 		"ansi-regex": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
 		},
 		"ansi-styles": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
 		},
 		"anymatch": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
 			"requires": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -4205,33 +4739,33 @@
 		},
 		"argparse": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg="
 		},
 		"array-union": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
 			"dev": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs="
 		},
 		"balanced-match": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
 		},
 		"big-integer": {
-			"version": "1.6.50",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
-			"integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ=="
+			"version": "1.6.51",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/big-integer/-/big-integer-1.6.51.tgz",
+			"integrity": "sha1-DfkqXZiAVg0/8tX9ICRciJ0TBoY="
 		},
 		"binary": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary/-/binary-0.3.0.tgz",
 			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
 			"requires": {
 				"buffers": "~0.1.1",
@@ -4240,18 +4774,18 @@
 		},
 		"binary-extensions": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0="
 		},
 		"bluebird": {
 			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bluebird/-/bluebird-3.4.7.tgz",
 			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -4259,58 +4793,57 @@
 		},
 		"braces": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
 		},
 		"browser-stdout": {
 			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA="
 		},
 		"browserslist": {
-			"version": "4.17.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.6.tgz",
-			"integrity": "sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==",
+			"version": "4.21.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browserslist/-/browserslist-4.21.2.tgz",
+			"integrity": "sha1-WaQAdXRlU1lUlGpAC4Qe034rTs8=",
 			"requires": {
-				"caniuse-lite": "^1.0.30001274",
-				"electron-to-chromium": "^1.3.886",
-				"escalade": "^3.1.1",
-				"node-releases": "^2.0.1",
-				"picocolors": "^1.0.0"
+				"caniuse-lite": "^1.0.30001366",
+				"electron-to-chromium": "^1.4.188",
+				"node-releases": "^2.0.6",
+				"update-browserslist-db": "^1.0.4"
 			}
 		},
 		"buffer-from": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U="
 		},
 		"buffer-indexof-polyfill": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+			"integrity": "sha1-0nMhNcWZnGSyd/z5savjSYJUcpw="
 		},
 		"buffers": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffers/-/buffers-0.1.1.tgz",
 			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"cacheable-lookup": {
 			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha1-WmuGWyxENXvj1evCpGewMnGacAU="
 		},
 		"cacheable-request": {
 			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-7.0.2.tgz",
+			"integrity": "sha1-6g0LiJNkolhUdXMByhKy2nf5HSc=",
 			"requires": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -4322,19 +4855,19 @@
 			}
 		},
 		"camelcase": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
+			"version": "6.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001279",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-			"integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
+			"version": "1.0.30001366",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001366.tgz",
+			"integrity": "sha1-xzNSyDgwqery3qD/cftLmku6qJw="
 		},
 		"chai": {
 			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chai/-/chai-4.3.4.tgz",
+			"integrity": "sha1-tV5lWzHh6scJm+TAjCGWT84ubEk=",
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
@@ -4346,7 +4879,7 @@
 		},
 		"chainsaw": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chainsaw/-/chainsaw-0.1.0.tgz",
 			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
 			"requires": {
 				"traverse": ">=0.3.0 <0.4"
@@ -4354,8 +4887,8 @@
 		},
 		"chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
 			"requires": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -4363,8 +4896,8 @@
 			"dependencies": {
 				"supports-color": {
 					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -4373,18 +4906,18 @@
 		},
 		"check-error": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/check-error/-/check-error-1.0.2.tgz",
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
 		},
 		"child_process": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/child_process/-/child_process-1.0.2.tgz",
 			"integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
 		},
 		"chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha1-HPN8hwe5Mr0a8a4iwEMuKs0ZA70=",
 			"requires": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -4398,8 +4931,8 @@
 			"dependencies": {
 				"glob-parent": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
 					"requires": {
 						"is-glob": "^4.0.1"
 					}
@@ -4408,18 +4941,18 @@
 		},
 		"chrome-trace-event": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
-			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+			"integrity": "sha1-EBXs7UdB4V0GZkqVfbv1DQQeJqw="
 		},
 		"clean-stack": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs="
 		},
 		"cliui": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
 			"requires": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
@@ -4428,8 +4961,8 @@
 		},
 		"clone-deep": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clone-deep/-/clone-deep-4.0.1.tgz",
+			"integrity": "sha1-wZ/Zvbv4WUK0/ZechNz31fB8I4c=",
 			"dev": true,
 			"requires": {
 				"is-plain-object": "^2.0.4",
@@ -4439,7 +4972,7 @@
 		},
 		"clone-response": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
 			"requires": {
 				"mimic-response": "^1.0.0"
@@ -4447,37 +4980,46 @@
 		},
 		"color-convert": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
 			"requires": {
 				"color-name": "~1.1.4"
 			}
 		},
 		"color-name": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
 		},
 		"colorette": {
-			"version": "2.0.16",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+			"version": "2.0.19",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/colorette/-/colorette-2.0.19.tgz",
+			"integrity": "sha1-zfBE9HrUGg9LVrOg1bTm4aLVp5g=",
 			"dev": true
 		},
 		"commander": {
 			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM="
+		},
+		"compress-brotli": {
+			"version": "1.3.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/compress-brotli/-/compress-brotli-1.3.8.tgz",
+			"integrity": "sha1-DApgyXqYkUUxTsOB6E4maC57ONs=",
+			"requires": {
+				"@types/json-buffer": "~3.0.0",
+				"json-buffer": "~3.0.1"
+			}
 		},
 		"concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"copy-webpack-plugin": {
 			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
-			"integrity": "sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
+			"integrity": "sha1-tx0hmRWZ9hpO4AunkIe4uiebu1k=",
 			"dev": true,
 			"requires": {
 				"fast-glob": "^3.2.5",
@@ -4491,13 +5033,13 @@
 		},
 		"core-util-is": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U="
 		},
 		"cross-spawn": {
 			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
 			"dev": true,
 			"requires": {
 				"path-key": "^3.1.0",
@@ -4506,123 +5048,123 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
 			"requires": {
 				"ms": "2.1.2"
 			},
 			"dependencies": {
 				"ms": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
 				}
 			}
 		},
 		"decamelize": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc="
 		},
 		"decompress-response": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha1-yjh2Et234QS9FthaqwDV7PCcZvw=",
 			"requires": {
 				"mimic-response": "^3.1.0"
 			},
 			"dependencies": {
 				"mimic-response": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-					"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz",
+					"integrity": "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k="
 				}
 			}
 		},
 		"deep-eql": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
 			"requires": {
 				"type-detect": "^4.0.0"
 			}
 		},
 		"defer-to-connect": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc="
 		},
 		"define-lazy-prop": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8="
 		},
 		"diff": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
+			"version": "5.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.1.0.tgz",
+			"integrity": "sha1-vFLSmMXqjfkZSAAiREXtQ//IfkA="
 		},
 		"dir-glob": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
 			"dev": true,
 			"requires": {
 				"path-type": "^4.0.0"
 			}
 		},
 		"dns-packet": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.0.tgz",
-			"integrity": "sha512-Nce7YLu6YCgWRvOmDBsJMo9M5/jV3lEZ5vUWnWXYmwURvPylHvq7nkDWhNmk1ZQoZZOP7oQh/S0lSxbisKOfHg==",
+			"version": "5.4.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dns-packet/-/dns-packet-5.4.0.tgz",
+			"integrity": "sha1-H4hHfPnyfniiE/ttEYrjjnWah5s=",
 			"requires": {
 				"@leichtgewicht/ip-codec": "^2.0.1"
 			}
 		},
 		"dns-socket": {
 			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.2.tgz",
-			"integrity": "sha512-BDeBd8najI4/lS00HSKpdFia+OvUMytaVjfzR9n5Lq8MlZRSvtbI+uLtx1+XmQFls5wFU9dssccTmQQ6nfpjdg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dns-socket/-/dns-socket-4.2.2.tgz",
+			"integrity": "sha1-WLAYbsBT6gcx/rBng8furEuVthY=",
 			"requires": {
 				"dns-packet": "^5.2.4"
 			}
 		},
 		"duplexer2": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer2/-/duplexer2-0.1.4.tgz",
 			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
 			"requires": {
 				"readable-stream": "^2.0.2"
 			}
 		},
 		"duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+			"version": "0.1.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer3/-/duplexer3-0.1.5.tgz",
+			"integrity": "sha1-C15Ne61d6JAepEQGJMjh0gCZIX4="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.893",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.893.tgz",
-			"integrity": "sha512-ChtwF7qB03INq1SyMpue08wc6cve+ktj2UC/Y7se9vB+JryfzziJeYwsgb8jLaCA5GMkHCdn5M62PfSMWhifZg=="
+			"version": "1.4.191",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.191.tgz",
+			"integrity": "sha1-Ad1L8yUCpIziS/OJC1VTocX5NTk="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
 			"requires": {
 				"once": "^1.4.0"
 			}
 		},
 		"enhanced-resolve": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-			"integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+			"version": "5.10.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+			"integrity": "sha1-DcV5w7sqEDLjV6xFuPOm861PseY=",
 			"requires": {
 				"graceful-fs": "^4.2.4",
 				"tapable": "^2.2.0"
@@ -4630,29 +5172,29 @@
 		},
 		"envinfo": {
 			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
-			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/envinfo/-/envinfo-7.8.1.tgz",
+			"integrity": "sha1-Bjd+Pl9NN5/qesWS1a2JJ+DE1HU=",
 			"dev": true
 		},
 		"es-module-lexer": {
 			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+			"integrity": "sha1-bxPbAMw4QXE32vdDZvU1yOtDjxk="
 		},
 		"escalade": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA="
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ="
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
 			"requires": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
@@ -4660,38 +5202,38 @@
 		},
 		"esprima": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
 		},
 		"esrecurse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
 			"requires": {
 				"estraverse": "^5.2.0"
 			},
 			"dependencies": {
 				"estraverse": {
 					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM="
 				}
 			}
 		},
 		"estraverse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0="
 		},
 		"events": {
 			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/events/-/events-3.3.0.tgz",
+			"integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA="
 		},
 		"execa": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^7.0.3",
@@ -4707,21 +5249,21 @@
 			"dependencies": {
 				"get-stream": {
 					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
 					"dev": true
 				}
 			}
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
 		},
 		"fast-glob": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-			"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+			"version": "3.2.11",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-glob/-/fast-glob-3.2.11.tgz",
+			"integrity": "sha1-oRcq2VzrihbiDKpcXlZIDlEpwdk=",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -4733,8 +5275,8 @@
 			"dependencies": {
 				"glob-parent": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
@@ -4744,19 +5286,19 @@
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM="
 		},
 		"fastest-levenshtein": {
 			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
-			"integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+			"integrity": "sha1-mZD306iMxan/0fF0V0UlFwDUl+I=",
 			"dev": true
 		},
 		"fastq": {
 			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fastq/-/fastq-1.13.0.tgz",
+			"integrity": "sha1-YWdg+Ip1Jr38WWt8q4wYk4w2uYw=",
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
@@ -4764,16 +5306,16 @@
 		},
 		"fill-range": {
 			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
 			"requires": {
 				"to-regex-range": "^5.0.1"
 			}
 		},
 		"find-up": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
 			"requires": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -4781,24 +5323,24 @@
 		},
 		"flat": {
 			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
 			"optional": true
 		},
 		"fstream": {
 			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"inherits": "~2.0.0",
@@ -4808,8 +5350,8 @@
 			"dependencies": {
 				"rimraf": {
 					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
 					"requires": {
 						"glob": "^7.1.3"
 					}
@@ -4818,44 +5360,44 @@
 		},
 		"function-bind": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
 		},
 		"get-func-name": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-func-name/-/get-func-name-2.0.0.tgz",
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
 		},
 		"get-stream": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
 			"requires": {
 				"pump": "^3.0.0"
 			}
 		},
 		"glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+			"version": "7.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-parent": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.3"
@@ -4863,34 +5405,34 @@
 		},
 		"glob-to-regexp": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+			"integrity": "sha1-x1KXCHyFG5pXi9IX3VmpL1n+VG4="
 		},
 		"globby": {
-			"version": "11.0.4",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-			"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+			"version": "11.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha1-vUvpi7BC+D15b344EZkfvoKg00s=",
 			"dev": true,
 			"requires": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.1.1",
-				"ignore": "^5.1.4",
-				"merge2": "^1.3.0",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
 			}
 		},
 		"got": {
-			"version": "11.8.2",
-			"resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-			"integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+			"version": "11.8.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz",
+			"integrity": "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY=",
 			"requires": {
 				"@sindresorhus/is": "^4.0.0",
 				"@szmarczak/http-timer": "^4.0.5",
 				"@types/cacheable-request": "^6.0.1",
 				"@types/responselike": "^1.0.0",
 				"cacheable-lookup": "^5.0.3",
-				"cacheable-request": "^7.0.1",
+				"cacheable-request": "^7.0.2",
 				"decompress-response": "^6.0.0",
 				"http2-wrapper": "^1.0.0-beta.5.2",
 				"lowercase-keys": "^2.0.0",
@@ -4899,32 +5441,32 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+			"version": "4.2.10",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha1-FH06AG2kyjzhRyjHrvwofDZ9emw="
 		},
 		"growl": {
 			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4="
 		},
 		"has": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has/-/has-1.0.3.tgz",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
 		},
 		"hash.js": {
 			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -4932,12 +5474,12 @@
 		},
 		"he": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/he/-/he-1.2.0.tgz",
+			"integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"requires": {
 				"hash.js": "^1.0.3",
@@ -4947,13 +5489,13 @@
 		},
 		"http-cache-semantics": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+			"integrity": "sha1-SekcXL82yblLz81xwj1SSex045A="
 		},
 		"http-proxy-agent": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
 			"requires": {
 				"@tootallnate/once": "1",
 				"agent-base": "6",
@@ -4962,17 +5504,17 @@
 		},
 		"http2-wrapper": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha1-uPVeDB8l1OvQizsMLAeflZCACz0=",
 			"requires": {
 				"quick-lru": "^5.1.1",
 				"resolve-alpn": "^1.0.0"
 			}
 		},
 		"https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
 			"requires": {
 				"agent-base": "6",
 				"debug": "4"
@@ -4980,20 +5522,20 @@
 		},
 		"human-signals": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
 			"dev": true
 		},
 		"ignore": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-			"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+			"version": "5.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ignore/-/ignore-5.2.0.tgz",
+			"integrity": "sha1-bTusj6f+DUXZ+b57rC/CeVd+NFo=",
 			"dev": true
 		},
 		"import-local": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
-			"integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
+			"version": "3.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/import-local/-/import-local-3.1.0.tgz",
+			"integrity": "sha1-tEed+KX9RPbNziQHBnVnYGPJXLQ=",
 			"dev": true,
 			"requires": {
 				"pkg-dir": "^4.2.0",
@@ -5002,12 +5544,12 @@
 		},
 		"indent-string": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE="
 		},
 		"inflight": {
 			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
 				"once": "^1.3.0",
@@ -5016,75 +5558,75 @@
 		},
 		"inherits": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
 		},
 		"interpret": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/interpret/-/interpret-1.4.0.tgz",
+			"integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4="
 		},
 		"ip-regex": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-			"integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ip-regex/-/ip-regex-4.3.0.tgz",
+			"integrity": "sha1-aHJ1qw9X+naXj/j03dyKI9WZDbU="
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
 			"requires": {
 				"binary-extensions": "^2.0.0"
 			}
 		},
 		"is-core-module": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-			"integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+			"version": "2.9.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha1-4cNEKc1Rxt2eCeB5njluJ7GanGk=",
 			"requires": {
 				"has": "^1.0.3"
 			}
 		},
 		"is-docker": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-fullwidth-code-point": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
 		},
 		"is-glob": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
 		},
 		"is-ip": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-ip/-/is-ip-3.1.0.tgz",
+			"integrity": "sha1-KuXd+vrwXLgAimIJPPKXNPZXxdg=",
 			"requires": {
 				"ip-regex": "^4.0.0"
 			}
 		},
 		"is-number": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
 		},
 		"is-online": {
 			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/is-online/-/is-online-9.0.1.tgz",
-			"integrity": "sha512-+08dRW0dcFOtleR2N3rHRVxDyZtQitUp9cC+KpKTds0mXibbQyW5js7xX0UGyQXkaLUJObe0w6uQ4ex34lX9LA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-9.0.1.tgz",
+			"integrity": "sha1-caNCAvqCa65vP/i+pCDFZXNEil8=",
 			"requires": {
 				"got": "^11.8.0",
 				"p-any": "^3.0.0",
@@ -5094,13 +5636,13 @@
 		},
 		"is-plain-obj": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
@@ -5108,43 +5650,43 @@
 		},
 		"is-stream": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
 			"dev": true
 		},
 		"is-unicode-supported": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc="
 		},
 		"is-wsl": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
 			"requires": {
 				"is-docker": "^2.0.0"
 			}
 		},
 		"isarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
 		"jest-worker": {
-			"version": "27.3.1",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
-			"integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
+			"version": "27.5.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jest-worker/-/jest-worker-27.5.1.tgz",
+			"integrity": "sha1-jRRvCQDolzsQa29zzB6ajLhvjbA=",
 			"requires": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -5153,68 +5695,69 @@
 		},
 		"js-tokens": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
 		},
 		"js-yaml": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
 			"requires": {
 				"argparse": "^2.0.1"
 			}
 		},
 		"json-buffer": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
 		},
 		"keyv": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
-			"integrity": "sha512-vqNHbAc8BBsxk+7QBYLW0Y219rWcClspR6WSeoHYKG5mnsSoOH+BL1pWq02DDCVdvvuUny5rkBlzMRzoqc+GIg==",
+			"version": "4.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.3.2.tgz",
+			"integrity": "sha1-6DnfZ2oMfuWUyINefByDdCVY5cI=",
 			"requires": {
+				"compress-brotli": "^1.3.8",
 				"json-buffer": "3.0.1"
 			}
 		},
 		"kind-of": {
 			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
 			"dev": true
 		},
 		"listenercount": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/listenercount/-/listenercount-1.0.1.tgz",
 			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
 		},
 		"loader-runner": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
-			"integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw=="
+			"version": "4.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/loader-runner/-/loader-runner-4.3.0.tgz",
+			"integrity": "sha1-wbShY7mfYUgwNTsWdV5xSawjFOE="
 		},
 		"locate-path": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
 			"requires": {
 				"p-locate": "^5.0.0"
 			}
 		},
 		"log-symbols": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
 			"requires": {
 				"chalk": "^4.1.0",
 				"is-unicode-supported": "^0.1.0"
@@ -5222,127 +5765,132 @@
 		},
 		"lowercase-keys": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk="
 		},
 		"lru-cache": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
 			"requires": {
 				"yallist": "^4.0.0"
 			}
 		},
 		"merge-stream": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A="
 		},
 		"merge2": {
 			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
 			"dev": true
 		},
 		"micromatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"version": "4.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/micromatch/-/micromatch-4.0.5.tgz",
+			"integrity": "sha1-vImZp8u/d83InxMvbkZwUbSQkMY=",
 			"requires": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
+				"braces": "^3.0.2",
+				"picomatch": "^2.3.1"
 			}
 		},
 		"mime-db": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-			"integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+			"version": "1.52.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A="
 		},
 		"mime-types": {
-			"version": "2.1.34",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-			"integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+			"version": "2.1.35",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
 			"requires": {
-				"mime-db": "1.51.0"
+				"mime-db": "1.52.0"
 			}
 		},
 		"mimic-fn": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
 			"dev": true
 		},
 		"mimic-response": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
 			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q="
 		},
 		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
 			"requires": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			}
 		},
 		"mocha": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-			"integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+			"version": "9.2.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mocha/-/mocha-9.2.2.tgz",
+			"integrity": "sha1-1w20a9uTyldALICTM+WoSXeoj7k=",
 			"requires": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.2",
-				"debug": "4.3.2",
+				"chokidar": "3.5.3",
+				"debug": "4.3.3",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
-				"glob": "7.1.7",
+				"glob": "7.2.0",
 				"growl": "1.10.5",
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
-				"minimatch": "3.0.4",
+				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
+				"nanoid": "3.3.1",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"workerpool": "6.1.5",
+				"workerpool": "6.2.0",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
 			},
 			"dependencies": {
+				"diff": {
+					"version": "5.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.0.0.tgz",
+					"integrity": "sha1-ftatdthZ0DB4fsNYVfWx2vMdhSs="
+				},
 				"glob": {
-					"version": "7.1.7",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-					"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+					"version": "7.2.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.0.tgz",
+					"integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -5350,44 +5898,62 @@
 						"minimatch": "^3.0.4",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
+					},
+					"dependencies": {
+						"minimatch": {
+							"version": "3.1.2",
+							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+							"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						}
+					}
+				},
+				"minimatch": {
+					"version": "4.2.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-4.2.1.tgz",
+					"integrity": "sha1-QNnVEaRr3E5WPCLDCAzenA2CmbQ=",
+					"requires": {
+						"brace-expansion": "^1.1.7"
 					}
 				}
 			}
 		},
 		"ms": {
 			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
 		},
 		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
+			"version": "3.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha1-Y0ehjKyIr4j1ivCzWUtyPV6ZuzU="
 		},
 		"neo-async": {
 			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8="
 		},
 		"node-releases": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+			"version": "2.0.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-releases/-/node-releases-2.0.6.tgz",
+			"integrity": "sha1-inCIxjpV5JOEVoPr88go2MUcVQM="
 		},
 		"normalize-path": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
 		},
 		"normalize-url": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo="
 		},
 		"npm-run-path": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
 			"dev": true,
 			"requires": {
 				"path-key": "^3.0.0"
@@ -5395,7 +5961,7 @@
 		},
 		"once": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
 				"wrappy": "1"
@@ -5403,8 +5969,8 @@
 		},
 		"onetime": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
 			"dev": true,
 			"requires": {
 				"mimic-fn": "^2.1.0"
@@ -5412,8 +5978,8 @@
 		},
 		"open": {
 			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-			"integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-8.4.0.tgz",
+			"integrity": "sha1-NFMhrhj4E4+CVlqRD9xrOejCRPg=",
 			"requires": {
 				"define-lazy-prop": "^2.0.0",
 				"is-docker": "^2.1.1",
@@ -5422,8 +5988,8 @@
 		},
 		"p-any": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-any/-/p-any-3.0.0.tgz",
-			"integrity": "sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-3.0.0.tgz",
+			"integrity": "sha1-eYR67tcLXToQ6mJSlsDD0ukKh7k=",
 			"requires": {
 				"p-cancelable": "^2.0.0",
 				"p-some": "^5.0.0"
@@ -5431,34 +5997,34 @@
 		},
 		"p-cancelable": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8="
 		},
 		"p-finally": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
 			"requires": {
 				"yocto-queue": "^0.1.0"
 			}
 		},
 		"p-locate": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
 			"requires": {
 				"p-limit": "^3.0.2"
 			}
 		},
 		"p-some": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
-			"integrity": "sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-5.0.0.tgz",
+			"integrity": "sha1-i3MMdLT+UWnXJkokCtAQtuvGhqQ=",
 			"requires": {
 				"aggregate-error": "^3.0.0",
 				"p-cancelable": "^2.0.0"
@@ -5466,64 +6032,64 @@
 		},
 		"p-timeout": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
 			"requires": {
 				"p-finally": "^1.0.0"
 			}
 		},
 		"p-try": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
 			"dev": true
 		},
 		"path-exists": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
 			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
 		},
 		"path-type": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
 			"dev": true
 		},
 		"pathval": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha1-hTTnenfOesWiUS6iHg/bj89sPY0="
 		},
 		"picocolors": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw="
 		},
 		"picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+			"version": "2.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI="
 		},
 		"pkg-dir": {
 			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
 			"dev": true,
 			"requires": {
 				"find-up": "^4.0.0"
@@ -5531,8 +6097,8 @@
 			"dependencies": {
 				"find-up": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
 					"dev": true,
 					"requires": {
 						"locate-path": "^5.0.0",
@@ -5541,8 +6107,8 @@
 				},
 				"locate-path": {
 					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
 					"dev": true,
 					"requires": {
 						"p-locate": "^4.1.0"
@@ -5550,8 +6116,8 @@
 				},
 				"p-limit": {
 					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -5559,8 +6125,8 @@
 				},
 				"p-locate": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
 					"dev": true,
 					"requires": {
 						"p-limit": "^2.2.0"
@@ -5570,18 +6136,18 @@
 		},
 		"prepend-http": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prepend-http/-/prepend-http-2.0.0.tgz",
 			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
 		},
 		"public-ip": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/public-ip/-/public-ip-4.0.4.tgz",
-			"integrity": "sha512-EJ0VMV2vF6Cu7BIPo3IMW1Maq6ME+fbR0NcPmqDfpfNGIRPue1X8QrGjrg/rfjDkOsIkKHIf2S5FlEa48hFMTA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-4.0.4.tgz",
+			"integrity": "sha1-s3hKWh/xuB0BW5oYRQvmX/2SnrM=",
 			"requires": {
 				"dns-socket": "^4.2.2",
 				"got": "^9.6.0",
@@ -5590,21 +6156,21 @@
 			"dependencies": {
 				"@sindresorhus/is": {
 					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-					"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-0.14.0.tgz",
+					"integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o="
 				},
 				"@szmarczak/http-timer": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-					"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+					"integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
 					"requires": {
 						"defer-to-connect": "^1.0.1"
 					}
 				},
 				"cacheable-request": {
 					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-					"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-6.1.0.tgz",
+					"integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
 					"requires": {
 						"clone-response": "^1.0.2",
 						"get-stream": "^5.1.0",
@@ -5617,7 +6183,7 @@
 				},
 				"decompress-response": {
 					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-3.3.0.tgz",
 					"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
 					"requires": {
 						"mimic-response": "^1.0.0"
@@ -5625,13 +6191,13 @@
 				},
 				"defer-to-connect": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-					"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+					"integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE="
 				},
 				"got": {
 					"version": "9.6.0",
-					"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-					"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-9.6.0.tgz",
+					"integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
 					"requires": {
 						"@sindresorhus/is": "^0.14.0",
 						"@szmarczak/http-timer": "^1.1.2",
@@ -5648,45 +6214,45 @@
 					"dependencies": {
 						"get-stream": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-							"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-4.1.0.tgz",
+							"integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
 							"requires": {
 								"pump": "^3.0.0"
 							}
 						},
 						"lowercase-keys": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-							"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+							"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
 						}
 					}
 				},
 				"json-buffer": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.0.tgz",
 					"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
 				},
 				"keyv": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-					"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-3.1.0.tgz",
+					"integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
 					"requires": {
 						"json-buffer": "3.0.0"
 					}
 				},
 				"normalize-url": {
 					"version": "4.5.1",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-					"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-4.5.1.tgz",
+					"integrity": "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo="
 				},
 				"p-cancelable": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-					"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-1.1.0.tgz",
+					"integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw="
 				},
 				"responselike": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-1.0.2.tgz",
 					"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
 					"requires": {
 						"lowercase-keys": "^1.0.0"
@@ -5694,8 +6260,8 @@
 					"dependencies": {
 						"lowercase-keys": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-							"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+							"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
 						}
 					}
 				}
@@ -5703,8 +6269,8 @@
 		},
 		"pump": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -5712,32 +6278,32 @@
 		},
 		"punycode": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
 		},
 		"queue-microtask": {
 			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
 			"dev": true
 		},
 		"quick-lru": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha1-NmST5rPkKjpoheLpnRj4D7eoyTI="
 		},
 		"randombytes": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
 		},
 		"readable-stream": {
 			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -5750,22 +6316,22 @@
 			"dependencies": {
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
 				}
 			}
 		},
 		"readdirp": {
 			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
 		},
 		"rechoir": {
 			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
 				"resolve": "^1.1.6"
@@ -5773,27 +6339,28 @@
 		},
 		"require-directory": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"version": "1.22.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha1-J8suu1P5GrtJRwqSi7p1WAZqwXc=",
 			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
 		"resolve-alpn": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha1-t629rDVGqq7CC0Xn2CZZJwcnJvk="
 		},
 		"resolve-cwd": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
 			"dev": true,
 			"requires": {
 				"resolve-from": "^5.0.0"
@@ -5801,36 +6368,36 @@
 		},
 		"resolve-from": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
 			"dev": true
 		},
 		"responselike": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-			"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-2.0.0.tgz",
+			"integrity": "sha1-JjkbzDF091D5p56sxAoSpcQtdyM=",
 			"requires": {
 				"lowercase-keys": "^2.0.0"
 			}
 		},
 		"reusify": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
 			"dev": true
 		},
 		"rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
 			"requires": {
 				"glob": "^7.1.3"
 			}
 		},
 		"run-parallel": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
 			"dev": true,
 			"requires": {
 				"queue-microtask": "^1.2.2"
@@ -5838,13 +6405,13 @@
 		},
 		"safe-buffer": {
 			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
 		},
 		"schema-utils": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/schema-utils/-/schema-utils-3.1.1.tgz",
+			"integrity": "sha1-vHTEtraZXB2I92qLd76nIZ4MgoE=",
 			"requires": {
 				"@types/json-schema": "^7.0.8",
 				"ajv": "^6.12.5",
@@ -5852,30 +6419,30 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha1-EsW2Sa/b+QSXB3luIqQCiBTOUj8=",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
 		},
 		"serialize-javascript": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+			"integrity": "sha1-765diPRdeSQUHai1w6en5mP+/rg=",
 			"requires": {
 				"randombytes": "^2.1.0"
 			}
 		},
 		"setimmediate": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"shallow-clone": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shallow-clone/-/shallow-clone-3.0.1.tgz",
+			"integrity": "sha1-jymBrZJTH1UDWwH7IwdppA4C76M=",
 			"dev": true,
 			"requires": {
 				"kind-of": "^6.0.2"
@@ -5883,8 +6450,8 @@
 		},
 		"shebang-command": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
 			"dev": true,
 			"requires": {
 				"shebang-regex": "^3.0.0"
@@ -5892,14 +6459,14 @@
 		},
 		"shebang-regex": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
 			"dev": true
 		},
 		"shelljs": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-			"integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+			"version": "0.8.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
+			"integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
 			"requires": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -5907,26 +6474,26 @@
 			}
 		},
 		"signal-exit": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-			"integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+			"version": "3.0.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
 			"dev": true
 		},
 		"slash": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
 			"dev": true
 		},
 		"source-map": {
 			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
 		},
 		"source-map-support": {
-			"version": "0.5.20",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-			"integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+			"version": "0.5.21",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha1-BP58f54e0tZiIzwoyys1ufY/bk8=",
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -5934,28 +6501,28 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			},
 			"dependencies": {
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
 				}
 			}
 		},
 		"string-width": {
 			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -5964,87 +6531,74 @@
 		},
 		"strip-ansi": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
 			"requires": {
 				"ansi-regex": "^5.0.1"
 			}
 		},
 		"strip-final-newline": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
 			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY="
 		},
 		"supports-color": {
 			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
 			"requires": {
 				"has-flag": "^4.0.0"
 			}
 		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk="
+		},
 		"tapable": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha1-GWenPvQGCoLxKrlq+G1S/bdu7KA="
 		},
 		"terser": {
-			"version": "5.9.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
-			"integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
+			"version": "5.14.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/terser/-/terser-5.14.2.tgz",
+			"integrity": "sha1-msnyKwaZTXNhdPQJGqNo24lvHBA=",
 			"requires": {
+				"@jridgewell/source-map": "^0.3.2",
+				"acorn": "^8.5.0",
 				"commander": "^2.20.0",
-				"source-map": "~0.7.2",
 				"source-map-support": "~0.5.20"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.7.3",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-				}
-			}
-		},
-		"terser-webpack-plugin": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz",
-			"integrity": "sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==",
-			"requires": {
-				"jest-worker": "^27.0.6",
-				"schema-utils": "^3.1.1",
-				"serialize-javascript": "^6.0.0",
-				"source-map": "^0.6.1",
-				"terser": "^5.7.2"
 			}
 		},
 		"to-readable-stream": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+			"integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E="
 		},
 		"to-regex-range": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
 			"requires": {
 				"is-number": "^7.0.0"
 			}
 		},
 		"traverse": {
 			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/traverse/-/traverse-0.3.9.tgz",
 			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
 		},
 		"ts-loader": {
-			"version": "9.2.6",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
-			"integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
+			"version": "9.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ts-loader/-/ts-loader-9.3.1.tgz",
+			"integrity": "sha1-/iXMpW4+ccEIf+SNxn9N+MWbItQ=",
 			"requires": {
 				"chalk": "^4.1.0",
 				"enhanced-resolve": "^5.0.0",
@@ -6054,13 +6608,13 @@
 		},
 		"tslib": {
 			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA="
 		},
 		"tslint": {
 			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslint/-/tslint-5.20.1.tgz",
+			"integrity": "sha1-5AHortoBUrxE3QfmFANPP4DGe30=",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"builtin-modules": "^1.1.1",
@@ -6079,24 +6633,24 @@
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
 				},
 				"argparse": {
 					"version": "1.0.10",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
 					"requires": {
 						"sprintf-js": "~1.0.2"
 					}
 				},
 				"chalk": {
 					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -6105,36 +6659,36 @@
 				},
 				"color-convert": {
 					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
 					"requires": {
 						"color-name": "1.1.3"
 					}
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
 				"diff": {
 					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0="
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"js-yaml": {
 					"version": "3.14.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
 					"requires": {
 						"argparse": "^1.0.7",
 						"esprima": "^4.0.0"
@@ -6142,41 +6696,41 @@
 				},
 				"semver": {
 					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
 				},
 				"supports-color": {
 					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 					"requires": {
 						"has-flag": "^3.0.0"
+					}
+				},
+				"tsutils": {
+					"version": "2.29.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tsutils/-/tsutils-2.29.0.tgz",
+					"integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+					"requires": {
+						"tslib": "^1.8.1"
 					}
 				}
 			}
 		},
-		"tsutils": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-			"requires": {
-				"tslib": "^1.8.1"
-			}
-		},
 		"type-detect": {
 			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw="
 		},
 		"typescript": {
 			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha1-LNAaGh8WBwTTEB/VpY/w+fy4Aww="
 		},
 		"unzipper": {
 			"version": "0.10.11",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unzipper/-/unzipper-0.10.11.tgz",
+			"integrity": "sha1-C0mRRGRyy9uS7nQDkJ8mwkGceC4=",
 			"requires": {
 				"big-integer": "^1.6.17",
 				"binary": "~0.3.0",
@@ -6190,17 +6744,26 @@
 				"setimmediate": "~1.0.4"
 			}
 		},
+		"update-browserslist-db": {
+			"version": "1.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
+			"integrity": "sha1-2/xaeJyqJrHbiZB5bCyOu84wSCQ=",
+			"requires": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			}
+		},
 		"uri-js": {
 			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
 			"requires": {
 				"punycode": "^2.1.0"
 			}
 		},
 		"url-parse-lax": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
 			"requires": {
 				"prepend-http": "^2.0.0"
@@ -6208,13 +6771,13 @@
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"vscode-dotnet-runtime-library": {
 			"version": "file:../vscode-dotnet-runtime-library",
 			"requires": {
-				"@types/chai": "^4.2.22",
+				"@types/chai": "4.2.22",
 				"@types/chai-as-promised": "^7.1.4",
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
@@ -6223,7 +6786,7 @@
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
 				"@types/vscode": "1.62.0",
-				"chai": "^4.3.4",
+				"chai": "4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",
 				"eol": "^0.9.1",
@@ -6246,8 +6809,8 @@
 		},
 		"vscode-test": {
 			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vscode-test/-/vscode-test-1.6.1.tgz",
+			"integrity": "sha1-RCVMZwNt6SsA/dcvas5fGFThpWM=",
 			"requires": {
 				"http-proxy-agent": "^4.0.1",
 				"https-proxy-agent": "^5.0.0",
@@ -6256,9 +6819,9 @@
 			}
 		},
 		"watchpack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-			"integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+			"version": "2.4.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/watchpack/-/watchpack-2.4.0.tgz",
+			"integrity": "sha1-+jMDI3SWLHgRP5PH8vtMVMmGKl0=",
 			"requires": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -6266,8 +6829,8 @@
 		},
 		"webpack": {
 			"version": "5.63.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.63.0.tgz",
-			"integrity": "sha512-HYrw6bkj/MDmphAXvqLEvn2fVoDZsYu6O638WjK6lSNgIpjb5jl/KtOrqJyU9EC/ZV9mLUmZW5h4mASB+CVA4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack/-/webpack-5.63.0.tgz",
+			"integrity": "sha1-SwdBFYAOBSbYURKYXkbGS5XgSq8=",
 			"requires": {
 				"@types/eslint-scope": "^3.7.0",
 				"@types/estree": "^0.0.50",
@@ -6293,12 +6856,26 @@
 				"terser-webpack-plugin": "^5.1.3",
 				"watchpack": "^2.2.0",
 				"webpack-sources": "^3.2.0"
+			},
+			"dependencies": {
+				"terser-webpack-plugin": {
+					"version": "5.3.3",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
+					"integrity": "sha1-gDPbh23Vh1SHIT6Hxie8oyPl7ZA=",
+					"requires": {
+						"@jridgewell/trace-mapping": "^0.3.7",
+						"jest-worker": "^27.4.5",
+						"schema-utils": "^3.1.1",
+						"serialize-javascript": "^6.0.0",
+						"terser": "^5.7.2"
+					}
+				}
 			}
 		},
 		"webpack-cli": {
 			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-			"integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-cli/-/webpack-cli-4.9.1.tgz",
+			"integrity": "sha1-tkvoJeLRsTDyhcMUyqOxuppGMrM=",
 			"dev": true,
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
@@ -6315,22 +6892,45 @@
 				"webpack-merge": "^5.7.3"
 			},
 			"dependencies": {
+				"@webpack-cli/configtest": {
+					"version": "1.2.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+					"integrity": "sha1-eyDOHBJTORLDshfqaCYjZfoppvU=",
+					"dev": true,
+					"requires": {}
+				},
+				"@webpack-cli/info": {
+					"version": "1.5.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webpack-cli/info/-/info-1.5.0.tgz",
+					"integrity": "sha1-bHjBPFh0hS1uLdF/CKQfP+TCYbE=",
+					"dev": true,
+					"requires": {
+						"envinfo": "^7.7.3"
+					}
+				},
+				"@webpack-cli/serve": {
+					"version": "1.7.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webpack-cli/serve/-/serve-1.7.0.tgz",
+					"integrity": "sha1-4Zk2iaxC0rFukZQ3bPtnU/YlTbE=",
+					"dev": true,
+					"requires": {}
+				},
 				"commander": {
 					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-					"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-7.2.0.tgz",
+					"integrity": "sha1-o2y1fQtQHOEI5NIFWaFQo5HZerc=",
 					"dev": true
 				},
 				"interpret": {
 					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-					"integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/interpret/-/interpret-2.2.0.tgz",
+					"integrity": "sha1-GnigtZZcQKVBbQB61vUK0nxBffk=",
 					"dev": true
 				},
 				"rechoir": {
 					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-					"integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rechoir/-/rechoir-0.7.1.tgz",
+					"integrity": "sha1-lHipahyhNbXoj8An8D7pLWxkVoY=",
 					"dev": true,
 					"requires": {
 						"resolve": "^1.9.0"
@@ -6340,8 +6940,8 @@
 		},
 		"webpack-merge": {
 			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-			"integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-merge/-/webpack-merge-5.8.0.tgz",
+			"integrity": "sha1-Kznb8ir4d3atdEw5AiNzHTCmj2E=",
 			"dev": true,
 			"requires": {
 				"clone-deep": "^4.0.1",
@@ -6349,33 +6949,33 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-			"integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA=="
+			"version": "3.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-sources/-/webpack-sources-3.2.3.tgz",
+			"integrity": "sha1-LU2quEUf1LJAzCcFX/agwszqDN4="
 		},
 		"which": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
+			"integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
 			"requires": {
 				"isexe": "^2.0.0"
 			}
 		},
 		"wildcard": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-			"integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wildcard/-/wildcard-2.0.0.tgz",
+			"integrity": "sha1-p30g5SAMb6qsl55LOq3Hs91/j+w=",
 			"dev": true
 		},
 		"workerpool": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-			"integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw=="
+			"version": "6.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/workerpool/-/workerpool-6.2.0.tgz",
+			"integrity": "sha1-gn2Tyboj7iAZw/+v9cJ/zOoonos="
 		},
 		"wrap-ansi": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
 			"requires": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -6384,23 +6984,23 @@
 		},
 		"wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"y18n": {
 			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU="
 		},
 		"yallist": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
 		},
 		"yargs": {
 			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
 			"requires": {
 				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
@@ -6413,13 +7013,13 @@
 		},
 		"yargs-parser": {
 			"version": "20.2.4",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-parser/-/yargs-parser-20.2.4.tgz",
+			"integrity": "sha1-tCiQ8UVmeW+Fro46JSkNIF8VSlQ="
 		},
 		"yargs-unparser": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
 			"requires": {
 				"camelcase": "^6.0.0",
 				"decamelize": "^4.0.0",
@@ -6429,8 +7029,8 @@
 		},
 		"yocto-queue": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs="
 		}
 	}
 }

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -30,13 +30,13 @@
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"copy-webpack-plugin": "9.0.1",
 				"webpack": "5.63.0",
 				"webpack-cli": "4.9.1"
 			},
 			"engines": {
-				"vscode": "^1.62.0"
+				"vscode": "1.62.0"
 			}
 		},
 		"../vscode-dotnet-runtime-library": {
@@ -50,7 +50,7 @@
 				"@types/rimraf": "3.0.2",
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"chai": "^4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",
@@ -74,7 +74,7 @@
 				"glob": "^7.2.0"
 			},
 			"engines": {
-				"vscode": "^1.62.0"
+				"vscode": "1.62.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "^2.3.2"
@@ -6222,7 +6222,7 @@
 				"@types/rimraf": "3.0.2",
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"chai": "^4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -107,5 +107,11 @@
 		"copy-webpack-plugin": "9.0.1",
 		"webpack": "5.63.0",
 		"webpack-cli": "4.9.1"
+	},
+	"__metadata": {
+		"id": "1aab81a1-b3d9-4aef-976b-577d5d90fe3f",
+		"publisherDisplayName": "Microsoft",
+		"publisherId": "d05e23de-3974-4ff0-8d47-23ee77830092",
+		"isPreReleaseVersion": false
 	}
 }

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -16,7 +16,7 @@
 	"version": "1.6.0",
 	"publisher": "ms-dotnettools",
 	"engines": {
-		"vscode": "^1.62.0"
+		"vscode": "1.62.0"
 	},
 	"categories": [
 		"Other"
@@ -103,7 +103,7 @@
 		"@types/mocha": "^9.0.0",
 		"@types/node": "16.11.7",
 		"@types/rimraf": "3.0.2",
-		"@types/vscode": "^1.62.0",
+		"@types/vscode": "1.62.0",
 		"copy-webpack-plugin": "9.0.1",
 		"webpack": "5.63.0",
 		"webpack-cli": "4.9.1"

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -82,7 +82,7 @@
 		"webpack": "webpack --mode development"
 	},
 	"dependencies": {
-		"chai": "^4.3.4",
+		"chai": "4.3.4",
 		"child_process": "^1.0.2",
 		"diff": ">=5.0.0",
 		"glob": "^7.2.0",
@@ -99,7 +99,7 @@
 		"vscode-test": "^1.6.1"
 	},
 	"devDependencies": {
-		"@types/chai": "^4.2.22",
+		"@types/chai": "4.2.22",
 		"@types/mocha": "^9.0.0",
 		"@types/node": "16.11.7",
 		"@types/rimraf": "3.0.2",

--- a/vscode-dotnet-runtime-library/.npmrc
+++ b/vscode-dotnet-runtime-library/.npmrc
@@ -1,1 +1,2 @@
 registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+always-auth=true

--- a/vscode-dotnet-runtime-library/.npmrc
+++ b/vscode-dotnet-runtime-library/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/

--- a/vscode-dotnet-runtime-library/.npmrc
+++ b/vscode-dotnet-runtime-library/.npmrc
@@ -1,2 +1,1 @@
 registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
-always-auth=true

--- a/vscode-dotnet-runtime-library/package-lock.json
+++ b/vscode-dotnet-runtime-library/package-lock.json
@@ -47,32 +47,45 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha1-OyXTjIlgC6otzCGe36iKdOssQno=",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.12.13"
+				"@babel/highlight": "^7.18.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha1-nJfjDTGyuMcqHQiYTyyptXTXoHY=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-			"integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha1-gRWGAek+JWN5Wty/vfXWS+Py7N8=",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/ansi-styles": {
 			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -82,8 +95,9 @@
 		},
 		"node_modules/@babel/highlight/node_modules/chalk": {
 			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -95,37 +109,42 @@
 		},
 		"node_modules/@babel/highlight/node_modules/color-convert": {
 			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/color-name": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"license": "MIT"
 		},
 		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/has-flag": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/supports-color": {
 			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -134,14 +153,16 @@
 			}
 		},
 		"node_modules/@leichtgewicht/ip-codec": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
-			"integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+			"version": "2.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+			"integrity": "sha1-sqxibWy5yHGKtFkWbUu0Bbj/p4s=",
+			"license": "MIT"
 		},
 		"node_modules/@sindresorhus/is": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-			"integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==",
+			"version": "4.6.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha1-PHycRuZ4/u/nouW7YJ09vWZf+z8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -151,8 +172,9 @@
 		},
 		"node_modules/@szmarczak/http-timer": {
 			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac=",
+			"license": "MIT",
 			"dependencies": {
 				"defer-to-connect": "^2.0.0"
 			},
@@ -162,16 +184,18 @@
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
 			}
 		},
 		"node_modules/@types/cacheable-request": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
-			"integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+			"integrity": "sha1-wyTaAZfeCpiiMSFWU2riYkKf9rk=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/http-cache-semantics": "*",
 				"@types/keyv": "*",
@@ -181,26 +205,30 @@
 		},
 		"node_modules/@types/caseless": {
 			"version": "0.12.2",
-			"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-			"integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/caseless/-/caseless-0.12.2.tgz",
+			"integrity": "sha1-9l09Y4ngHutFi9VNyPUrlalGO8g=",
+			"license": "MIT"
 		},
 		"node_modules/@types/chai": {
-			"version": "4.2.22",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
-			"integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ=="
+			"version": "4.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai/-/chai-4.3.1.tgz",
+			"integrity": "sha1-4sbnPgveslIdAHVtCZIY6fXZCgQ=",
+			"license": "MIT"
 		},
 		"node_modules/@types/chai-as-promised": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.4.tgz",
-			"integrity": "sha512-1y3L1cHePcIm5vXkh1DSGf/zQq5n5xDKG1fpCvf18+uOkpce0Z1ozNFPkyWsVswK7ntN1sZBw3oU6gmN+pDUcA==",
+			"version": "7.1.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+			"integrity": "sha1-bgFoEfbHpk8u7YIxkcOmlVCU4lU=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/chai": "*"
 			}
 		},
 		"node_modules/@types/glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+			"version": "7.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-vBtb86qS8lvV3TnzXFc2G9zlsus=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/minimatch": "*",
 				"@types/node": "*"
@@ -208,36 +236,48 @@
 		},
 		"node_modules/@types/http-cache-semantics": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+			"integrity": "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI=",
+			"license": "MIT"
+		},
+		"node_modules/@types/json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-hcH/DwlI/BWYENS1vjW/jCCHX2Q=",
+			"license": "MIT"
 		},
 		"node_modules/@types/keyv": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.3.tgz",
-			"integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
+			"version": "3.1.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha1-PM2xxnUbDH5SMAvNrNW8v4+qdbY=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/minimatch": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+			"version": "3.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/minimatch/-/minimatch-3.0.5.tgz",
+			"integrity": "sha1-EAHMXmo3BLg8I2An538vWOoBD0A=",
+			"license": "MIT"
 		},
 		"node_modules/@types/mocha": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-			"integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA=="
+			"version": "9.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/mocha/-/mocha-9.1.1.tgz",
+			"integrity": "sha1-58TxAB7vpLivvR7uJ6I3/uO/KcQ=",
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "16.11.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-			"integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-16.11.7.tgz",
+			"integrity": "sha1-NoIJRQYTJpeMQqAeVrYc0iPf3EI=",
+			"license": "MIT"
 		},
 		"node_modules/@types/request": {
-			"version": "2.48.5",
-			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
-			"integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+			"version": "2.48.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/request/-/request-2.48.8.tgz",
+			"integrity": "sha1-C5D947ZVq1CXbLjFrAD6yiL1qCw=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/caseless": "*",
 				"@types/node": "*",
@@ -247,80 +287,77 @@
 		},
 		"node_modules/@types/request-promise-native": {
 			"version": "1.0.18",
-			"resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.18.tgz",
-			"integrity": "sha512-tPnODeISFc/c1LjWyLuZUY+Z0uLB3+IMfNoQyDEi395+j6kTFTTRAqjENjoPJUid4vHRGEozoTrcTrfZM+AcbA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/request-promise-native/-/request-promise-native-1.0.18.tgz",
+			"integrity": "sha1-Q37i0Ldy4ByWkamDtVgIS0s+/Cw=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/request": "*"
 			}
 		},
-		"node_modules/@types/request/node_modules/form-data": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-			"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 0.12"
-			}
-		},
 		"node_modules/@types/responselike": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha1-JR9P59FU0rrRJavhtCmyOv0mLik=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/retry": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-			"integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+			"version": "0.12.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha1-KzXsz87n04zXKtmSMvvVi/+zyE0=",
+			"license": "MIT"
 		},
 		"node_modules/@types/rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-pj0XWzMXSOUiCtSMkB17vx9E7vg=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/glob": "*",
 				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/semver": {
-			"version": "7.3.9",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
-			"integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
+			"version": "7.3.10",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/semver/-/semver-7.3.10.tgz",
+			"integrity": "sha1-XxnuQMvv+H2Rbu3Iwr/iMF2Vf3M=",
+			"license": "MIT"
 		},
 		"node_modules/@types/shelljs": {
 			"version": "0.8.9",
-			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.9.tgz",
-			"integrity": "sha512-flVe1dvlrCyQJN/SGrnBxqHG+RzXrVKsmjD8WS/qYHpq5UPjfq7UWFBENP0ZuOl0g6OpAlL6iBoLSvKYUUmyQw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/shelljs/-/shelljs-0.8.9.tgz",
+			"integrity": "sha1-Rd2FAaqYgpdso2EFF9rDgxwvu/Q=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/glob": "*",
 				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/tough-cookie": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-			"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
+			"version": "4.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
+			"integrity": "sha1-Yoa0xyKNWKt4ZtGXFvNpbgOgk5c=",
+			"license": "MIT"
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.62.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA=="
+			"version": "1.69.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.69.0.tgz",
+			"integrity": "sha1-pHIBGvOS+8+Cy7gvYLTCOcIbkhw=",
+			"license": "MIT"
 		},
 		"node_modules/@ungap/promise-all-settled": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+			"integrity": "sha1-qlgEJxHW4ydd033Fl+XTHowpCkQ=",
+			"license": "ISC"
 		},
 		"node_modules/agent-base": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+			"license": "MIT",
 			"dependencies": {
 				"debug": "4"
 			},
@@ -330,8 +367,9 @@
 		},
 		"node_modules/aggregate-error": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+			"license": "MIT",
 			"dependencies": {
 				"clean-stack": "^2.0.0",
 				"indent-string": "^4.0.0"
@@ -342,46 +380,58 @@
 		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
+			"license": "ISC",
 			"dependencies": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -392,76 +442,87 @@
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
+			"license": "Python-2.0"
 		},
 		"node_modules/asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"version": "0.2.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha1-DTp7tuZOAqkMAwOzHykoaOoJoI0=",
+			"license": "MIT",
 			"dependencies": {
 				"safer-buffer": "~2.1.0"
 			}
 		},
 		"node_modules/assert-plus": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8"
 			}
 		},
 		"node_modules/assertion-error": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"license": "MIT"
 		},
 		"node_modules/aws-sign2": {
 			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aws-sign2/-/aws-sign2-0.7.0.tgz",
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/aws4": {
 			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk=",
+			"license": "MIT"
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"version": "1.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+			"license": "MIT"
 		},
 		"node_modules/bcrypt-pbkdf": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"tweetnacl": "^0.14.3"
 			}
 		},
 		"node_modules/big-integer": {
-			"version": "1.6.48",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+			"version": "1.6.51",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/big-integer/-/big-integer-1.6.51.tgz",
+			"integrity": "sha1-DfkqXZiAVg0/8tX9ICRciJ0TBoY=",
+			"license": "Unlicense",
 			"engines": {
 				"node": ">=0.6"
 			}
 		},
 		"node_modules/binary": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary/-/binary-0.3.0.tgz",
 			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+			"license": "MIT",
 			"dependencies": {
 				"buffers": "~0.1.1",
 				"chainsaw": "~0.1.0"
@@ -469,21 +530,24 @@
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/bluebird": {
 			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bluebird/-/bluebird-3.4.7.tgz",
+			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -491,8 +555,9 @@
 		},
 		"node_modules/braces": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.0.1"
 			},
@@ -502,20 +567,22 @@
 		},
 		"node_modules/browser-stdout": {
 			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+			"license": "ISC"
 		},
 		"node_modules/buffer-indexof-polyfill": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+			"integrity": "sha1-0nMhNcWZnGSyd/z5savjSYJUcpw=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10"
 			}
 		},
 		"node_modules/buffers": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffers/-/buffers-0.1.1.tgz",
 			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
 			"engines": {
 				"node": ">=0.2.0"
@@ -523,24 +590,27 @@
 		},
 		"node_modules/builtin-modules": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/cacheable-lookup": {
 			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha1-WmuGWyxENXvj1evCpGewMnGacAU=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.6.0"
 			}
 		},
 		"node_modules/cacheable-request": {
 			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-7.0.2.tgz",
+			"integrity": "sha1-6g0LiJNkolhUdXMByhKy2nf5HSc=",
+			"license": "MIT",
 			"dependencies": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -556,35 +626,46 @@
 		},
 		"node_modules/call-bind": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
+			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/camelcase": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+			"version": "6.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/caseless": {
 			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"license": "Apache-2.0"
 		},
 		"node_modules/chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha1-/+S6LZ+p1mgMwLNwra5wnskBHpw=",
+			"license": "MIT",
 			"dependencies": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			},
@@ -594,24 +675,30 @@
 		},
 		"node_modules/chai-as-promised": {
 			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-			"integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+			"integrity": "sha1-CGRdgl3rhpbuYXJdv1kMAS6wDKA=",
+			"license": "WTFPL",
 			"dependencies": {
 				"check-error": "^1.0.2"
+			},
+			"peerDependencies": {
+				"chai": ">= 2.1.2 < 5"
 			}
 		},
 		"node_modules/chainsaw": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chainsaw/-/chainsaw-0.1.0.tgz",
 			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+			"license": "MIT/X11",
 			"dependencies": {
 				"traverse": ">=0.3.0 <0.4"
 			}
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -625,8 +712,9 @@
 		},
 		"node_modules/chalk/node_modules/supports-color": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -636,16 +724,24 @@
 		},
 		"node_modules/check-error": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/check-error/-/check-error-1.0.2.tgz",
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha1-HPN8hwe5Mr0a8a4iwEMuKs0ZA70=",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			],
+			"license": "MIT",
 			"dependencies": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -664,66 +760,38 @@
 		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
+			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
 			}
 		},
-		"node_modules/cliui/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cliui/node_modules/string-width": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cliui/node_modules/strip-ansi": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-			"dependencies": {
-				"ansi-regex": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/clone-response": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^1.0.0"
 			}
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -733,13 +801,15 @@
 		},
 		"node_modules/color-name": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+			"license": "MIT"
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+			"license": "MIT",
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
 			},
@@ -749,23 +819,40 @@
 		},
 		"node_modules/commander": {
 			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+			"license": "MIT"
+		},
+		"node_modules/compress-brotli": {
+			"version": "1.3.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/compress-brotli/-/compress-brotli-1.3.8.tgz",
+			"integrity": "sha1-DApgyXqYkUUxTsOB6E4maC57ONs=",
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-buffer": "~3.0.0",
+				"json-buffer": "~3.0.1"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"license": "MIT"
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"license": "MIT"
 		},
 		"node_modules/dashdash": {
 			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"license": "MIT",
 			"dependencies": {
 				"assert-plus": "^1.0.0"
 			},
@@ -774,9 +861,10 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
+			"license": "MIT",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -791,21 +879,27 @@
 		},
 		"node_modules/debug/node_modules/ms": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+			"license": "MIT"
 		},
 		"node_modules/decamelize": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/decompress-response": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha1-yjh2Et234QS9FthaqwDV7PCcZvw=",
+			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^3.1.0"
 			},
@@ -818,8 +912,9 @@
 		},
 		"node_modules/decompress-response/node_modules/mimic-response": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -829,8 +924,9 @@
 		},
 		"node_modules/deep-eql": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+			"license": "MIT",
 			"dependencies": {
 				"type-detect": "^4.0.0"
 			},
@@ -840,51 +936,61 @@
 		},
 		"node_modules/defer-to-connect": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/define-lazy-prop": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"version": "1.1.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-properties/-/define-properties-1.1.4.tgz",
+			"integrity": "sha1-CxTXvX++svNXLDp+2oDqXVf7BbE=",
+			"license": "MIT",
 			"dependencies": {
-				"object-keys": "^1.0.12"
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/diff": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"version": "5.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.1.0.tgz",
+			"integrity": "sha1-vFLSmMXqjfkZSAAiREXtQ//IfkA=",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dns-packet": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.0.tgz",
-			"integrity": "sha512-Nce7YLu6YCgWRvOmDBsJMo9M5/jV3lEZ5vUWnWXYmwURvPylHvq7nkDWhNmk1ZQoZZOP7oQh/S0lSxbisKOfHg==",
+			"version": "5.4.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dns-packet/-/dns-packet-5.4.0.tgz",
+			"integrity": "sha1-H4hHfPnyfniiE/ttEYrjjnWah5s=",
+			"license": "MIT",
 			"dependencies": {
 				"@leichtgewicht/ip-codec": "^2.0.1"
 			},
@@ -894,8 +1000,9 @@
 		},
 		"node_modules/dns-socket": {
 			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.2.tgz",
-			"integrity": "sha512-BDeBd8najI4/lS00HSKpdFia+OvUMytaVjfzR9n5Lq8MlZRSvtbI+uLtx1+XmQFls5wFU9dssccTmQQ6nfpjdg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dns-socket/-/dns-socket-4.2.2.tgz",
+			"integrity": "sha1-WLAYbsBT6gcx/rBng8furEuVthY=",
+			"license": "MIT",
 			"dependencies": {
 				"dns-packet": "^5.2.4"
 			},
@@ -905,21 +1012,24 @@
 		},
 		"node_modules/duplexer2": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer2/-/duplexer2-0.1.4.tgz",
 			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"readable-stream": "^2.0.2"
 			}
 		},
 		"node_modules/duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+			"version": "0.1.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer3/-/duplexer3-0.1.5.tgz",
+			"integrity": "sha1-C15Ne61d6JAepEQGJMjh0gCZIX4=",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/ecc-jsbn": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"license": "MIT",
 			"dependencies": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -927,47 +1037,54 @@
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+			"license": "MIT"
 		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
 			}
 		},
 		"node_modules/eol": {
 			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
-			"integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eol/-/eol-0.9.1.tgz",
+			"integrity": "sha1-9wGRL1BAdL41xhF6XEreSc1Ues0=",
+			"license": "MIT"
 		},
 		"node_modules/es-abstract": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-			"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+			"version": "1.20.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-abstract/-/es-abstract-1.20.1.tgz",
+			"integrity": "sha1-AnKSzW70S9ErGRO4KBFvVHh9GBQ=",
+			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
+				"function.prototype.name": "^1.1.5",
 				"get-intrinsic": "^1.1.1",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.2",
+				"has-property-descriptors": "^1.0.0",
+				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
 				"is-callable": "^1.2.4",
-				"is-negative-zero": "^2.0.1",
+				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.1",
+				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
-				"is-weakref": "^1.0.1",
-				"object-inspect": "^1.11.0",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.12.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.2",
-				"string.prototype.trimend": "^1.0.4",
-				"string.prototype.trimstart": "^1.0.4",
-				"unbox-primitive": "^1.0.1"
+				"regexp.prototype.flags": "^1.4.3",
+				"string.prototype.trimend": "^1.0.5",
+				"string.prototype.trimstart": "^1.0.5",
+				"unbox-primitive": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -978,8 +1095,9 @@
 		},
 		"node_modules/es-to-primitive": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
+			"license": "MIT",
 			"dependencies": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
@@ -987,28 +1105,37 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/escalade": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/esprima": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+			"license": "BSD-2-Clause",
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -1019,31 +1146,36 @@
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+			"license": "MIT"
 		},
 		"node_modules/extsprintf": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
 			"engines": [
 				"node >=0.6.0"
-			]
+			],
+			"license": "MIT"
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+			"license": "MIT"
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+			"license": "MIT"
 		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -1053,36 +1185,43 @@
 		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
+			"license": "MIT",
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/flat": {
 			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE=",
+			"license": "BSD-3-Clause",
 			"bin": {
 				"flat": "cli.js"
 			}
 		},
 		"node_modules/forever-agent": {
 			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"version": "2.5.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/form-data/-/form-data-2.5.1.tgz",
+			"integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
+			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -1094,13 +1233,15 @@
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"license": "ISC"
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1111,8 +1252,9 @@
 		},
 		"node_modules/fstream": {
 			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
+			"license": "ISC",
 			"dependencies": {
 				"graceful-fs": "^4.1.2",
 				"inherits": "~2.0.0",
@@ -1125,8 +1267,9 @@
 		},
 		"node_modules/fstream/node_modules/rimraf": {
 			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+			"license": "ISC",
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -1136,39 +1279,74 @@
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+			"license": "MIT"
+		},
+		"node_modules/function.prototype.name": {
+			"version": "1.1.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+			"integrity": "sha1-zOBQX+H/uAUD5vnkbMZORqEqliE=",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.0",
+				"functions-have-names": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ=",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
 		"node_modules/get-func-name": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-func-name/-/get-func-name-2.0.0.tgz",
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+			"integrity": "sha1-M2l1Ej4FrQt7pB8VLuSq2+ps9Zg=",
+			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.1"
+				"has-symbols": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/get-stream": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
+			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0"
 			},
@@ -1181,8 +1359,9 @@
 		},
 		"node_modules/get-symbol-description": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-			"integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+			"integrity": "sha1-f9uByQAQH71WTdXxowr1qtweWNY=",
+			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.1"
@@ -1196,21 +1375,23 @@
 		},
 		"node_modules/getpass": {
 			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"license": "MIT",
 			"dependencies": {
 				"assert-plus": "^1.0.0"
 			}
 		},
 		"node_modules/glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+			"version": "7.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			},
@@ -1223,8 +1404,9 @@
 		},
 		"node_modules/glob-parent": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
+			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
 			},
@@ -1233,16 +1415,17 @@
 			}
 		},
 		"node_modules/got": {
-			"version": "11.8.2",
-			"resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-			"integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+			"version": "11.8.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz",
+			"integrity": "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY=",
+			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/is": "^4.0.0",
 				"@szmarczak/http-timer": "^4.0.5",
 				"@types/cacheable-request": "^6.0.1",
 				"@types/responselike": "^1.0.0",
 				"cacheable-lookup": "^5.0.3",
-				"cacheable-request": "^7.0.1",
+				"cacheable-request": "^7.0.2",
 				"decompress-response": "^6.0.0",
 				"http2-wrapper": "^1.0.0-beta.5.2",
 				"lowercase-keys": "^2.0.0",
@@ -1257,30 +1440,34 @@
 			}
 		},
 		"node_modules/graceful-fs": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+			"version": "4.2.10",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha1-FH06AG2kyjzhRyjHrvwofDZ9emw=",
+			"license": "ISC"
 		},
 		"node_modules/growl": {
 			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.x"
 			}
 		},
 		"node_modules/har-schema": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/har-schema/-/har-schema-2.0.0.tgz",
 			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"license": "ISC",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/har-validator": {
 			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
+			"license": "MIT",
 			"dependencies": {
 				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
@@ -1291,8 +1478,9 @@
 		},
 		"node_modules/has": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has/-/has-1.0.3.tgz",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.1"
 			},
@@ -1301,25 +1489,40 @@
 			}
 		},
 		"node_modules/has-bigints": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+			"version": "1.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha1-CHG9Pj1RYm9soJZmaLo11WAtbqo=",
+			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha1-YQcIYAYG02lh7QTBlhk7amB/qGE=",
+			"license": "MIT",
+			"dependencies": {
+				"get-intrinsic": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/has-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+			"version": "1.0.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -1329,8 +1532,9 @@
 		},
 		"node_modules/has-tostringtag": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+			"integrity": "sha1-fhM4GKfTlHNPlB5zw9P5KR5liyU=",
+			"license": "MIT",
 			"dependencies": {
 				"has-symbols": "^1.0.2"
 			},
@@ -1343,21 +1547,24 @@
 		},
 		"node_modules/he": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/he/-/he-1.2.0.tgz",
+			"integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
+			"license": "MIT",
 			"bin": {
 				"he": "bin/he"
 			}
 		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+			"integrity": "sha1-SekcXL82yblLz81xwj1SSex045A=",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
+			"license": "MIT",
 			"dependencies": {
 				"@tootallnate/once": "1",
 				"agent-base": "6",
@@ -1369,8 +1576,9 @@
 		},
 		"node_modules/http-signature": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"license": "MIT",
 			"dependencies": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -1383,8 +1591,9 @@
 		},
 		"node_modules/http2-wrapper": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha1-uPVeDB8l1OvQizsMLAeflZCACz0=",
+			"license": "MIT",
 			"dependencies": {
 				"quick-lru": "^5.1.1",
 				"resolve-alpn": "^1.0.0"
@@ -1394,9 +1603,10 @@
 			}
 		},
 		"node_modules/https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+			"license": "MIT",
 			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
@@ -1407,16 +1617,18 @@
 		},
 		"node_modules/indent-string": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"license": "ISC",
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1424,13 +1636,15 @@
 		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+			"license": "ISC"
 		},
 		"node_modules/internal-slot": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-			"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/internal-slot/-/internal-slot-1.0.3.tgz",
+			"integrity": "sha1-c0fjB97uovqsKsYgXUvH00ln9Zw=",
+			"license": "MIT",
 			"dependencies": {
 				"get-intrinsic": "^1.1.0",
 				"has": "^1.0.3",
@@ -1442,24 +1656,27 @@
 		},
 		"node_modules/interpret": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/interpret/-/interpret-1.4.0.tgz",
+			"integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
 			}
 		},
 		"node_modules/ip-regex": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-			"integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ip-regex/-/ip-regex-4.3.0.tgz",
+			"integrity": "sha1-aHJ1qw9X+naXj/j03dyKI9WZDbU=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/is-bigint": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha1-CBR6GHW8KzIAXUHM2Ckd/8ZpHfM=",
+			"license": "MIT",
 			"dependencies": {
 				"has-bigints": "^1.0.1"
 			},
@@ -1469,8 +1686,9 @@
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+			"license": "MIT",
 			"dependencies": {
 				"binary-extensions": "^2.0.0"
 			},
@@ -1480,8 +1698,9 @@
 		},
 		"node_modules/is-boolean-object": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha1-XG3CACRt2TIa5LiFoRS7H3X2Nxk=",
+			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -1495,8 +1714,9 @@
 		},
 		"node_modules/is-callable": {
 			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-callable/-/is-callable-1.2.4.tgz",
+			"integrity": "sha1-RzAdWN0CWUB4ZVR4U99tYf5HGUU=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -1505,44 +1725,70 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.9.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha1-4cNEKc1Rxt2eCeB5njluJ7GanGk=",
+			"license": "MIT",
 			"dependencies": {
 				"has": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-date-object": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+			"version": "1.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-date-object/-/is-date-object-1.0.5.tgz",
+			"integrity": "sha1-CEHVU25yTCVZe/bqYuG9OCmN8x8=",
+			"license": "MIT",
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-docker": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-			"integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+			"version": "2.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=",
+			"license": "MIT",
 			"bin": {
 				"is-docker": "cli.js"
 			},
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
+			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
 			},
@@ -1552,8 +1798,9 @@
 		},
 		"node_modules/is-ip": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-ip/-/is-ip-3.1.0.tgz",
+			"integrity": "sha1-KuXd+vrwXLgAimIJPPKXNPZXxdg=",
+			"license": "MIT",
 			"dependencies": {
 				"ip-regex": "^4.0.0"
 			},
@@ -1562,25 +1809,31 @@
 			}
 		},
 		"node_modules/is-negative-zero": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+			"version": "2.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+			"integrity": "sha1-e/bwOigAO4s5Zd46wm9mTXZfMVA=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
 		},
 		"node_modules/is-number-object": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-			"integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+			"version": "1.0.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha1-WdUK2kxFJReE6ZBPUkbHQvB6Qvw=",
+			"license": "MIT",
 			"dependencies": {
 				"has-tostringtag": "^1.0.0"
 			},
@@ -1593,8 +1846,9 @@
 		},
 		"node_modules/is-online": {
 			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/is-online/-/is-online-9.0.1.tgz",
-			"integrity": "sha512-+08dRW0dcFOtleR2N3rHRVxDyZtQitUp9cC+KpKTds0mXibbQyW5js7xX0UGyQXkaLUJObe0w6uQ4ex34lX9LA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-9.0.1.tgz",
+			"integrity": "sha1-caNCAvqCa65vP/i+pCDFZXNEil8=",
+			"license": "MIT",
 			"dependencies": {
 				"got": "^11.8.0",
 				"p-any": "^3.0.0",
@@ -1610,16 +1864,18 @@
 		},
 		"node_modules/is-plain-obj": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/is-regex": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=",
+			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -1632,17 +1888,22 @@
 			}
 		},
 		"node_modules/is-shared-array-buffer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+			"version": "1.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+			"integrity": "sha1-jyWcVztgtqMtQFihoHQwwKc0THk=",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-string": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=",
+			"license": "MIT",
 			"dependencies": {
 				"has-tostringtag": "^1.0.0"
 			},
@@ -1654,25 +1915,31 @@
 			}
 		},
 		"node_modules/is-symbol": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+			"version": "1.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
+			"license": "MIT",
 			"dependencies": {
-				"has-symbols": "^1.0.1"
+				"has-symbols": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-typedarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"license": "MIT"
 		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1681,11 +1948,12 @@
 			}
 		},
 		"node_modules/is-weakref": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+			"version": "1.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha1-lSnzg6kzggXol2XgOS78LxAPBvI=",
+			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -1693,8 +1961,9 @@
 		},
 		"node_modules/is-wsl": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+			"license": "MIT",
 			"dependencies": {
 				"is-docker": "^2.0.0"
 			},
@@ -1704,28 +1973,33 @@
 		},
 		"node_modules/isarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"license": "MIT"
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"license": "ISC"
 		},
 		"node_modules/isstream": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"license": "MIT"
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
+			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -1735,33 +2009,39 @@
 		},
 		"node_modules/jsbn": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"license": "MIT"
 		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
+			"license": "MIT"
 		},
 		"node_modules/json-schema": {
 			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha1-995M9u+rg4666zI2R0y7paGTCrU=",
+			"license": "(AFL-2.1 OR BSD-3-Clause)"
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+			"license": "MIT"
 		},
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"license": "ISC"
 		},
 		"node_modules/jsprim": {
 			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha1-cSxlUzoVyHi6WentXw4m1bd8X+s=",
+			"license": "MIT",
 			"dependencies": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -1773,38 +2053,47 @@
 			}
 		},
 		"node_modules/keyv": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
-			"integrity": "sha512-vqNHbAc8BBsxk+7QBYLW0Y219rWcClspR6WSeoHYKG5mnsSoOH+BL1pWq02DDCVdvvuUny5rkBlzMRzoqc+GIg==",
+			"version": "4.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.3.2.tgz",
+			"integrity": "sha1-6DnfZ2oMfuWUyINefByDdCVY5cI=",
+			"license": "MIT",
 			"dependencies": {
+				"compress-brotli": "^1.3.8",
 				"json-buffer": "3.0.1"
 			}
 		},
 		"node_modules/listenercount": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/listenercount/-/listenercount-1.0.1.tgz",
+			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+			"license": "ISC"
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
+			"license": "MIT",
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
+			"license": "MIT"
 		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
+			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"is-unicode-supported": "^0.1.0"
@@ -1816,28 +2105,40 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/loupe": {
+			"version": "2.3.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/loupe/-/loupe-2.3.4.tgz",
+			"integrity": "sha1-fgub/8dvFI+b52nLEyHT3PPLJfM=",
+			"license": "MIT",
+			"dependencies": {
+				"get-func-name": "^2.0.0"
+			}
+		},
 		"node_modules/lowercase-keys": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/mime-db": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-			"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
+			"version": "1.52.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mime-types": {
-			"version": "2.1.28",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-			"integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+			"version": "2.1.35",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
+			"license": "MIT",
 			"dependencies": {
-				"mime-db": "1.45.0"
+				"mime-db": "1.52.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
@@ -1845,16 +2146,18 @@
 		},
 		"node_modules/mimic-response": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -1863,47 +2166,50 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q=",
+			"license": "MIT"
 		},
 		"node_modules/mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
+			"license": "MIT",
 			"dependencies": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			},
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			}
 		},
 		"node_modules/mocha": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-			"integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+			"version": "9.2.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mocha/-/mocha-9.2.2.tgz",
+			"integrity": "sha1-1w20a9uTyldALICTM+WoSXeoj7k=",
+			"license": "MIT",
 			"dependencies": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.2",
-				"debug": "4.3.2",
+				"chokidar": "3.5.3",
+				"debug": "4.3.3",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
-				"glob": "7.1.7",
+				"glob": "7.2.0",
 				"growl": "1.10.5",
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
-				"minimatch": "3.0.4",
+				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
+				"nanoid": "3.3.1",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"workerpool": "6.1.5",
+				"workerpool": "6.2.0",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
@@ -1920,10 +2226,20 @@
 				"url": "https://opencollective.com/mochajs"
 			}
 		},
+		"node_modules/mocha/node_modules/diff": {
+			"version": "5.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha1-ftatdthZ0DB4fsNYVfWx2vMdhSs=",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/mocha/node_modules/glob": {
-			"version": "7.1.7",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"version": "7.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
+			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1939,15 +2255,41 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/mocha/node_modules/minimatch": {
+			"version": "4.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-4.2.1.tgz",
+			"integrity": "sha1-QNnVEaRr3E5WPCLDCAzenA2CmbQ=",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+			"version": "3.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha1-Y0ehjKyIr4j1ivCzWUtyPV6ZuzU=",
+			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -1957,16 +2299,18 @@
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/normalize-url": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1976,32 +2320,36 @@
 		},
 		"node_modules/oauth-sign": {
 			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+			"version": "1.12.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-inspect/-/object-inspect-1.12.2.tgz",
+			"integrity": "sha1-wGQfJjlFMvKKuNeWq5VOQ8AJqOo=",
+			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/object-keys": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
 		"node_modules/object.assign": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object.assign/-/object.assign-4.1.2.tgz",
+			"integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
+			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
@@ -2010,20 +2358,25 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
 			}
 		},
 		"node_modules/open": {
 			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-			"integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-8.4.0.tgz",
+			"integrity": "sha1-NFMhrhj4E4+CVlqRD9xrOejCRPg=",
+			"license": "MIT",
 			"dependencies": {
 				"define-lazy-prop": "^2.0.0",
 				"is-docker": "^2.1.1",
@@ -2038,8 +2391,9 @@
 		},
 		"node_modules/p-any": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-any/-/p-any-3.0.0.tgz",
-			"integrity": "sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-3.0.0.tgz",
+			"integrity": "sha1-eYR67tcLXToQ6mJSlsDD0ukKh7k=",
+			"license": "MIT",
 			"dependencies": {
 				"p-cancelable": "^2.0.0",
 				"p-some": "^5.0.0"
@@ -2053,48 +2407,59 @@
 		},
 		"node_modules/p-cancelable": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/p-finally": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
+			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-locate": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
+			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-retry": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-			"integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+			"version": "4.6.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha1-m6rnGEBX7dThcjHO4EJkEG4JKhY=",
+			"license": "MIT",
 			"dependencies": {
-				"@types/retry": "^0.12.0",
+				"@types/retry": "0.12.0",
 				"retry": "^0.13.1"
 			},
 			"engines": {
@@ -2103,8 +2468,9 @@
 		},
 		"node_modules/p-some": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
-			"integrity": "sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-5.0.0.tgz",
+			"integrity": "sha1-i3MMdLT+UWnXJkokCtAQtuvGhqQ=",
+			"license": "MIT",
 			"dependencies": {
 				"aggregate-error": "^3.0.0",
 				"p-cancelable": "^2.0.0"
@@ -2118,8 +2484,9 @@
 		},
 		"node_modules/p-timeout": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
+			"license": "MIT",
 			"dependencies": {
 				"p-finally": "^1.0.0"
 			},
@@ -2129,42 +2496,48 @@
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
+			"license": "MIT"
 		},
 		"node_modules/pathval": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha1-hTTnenfOesWiUS6iHg/bj89sPY0=",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/performance-now": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"license": "MIT"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+			"version": "2.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -2174,26 +2547,30 @@
 		},
 		"node_modules/prepend-http": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prepend-http/-/prepend-http-2.0.0.tgz",
 			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+			"license": "MIT"
 		},
 		"node_modules/psl": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+			"version": "1.9.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/psl/-/psl-1.9.0.tgz",
+			"integrity": "sha1-0N8qE38AeUVl/K87LADNCfjVpac=",
+			"license": "MIT"
 		},
 		"node_modules/public-ip": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/public-ip/-/public-ip-4.0.4.tgz",
-			"integrity": "sha512-EJ0VMV2vF6Cu7BIPo3IMW1Maq6ME+fbR0NcPmqDfpfNGIRPue1X8QrGjrg/rfjDkOsIkKHIf2S5FlEa48hFMTA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-4.0.4.tgz",
+			"integrity": "sha1-s3hKWh/xuB0BW5oYRQvmX/2SnrM=",
+			"license": "MIT",
 			"dependencies": {
 				"dns-socket": "^4.2.2",
 				"got": "^9.6.0",
@@ -2208,16 +2585,18 @@
 		},
 		"node_modules/public-ip/node_modules/@sindresorhus/is": {
 			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-0.14.0.tgz",
+			"integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/public-ip/node_modules/@szmarczak/http-timer": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+			"integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
+			"license": "MIT",
 			"dependencies": {
 				"defer-to-connect": "^1.0.1"
 			},
@@ -2227,8 +2606,9 @@
 		},
 		"node_modules/public-ip/node_modules/cacheable-request": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-6.1.0.tgz",
+			"integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
+			"license": "MIT",
 			"dependencies": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -2244,8 +2624,9 @@
 		},
 		"node_modules/public-ip/node_modules/decompress-response": {
 			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-3.3.0.tgz",
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^1.0.0"
 			},
@@ -2255,13 +2636,15 @@
 		},
 		"node_modules/public-ip/node_modules/defer-to-connect": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+			"integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE=",
+			"license": "MIT"
 		},
 		"node_modules/public-ip/node_modules/got": {
 			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-9.6.0.tgz",
+			"integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
+			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/is": "^0.14.0",
 				"@szmarczak/http-timer": "^1.1.2",
@@ -2281,8 +2664,9 @@
 		},
 		"node_modules/public-ip/node_modules/got/node_modules/get-stream": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0"
 			},
@@ -2292,61 +2676,69 @@
 		},
 		"node_modules/public-ip/node_modules/got/node_modules/lowercase-keys": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/public-ip/node_modules/json-buffer": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+			"license": "MIT"
 		},
 		"node_modules/public-ip/node_modules/keyv": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-3.1.0.tgz",
+			"integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
+			"license": "MIT",
 			"dependencies": {
 				"json-buffer": "3.0.0"
 			}
 		},
 		"node_modules/public-ip/node_modules/normalize-url": {
 			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-4.5.1.tgz",
+			"integrity": "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/public-ip/node_modules/p-cancelable": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-1.1.0.tgz",
+			"integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/public-ip/node_modules/responselike": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-1.0.2.tgz",
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"license": "MIT",
 			"dependencies": {
 				"lowercase-keys": "^1.0.0"
 			}
 		},
 		"node_modules/public-ip/node_modules/responselike/node_modules/lowercase-keys": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -2354,24 +2746,27 @@
 		},
 		"node_modules/punycode": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha1-Ou7/yRln7241wOSI70b7KWq3aq0=",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.6"
 			}
 		},
 		"node_modules/quick-lru": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha1-NmST5rPkKjpoheLpnRj4D7eoyTI=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -2381,16 +2776,18 @@
 		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
 		},
 		"node_modules/readable-stream": {
 			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+			"license": "MIT",
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -2403,13 +2800,15 @@
 		},
 		"node_modules/readable-stream/node_modules/safe-buffer": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+			"license": "MIT"
 		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
+			"license": "MIT",
 			"dependencies": {
 				"picomatch": "^2.2.1"
 			},
@@ -2419,7 +2818,7 @@
 		},
 		"node_modules/rechoir": {
 			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"dependencies": {
 				"resolve": "^1.1.6"
@@ -2428,10 +2827,28 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/regexp.prototype.flags": {
+			"version": "1.4.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+			"integrity": "sha1-h8qzD4D2ZmAYGju3v1mBqHKzZ6w=",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"functions-have-names": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/request": {
 			"version": "2.88.2",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/request/-/request-2.88.2.tgz",
+			"integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -2460,19 +2877,24 @@
 		},
 		"node_modules/request-promise-core": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-			"integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/request-promise-core/-/request-promise-core-1.1.4.tgz",
+			"integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
+			"license": "ISC",
 			"dependencies": {
 				"lodash": "^4.17.19"
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			},
+			"peerDependencies": {
+				"request": "^2.34"
 			}
 		},
 		"node_modules/request-promise-native": {
 			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-			"integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/request-promise-native/-/request-promise-native-1.0.9.tgz",
+			"integrity": "sha1-5AcSBSal79yaObKKVnm/R7nZ3Cg=",
+			"license": "ISC",
 			"dependencies": {
 				"request-promise-core": "1.1.4",
 				"stealthy-require": "^1.1.1",
@@ -2480,50 +2902,80 @@
 			},
 			"engines": {
 				"node": ">=0.12.0"
+			},
+			"peerDependencies": {
+				"request": "^2.34"
+			}
+		},
+		"node_modules/request/node_modules/form-data": {
+			"version": "2.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 0.12"
 			}
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"version": "1.22.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha1-J8suu1P5GrtJRwqSi7p1WAZqwXc=",
+			"license": "MIT",
 			"dependencies": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/resolve-alpn": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha1-t629rDVGqq7CC0Xn2CZZJwcnJvk=",
+			"license": "MIT"
 		},
 		"node_modules/responselike": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-			"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-2.0.0.tgz",
+			"integrity": "sha1-JjkbzDF091D5p56sxAoSpcQtdyM=",
+			"license": "MIT",
 			"dependencies": {
 				"lowercase-keys": "^2.0.0"
 			}
 		},
 		"node_modules/retry": {
 			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha1-GFsVh6z2eRnWOzVzSeA1N7JIRlg=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
 		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+			"license": "ISC",
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -2536,39 +2988,59 @@
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+			"license": "MIT"
 		},
 		"node_modules/semver": {
 			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
 			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+			"integrity": "sha1-765diPRdeSQUHai1w6en5mP+/rg=",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
 		},
 		"node_modules/setimmediate": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"license": "MIT"
 		},
 		"node_modules/shelljs": {
 			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-			"integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shelljs/-/shelljs-0.8.4.tgz",
+			"integrity": "sha1-3naE/ut2f4cWsyYHiooAh1iQ48I=",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -2583,8 +3055,9 @@
 		},
 		"node_modules/side-channel": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
+			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",
@@ -2596,13 +3069,15 @@
 		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"version": "1.17.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha1-V4CC2S1P5hKxMAdJblQ/oPvL5MU=",
+			"license": "MIT",
 			"dependencies": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -2620,80 +3095,135 @@
 		},
 		"node_modules/stealthy-require": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"license": "ISC",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/string_decoder/node_modules/safe-buffer": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+			"license": "MIT"
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/string.prototype.trimend": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+			"version": "1.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+			"integrity": "sha1-kUpluqqyX73U7ikcp93lfoacuNA=",
+			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/string.prototype.trimstart": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+			"version": "1.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+			"integrity": "sha1-VGbZO6WM+iE0g5+B1/QkN+jAH+8=",
+			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
 			"engines": {
 				"node": ">=8"
 			}
 		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/to-readable-stream": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+			"integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -2703,8 +3233,9 @@
 		},
 		"node_modules/tough-cookie": {
 			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
@@ -2715,18 +3246,21 @@
 		},
 		"node_modules/traverse": {
 			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/traverse/-/traverse-0.3.9.tgz",
+			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+			"license": "MIT/X11"
 		},
 		"node_modules/tslib": {
 			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
+			"license": "0BSD"
 		},
 		"node_modules/tslint": {
 			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslint/-/tslint-5.20.1.tgz",
+			"integrity": "sha1-5AHortoBUrxE3QfmFANPP4DGe30=",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
 				"builtin-modules": "^1.1.1",
@@ -2754,8 +3288,9 @@
 		},
 		"node_modules/tslint/node_modules/ansi-styles": {
 			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -2765,16 +3300,18 @@
 		},
 		"node_modules/tslint/node_modules/argparse": {
 			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+			"license": "MIT",
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
 		},
 		"node_modules/tslint/node_modules/chalk": {
 			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -2786,45 +3323,51 @@
 		},
 		"node_modules/tslint/node_modules/color-convert": {
 			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
 		},
 		"node_modules/tslint/node_modules/color-name": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"license": "MIT"
 		},
 		"node_modules/tslint/node_modules/diff": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/tslint/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/tslint/node_modules/has-flag": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/tslint/node_modules/js-yaml": {
 			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
+			"license": "MIT",
 			"dependencies": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -2835,8 +3378,9 @@
 		},
 		"node_modules/tslint/node_modules/supports-color": {
 			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -2844,18 +3388,23 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/tsutils": {
+		"node_modules/tslint/node_modules/tsutils": {
 			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "^1.8.1"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
 			}
 		},
 		"node_modules/tunnel-agent": {
 			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
 			},
@@ -2865,21 +3414,24 @@
 		},
 		"node_modules/tweetnacl": {
 			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"license": "Unlicense"
 		},
 		"node_modules/type-detect": {
 			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/typescript": {
 			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha1-LNAaGh8WBwTTEB/VpY/w+fy4Aww=",
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -2889,13 +3441,14 @@
 			}
 		},
 		"node_modules/unbox-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"version": "1.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha1-KQMgIQV9Xmzb0IxRKcIm3/jtb54=",
+			"license": "MIT",
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.1",
-				"has-symbols": "^1.0.2",
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
 			},
 			"funding": {
@@ -2904,8 +3457,9 @@
 		},
 		"node_modules/unzipper": {
 			"version": "0.10.11",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unzipper/-/unzipper-0.10.11.tgz",
+			"integrity": "sha1-C0mRRGRyy9uS7nQDkJ8mwkGceC4=",
+			"license": "MIT",
 			"dependencies": {
 				"big-integer": "^1.6.17",
 				"binary": "~0.3.0",
@@ -2921,16 +3475,18 @@
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
 		},
 		"node_modules/url-parse-lax": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+			"license": "MIT",
 			"dependencies": {
 				"prepend-http": "^2.0.0"
 			},
@@ -2940,24 +3496,27 @@
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"license": "MIT"
 		},
 		"node_modules/uuid": {
 			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+			"license": "MIT",
 			"bin": {
 				"uuid": "bin/uuid"
 			}
 		},
 		"node_modules/verror": {
 			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"engines": [
 				"node >=0.6.0"
 			],
+			"license": "MIT",
 			"dependencies": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -2965,17 +3524,19 @@
 			}
 		},
 		"node_modules/vscode-extension-telemetry": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.3.tgz",
-			"integrity": "sha512-opiIFOaAwyfACYMXByDqFMAlJ2iFMJR65/vIogJ960aLZWp9zaMdwY9CsY02EOYjHxPpjI7QeOQM3sYCb3xtJg==",
+			"version": "0.4.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.5.tgz",
+			"integrity": "sha1-GVfVqLDNatmnnU8mD+A3+/mHMrs=",
+			"license": "MIT",
 			"engines": {
 				"vscode": "^1.60.0"
 			}
 		},
 		"node_modules/vscode-test": {
 			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vscode-test/-/vscode-test-1.6.1.tgz",
+			"integrity": "sha1-RCVMZwNt6SsA/dcvas5fGFThpWM=",
+			"license": "MIT",
 			"dependencies": {
 				"http-proxy-agent": "^4.0.1",
 				"https-proxy-agent": "^5.0.0",
@@ -2988,8 +3549,9 @@
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
+			"integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -3002,8 +3564,9 @@
 		},
 		"node_modules/which-boxed-primitive": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
+			"license": "MIT",
 			"dependencies": {
 				"is-bigint": "^1.0.1",
 				"is-boolean-object": "^1.1.0",
@@ -3016,14 +3579,16 @@
 			}
 		},
 		"node_modules/workerpool": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-			"integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw=="
+			"version": "6.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/workerpool/-/workerpool-6.2.0.tgz",
+			"integrity": "sha1-gn2Tyboj7iAZw/+v9cJ/zOoonos=",
+			"license": "Apache-2.0"
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -3031,57 +3596,31 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/string-width": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.0"
 			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/strip-ansi": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-			"dependencies": {
-				"ansi-regex": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"license": "ISC"
 		},
 		"node_modules/y18n": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-			"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+			"version": "5.0.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
+			"license": "ISC",
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
+			"license": "MIT",
 			"dependencies": {
 				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
@@ -3097,16 +3636,18 @@
 		},
 		"node_modules/yargs-parser": {
 			"version": "20.2.4",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-parser/-/yargs-parser-20.2.4.tgz",
+			"integrity": "sha1-tCiQ8UVmeW+Fro46JSkNIF8VSlQ=",
+			"license": "ISC",
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/yargs-unparser": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
+			"license": "MIT",
 			"dependencies": {
 				"camelcase": "^6.0.0",
 				"decamelize": "^4.0.0",
@@ -3117,83 +3658,55 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/yargs/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/yargs/node_modules/string-width": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/yargs/node_modules/strip-ansi": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-			"dependencies": {
-				"ansi-regex": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		}
 	},
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha1-OyXTjIlgC6otzCGe36iKdOssQno=",
 			"requires": {
-				"@babel/highlight": "^7.12.13"
+				"@babel/highlight": "^7.18.6"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha1-nJfjDTGyuMcqHQiYTyyptXTXoHY="
 		},
 		"@babel/highlight": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-			"integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha1-gRWGAek+JWN5Wty/vfXWS+Py7N8=",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.12.11",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
 					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -3202,31 +3715,31 @@
 				},
 				"color-convert": {
 					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
 					"requires": {
 						"color-name": "1.1.3"
 					}
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -3234,32 +3747,32 @@
 			}
 		},
 		"@leichtgewicht/ip-codec": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
-			"integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+			"version": "2.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+			"integrity": "sha1-sqxibWy5yHGKtFkWbUu0Bbj/p4s="
 		},
 		"@sindresorhus/is": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-			"integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
+			"version": "4.6.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha1-PHycRuZ4/u/nouW7YJ09vWZf+z8="
 		},
 		"@szmarczak/http-timer": {
 			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac=",
 			"requires": {
 				"defer-to-connect": "^2.0.0"
 			}
 		},
 		"@tootallnate/once": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I="
 		},
 		"@types/cacheable-request": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
-			"integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+			"integrity": "sha1-wyTaAZfeCpiiMSFWU2riYkKf9rk=",
 			"requires": {
 				"@types/http-cache-semantics": "*",
 				"@types/keyv": "*",
@@ -3269,26 +3782,26 @@
 		},
 		"@types/caseless": {
 			"version": "0.12.2",
-			"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-			"integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/caseless/-/caseless-0.12.2.tgz",
+			"integrity": "sha1-9l09Y4ngHutFi9VNyPUrlalGO8g="
 		},
 		"@types/chai": {
-			"version": "4.2.22",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
-			"integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ=="
+			"version": "4.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai/-/chai-4.3.1.tgz",
+			"integrity": "sha1-4sbnPgveslIdAHVtCZIY6fXZCgQ="
 		},
 		"@types/chai-as-promised": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.4.tgz",
-			"integrity": "sha512-1y3L1cHePcIm5vXkh1DSGf/zQq5n5xDKG1fpCvf18+uOkpce0Z1ozNFPkyWsVswK7ntN1sZBw3oU6gmN+pDUcA==",
+			"version": "7.1.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+			"integrity": "sha1-bgFoEfbHpk8u7YIxkcOmlVCU4lU=",
 			"requires": {
 				"@types/chai": "*"
 			}
 		},
 		"@types/glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+			"version": "7.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-vBtb86qS8lvV3TnzXFc2G9zlsus=",
 			"requires": {
 				"@types/minimatch": "*",
 				"@types/node": "*"
@@ -3296,126 +3809,119 @@
 		},
 		"@types/http-cache-semantics": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+			"integrity": "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI="
+		},
+		"@types/json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-hcH/DwlI/BWYENS1vjW/jCCHX2Q="
 		},
 		"@types/keyv": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.3.tgz",
-			"integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
+			"version": "3.1.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha1-PM2xxnUbDH5SMAvNrNW8v4+qdbY=",
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@types/minimatch": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+			"version": "3.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/minimatch/-/minimatch-3.0.5.tgz",
+			"integrity": "sha1-EAHMXmo3BLg8I2An538vWOoBD0A="
 		},
 		"@types/mocha": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-			"integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA=="
+			"version": "9.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/mocha/-/mocha-9.1.1.tgz",
+			"integrity": "sha1-58TxAB7vpLivvR7uJ6I3/uO/KcQ="
 		},
 		"@types/node": {
 			"version": "16.11.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-			"integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-16.11.7.tgz",
+			"integrity": "sha1-NoIJRQYTJpeMQqAeVrYc0iPf3EI="
 		},
 		"@types/request": {
-			"version": "2.48.5",
-			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
-			"integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+			"version": "2.48.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/request/-/request-2.48.8.tgz",
+			"integrity": "sha1-C5D947ZVq1CXbLjFrAD6yiL1qCw=",
 			"requires": {
 				"@types/caseless": "*",
 				"@types/node": "*",
 				"@types/tough-cookie": "*",
 				"form-data": "^2.5.0"
-			},
-			"dependencies": {
-				"form-data": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-					"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.6",
-						"mime-types": "^2.1.12"
-					}
-				}
 			}
 		},
 		"@types/request-promise-native": {
 			"version": "1.0.18",
-			"resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.18.tgz",
-			"integrity": "sha512-tPnODeISFc/c1LjWyLuZUY+Z0uLB3+IMfNoQyDEi395+j6kTFTTRAqjENjoPJUid4vHRGEozoTrcTrfZM+AcbA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/request-promise-native/-/request-promise-native-1.0.18.tgz",
+			"integrity": "sha1-Q37i0Ldy4ByWkamDtVgIS0s+/Cw=",
 			"requires": {
 				"@types/request": "*"
 			}
 		},
 		"@types/responselike": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha1-JR9P59FU0rrRJavhtCmyOv0mLik=",
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@types/retry": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-			"integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+			"version": "0.12.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha1-KzXsz87n04zXKtmSMvvVi/+zyE0="
 		},
 		"@types/rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-pj0XWzMXSOUiCtSMkB17vx9E7vg=",
 			"requires": {
 				"@types/glob": "*",
 				"@types/node": "*"
 			}
 		},
 		"@types/semver": {
-			"version": "7.3.9",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
-			"integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
+			"version": "7.3.10",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/semver/-/semver-7.3.10.tgz",
+			"integrity": "sha1-XxnuQMvv+H2Rbu3Iwr/iMF2Vf3M="
 		},
 		"@types/shelljs": {
 			"version": "0.8.9",
-			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.9.tgz",
-			"integrity": "sha512-flVe1dvlrCyQJN/SGrnBxqHG+RzXrVKsmjD8WS/qYHpq5UPjfq7UWFBENP0ZuOl0g6OpAlL6iBoLSvKYUUmyQw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/shelljs/-/shelljs-0.8.9.tgz",
+			"integrity": "sha1-Rd2FAaqYgpdso2EFF9rDgxwvu/Q=",
 			"requires": {
 				"@types/glob": "*",
 				"@types/node": "*"
 			}
 		},
 		"@types/tough-cookie": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-			"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
+			"version": "4.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
+			"integrity": "sha1-Yoa0xyKNWKt4ZtGXFvNpbgOgk5c="
 		},
 		"@types/vscode": {
-			"version": "1.62.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA=="
+			"version": "1.69.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.69.0.tgz",
+			"integrity": "sha1-pHIBGvOS+8+Cy7gvYLTCOcIbkhw="
 		},
 		"@ungap/promise-all-settled": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+			"integrity": "sha1-qlgEJxHW4ydd033Fl+XTHowpCkQ="
 		},
 		"agent-base": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
 			"requires": {
 				"debug": "4"
 			}
 		},
 		"aggregate-error": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
 			"requires": {
 				"clean-stack": "^2.0.0",
 				"indent-string": "^4.0.0"
@@ -3423,8 +3929,8 @@
 		},
 		"ajv": {
 			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -3434,26 +3940,26 @@
 		},
 		"ansi-colors": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g="
 		},
 		"ansi-regex": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
 		},
 		"ansi-styles": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
 		},
 		"anymatch": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
 			"requires": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -3461,63 +3967,63 @@
 		},
 		"argparse": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg="
 		},
 		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"version": "0.2.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha1-DTp7tuZOAqkMAwOzHykoaOoJoI0=",
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
 		},
 		"assert-plus": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assertion-error": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs="
 		},
 		"asynckit": {
 			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aws-sign2/-/aws-sign2-0.7.0.tgz",
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
 			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk="
 		},
 		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"version": "1.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
 		},
 		"big-integer": {
-			"version": "1.6.48",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+			"version": "1.6.51",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/big-integer/-/big-integer-1.6.51.tgz",
+			"integrity": "sha1-DfkqXZiAVg0/8tX9ICRciJ0TBoY="
 		},
 		"binary": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary/-/binary-0.3.0.tgz",
 			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
 			"requires": {
 				"buffers": "~0.1.1",
@@ -3526,18 +4032,18 @@
 		},
 		"binary-extensions": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0="
 		},
 		"bluebird": {
 			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bluebird/-/bluebird-3.4.7.tgz",
 			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3545,41 +4051,41 @@
 		},
 		"braces": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
 		},
 		"browser-stdout": {
 			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA="
 		},
 		"buffer-indexof-polyfill": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+			"integrity": "sha1-0nMhNcWZnGSyd/z5savjSYJUcpw="
 		},
 		"buffers": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffers/-/buffers-0.1.1.tgz",
 			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"cacheable-lookup": {
 			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha1-WmuGWyxENXvj1evCpGewMnGacAU="
 		},
 		"cacheable-request": {
 			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-7.0.2.tgz",
+			"integrity": "sha1-6g0LiJNkolhUdXMByhKy2nf5HSc=",
 			"requires": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -3592,47 +4098,48 @@
 		},
 		"call-bind": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
 			"requires": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
 			}
 		},
 		"camelcase": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
+			"version": "6.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo="
 		},
 		"caseless": {
 			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha1-/+S6LZ+p1mgMwLNwra5wnskBHpw=",
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
 		},
 		"chai-as-promised": {
 			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-			"integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+			"integrity": "sha1-CGRdgl3rhpbuYXJdv1kMAS6wDKA=",
 			"requires": {
 				"check-error": "^1.0.2"
 			}
 		},
 		"chainsaw": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chainsaw/-/chainsaw-0.1.0.tgz",
 			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
 			"requires": {
 				"traverse": ">=0.3.0 <0.4"
@@ -3640,8 +4147,8 @@
 		},
 		"chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
 			"requires": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -3649,8 +4156,8 @@
 			"dependencies": {
 				"supports-color": {
 					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -3659,13 +4166,13 @@
 		},
 		"check-error": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/check-error/-/check-error-1.0.2.tgz",
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
 		},
 		"chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha1-HPN8hwe5Mr0a8a4iwEMuKs0ZA70=",
 			"requires": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -3679,47 +4186,22 @@
 		},
 		"clean-stack": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs="
 		},
 		"cliui": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
 			"requires": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
-			},
-			"dependencies": {
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				}
 			}
 		},
 		"clone-response": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
 			"requires": {
 				"mimic-response": "^1.0.0"
@@ -3727,151 +4209,161 @@
 		},
 		"color-convert": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
 			"requires": {
 				"color-name": "~1.1.4"
 			}
 		},
 		"color-name": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
 		},
 		"combined-stream": {
 			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
 			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM="
+		},
+		"compress-brotli": {
+			"version": "1.3.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/compress-brotli/-/compress-brotli-1.3.8.tgz",
+			"integrity": "sha1-DApgyXqYkUUxTsOB6E4maC57ONs=",
+			"requires": {
+				"@types/json-buffer": "~3.0.0",
+				"json-buffer": "~3.0.1"
+			}
 		},
 		"concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"dashdash": {
 			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
 		},
 		"debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
 			"requires": {
 				"ms": "2.1.2"
 			},
 			"dependencies": {
 				"ms": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
 				}
 			}
 		},
 		"decamelize": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc="
 		},
 		"decompress-response": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha1-yjh2Et234QS9FthaqwDV7PCcZvw=",
 			"requires": {
 				"mimic-response": "^3.1.0"
 			},
 			"dependencies": {
 				"mimic-response": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-					"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz",
+					"integrity": "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k="
 				}
 			}
 		},
 		"deep-eql": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
 			"requires": {
 				"type-detect": "^4.0.0"
 			}
 		},
 		"defer-to-connect": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc="
 		},
 		"define-lazy-prop": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8="
 		},
 		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"version": "1.1.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-properties/-/define-properties-1.1.4.tgz",
+			"integrity": "sha1-CxTXvX++svNXLDp+2oDqXVf7BbE=",
 			"requires": {
-				"object-keys": "^1.0.12"
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			}
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"diff": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
+			"version": "5.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.1.0.tgz",
+			"integrity": "sha1-vFLSmMXqjfkZSAAiREXtQ//IfkA="
 		},
 		"dns-packet": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.0.tgz",
-			"integrity": "sha512-Nce7YLu6YCgWRvOmDBsJMo9M5/jV3lEZ5vUWnWXYmwURvPylHvq7nkDWhNmk1ZQoZZOP7oQh/S0lSxbisKOfHg==",
+			"version": "5.4.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dns-packet/-/dns-packet-5.4.0.tgz",
+			"integrity": "sha1-H4hHfPnyfniiE/ttEYrjjnWah5s=",
 			"requires": {
 				"@leichtgewicht/ip-codec": "^2.0.1"
 			}
 		},
 		"dns-socket": {
 			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.2.tgz",
-			"integrity": "sha512-BDeBd8najI4/lS00HSKpdFia+OvUMytaVjfzR9n5Lq8MlZRSvtbI+uLtx1+XmQFls5wFU9dssccTmQQ6nfpjdg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dns-socket/-/dns-socket-4.2.2.tgz",
+			"integrity": "sha1-WLAYbsBT6gcx/rBng8furEuVthY=",
 			"requires": {
 				"dns-packet": "^5.2.4"
 			}
 		},
 		"duplexer2": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer2/-/duplexer2-0.1.4.tgz",
 			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
 			"requires": {
 				"readable-stream": "^2.0.2"
 			}
 		},
 		"duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+			"version": "0.1.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer3/-/duplexer3-0.1.5.tgz",
+			"integrity": "sha1-C15Ne61d6JAepEQGJMjh0gCZIX4="
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"requires": {
 				"jsbn": "~0.1.0",
@@ -3880,53 +4372,56 @@
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
 			"requires": {
 				"once": "^1.4.0"
 			}
 		},
 		"eol": {
 			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
-			"integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eol/-/eol-0.9.1.tgz",
+			"integrity": "sha1-9wGRL1BAdL41xhF6XEreSc1Ues0="
 		},
 		"es-abstract": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-			"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+			"version": "1.20.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-abstract/-/es-abstract-1.20.1.tgz",
+			"integrity": "sha1-AnKSzW70S9ErGRO4KBFvVHh9GBQ=",
 			"requires": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
+				"function.prototype.name": "^1.1.5",
 				"get-intrinsic": "^1.1.1",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.2",
+				"has-property-descriptors": "^1.0.0",
+				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
 				"is-callable": "^1.2.4",
-				"is-negative-zero": "^2.0.1",
+				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.1",
+				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
-				"is-weakref": "^1.0.1",
-				"object-inspect": "^1.11.0",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.12.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.2",
-				"string.prototype.trimend": "^1.0.4",
-				"string.prototype.trimstart": "^1.0.4",
-				"unbox-primitive": "^1.0.1"
+				"regexp.prototype.flags": "^1.4.3",
+				"string.prototype.trimend": "^1.0.5",
+				"string.prototype.trimstart": "^1.0.5",
+				"unbox-primitive": "^1.0.2"
 			}
 		},
 		"es-to-primitive": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
 			"requires": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
@@ -3935,51 +4430,51 @@
 		},
 		"escalade": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA="
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ="
 		},
 		"esprima": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
 		},
 		"extend": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
 		},
 		"extsprintf": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM="
 		},
 		"fill-range": {
 			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
 			"requires": {
 				"to-regex-range": "^5.0.1"
 			}
 		},
 		"find-up": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
 			"requires": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -3987,18 +4482,18 @@
 		},
 		"flat": {
 			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE="
 		},
 		"forever-agent": {
 			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"version": "2.5.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/form-data/-/form-data-2.5.1.tgz",
+			"integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -4007,19 +4502,19 @@
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
 			"optional": true
 		},
 		"fstream": {
 			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"inherits": "~2.0.0",
@@ -4029,8 +4524,8 @@
 			"dependencies": {
 				"rimraf": {
 					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
 					"requires": {
 						"glob": "^7.1.3"
 					}
@@ -4039,41 +4534,57 @@
 		},
 		"function-bind": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+		},
+		"function.prototype.name": {
+			"version": "1.1.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+			"integrity": "sha1-zOBQX+H/uAUD5vnkbMZORqEqliE=",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.0",
+				"functions-have-names": "^1.2.2"
+			}
+		},
+		"functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ="
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
 		},
 		"get-func-name": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-func-name/-/get-func-name-2.0.0.tgz",
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
 		},
 		"get-intrinsic": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+			"integrity": "sha1-M2l1Ej4FrQt7pB8VLuSq2+ps9Zg=",
 			"requires": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.1"
+				"has-symbols": "^1.0.3"
 			}
 		},
 		"get-stream": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
 			"requires": {
 				"pump": "^3.0.0"
 			}
 		},
 		"get-symbol-description": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-			"integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+			"integrity": "sha1-f9uByQAQH71WTdXxowr1qtweWNY=",
 			"requires": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.1"
@@ -4081,44 +4592,44 @@
 		},
 		"getpass": {
 			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+			"version": "7.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-parent": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
 			"requires": {
 				"is-glob": "^4.0.1"
 			}
 		},
 		"got": {
-			"version": "11.8.2",
-			"resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-			"integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+			"version": "11.8.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz",
+			"integrity": "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY=",
 			"requires": {
 				"@sindresorhus/is": "^4.0.0",
 				"@szmarczak/http-timer": "^4.0.5",
 				"@types/cacheable-request": "^6.0.1",
 				"@types/responselike": "^1.0.0",
 				"cacheable-lookup": "^5.0.3",
-				"cacheable-request": "^7.0.1",
+				"cacheable-request": "^7.0.2",
 				"decompress-response": "^6.0.0",
 				"http2-wrapper": "^1.0.0-beta.5.2",
 				"lowercase-keys": "^2.0.0",
@@ -4127,24 +4638,24 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+			"version": "4.2.10",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha1-FH06AG2kyjzhRyjHrvwofDZ9emw="
 		},
 		"growl": {
 			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4="
 		},
 		"har-schema": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/har-schema/-/har-schema-2.0.0.tgz",
 			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
 			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
 			"requires": {
 				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
@@ -4152,49 +4663,57 @@
 		},
 		"has": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has/-/has-1.0.3.tgz",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
 		},
 		"has-bigints": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+			"version": "1.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha1-CHG9Pj1RYm9soJZmaLo11WAtbqo="
 		},
 		"has-flag": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+		},
+		"has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha1-YQcIYAYG02lh7QTBlhk7amB/qGE=",
+			"requires": {
+				"get-intrinsic": "^1.1.1"
+			}
 		},
 		"has-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+			"version": "1.0.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg="
 		},
 		"has-tostringtag": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+			"integrity": "sha1-fhM4GKfTlHNPlB5zw9P5KR5liyU=",
 			"requires": {
 				"has-symbols": "^1.0.2"
 			}
 		},
 		"he": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/he/-/he-1.2.0.tgz",
+			"integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8="
 		},
 		"http-cache-semantics": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+			"integrity": "sha1-SekcXL82yblLz81xwj1SSex045A="
 		},
 		"http-proxy-agent": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
 			"requires": {
 				"@tootallnate/once": "1",
 				"agent-base": "6",
@@ -4203,7 +4722,7 @@
 		},
 		"http-signature": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
 				"assert-plus": "^1.0.0",
@@ -4213,17 +4732,17 @@
 		},
 		"http2-wrapper": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha1-uPVeDB8l1OvQizsMLAeflZCACz0=",
 			"requires": {
 				"quick-lru": "^5.1.1",
 				"resolve-alpn": "^1.0.0"
 			}
 		},
 		"https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
 			"requires": {
 				"agent-base": "6",
 				"debug": "4"
@@ -4231,12 +4750,12 @@
 		},
 		"indent-string": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE="
 		},
 		"inflight": {
 			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
 				"once": "^1.3.0",
@@ -4245,13 +4764,13 @@
 		},
 		"inherits": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
 		},
 		"internal-slot": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-			"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/internal-slot/-/internal-slot-1.0.3.tgz",
+			"integrity": "sha1-c0fjB97uovqsKsYgXUvH00ln9Zw=",
 			"requires": {
 				"get-intrinsic": "^1.1.0",
 				"has": "^1.0.3",
@@ -4260,34 +4779,34 @@
 		},
 		"interpret": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/interpret/-/interpret-1.4.0.tgz",
+			"integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4="
 		},
 		"ip-regex": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-			"integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ip-regex/-/ip-regex-4.3.0.tgz",
+			"integrity": "sha1-aHJ1qw9X+naXj/j03dyKI9WZDbU="
 		},
 		"is-bigint": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha1-CBR6GHW8KzIAXUHM2Ckd/8ZpHfM=",
 			"requires": {
 				"has-bigints": "^1.0.1"
 			}
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
 			"requires": {
 				"binary-extensions": "^2.0.0"
 			}
 		},
 		"is-boolean-object": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha1-XG3CACRt2TIa5LiFoRS7H3X2Nxk=",
 			"requires": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -4295,70 +4814,78 @@
 		},
 		"is-callable": {
 			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-callable/-/is-callable-1.2.4.tgz",
+			"integrity": "sha1-RzAdWN0CWUB4ZVR4U99tYf5HGUU="
 		},
 		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.9.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha1-4cNEKc1Rxt2eCeB5njluJ7GanGk=",
 			"requires": {
 				"has": "^1.0.3"
 			}
 		},
 		"is-date-object": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+			"version": "1.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-date-object/-/is-date-object-1.0.5.tgz",
+			"integrity": "sha1-CEHVU25yTCVZe/bqYuG9OCmN8x8=",
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
 		},
 		"is-docker": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-			"integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw=="
+			"version": "2.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+		},
+		"is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
 		},
 		"is-glob": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
 		},
 		"is-ip": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-ip/-/is-ip-3.1.0.tgz",
+			"integrity": "sha1-KuXd+vrwXLgAimIJPPKXNPZXxdg=",
 			"requires": {
 				"ip-regex": "^4.0.0"
 			}
 		},
 		"is-negative-zero": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+			"version": "2.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+			"integrity": "sha1-e/bwOigAO4s5Zd46wm9mTXZfMVA="
 		},
 		"is-number": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
 		},
 		"is-number-object": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-			"integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+			"version": "1.0.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha1-WdUK2kxFJReE6ZBPUkbHQvB6Qvw=",
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
 		},
 		"is-online": {
 			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/is-online/-/is-online-9.0.1.tgz",
-			"integrity": "sha512-+08dRW0dcFOtleR2N3rHRVxDyZtQitUp9cC+KpKTds0mXibbQyW5js7xX0UGyQXkaLUJObe0w6uQ4ex34lX9LA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-9.0.1.tgz",
+			"integrity": "sha1-caNCAvqCa65vP/i+pCDFZXNEil8=",
 			"requires": {
 				"got": "^11.8.0",
 				"p-any": "^3.0.0",
@@ -4368,122 +4895,125 @@
 		},
 		"is-plain-obj": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc="
 		},
 		"is-regex": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=",
 			"requires": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
 			}
 		},
 		"is-shared-array-buffer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+			"version": "1.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+			"integrity": "sha1-jyWcVztgtqMtQFihoHQwwKc0THk=",
+			"requires": {
+				"call-bind": "^1.0.2"
+			}
 		},
 		"is-string": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=",
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
 		},
 		"is-symbol": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+			"version": "1.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
 			"requires": {
-				"has-symbols": "^1.0.1"
+				"has-symbols": "^1.0.2"
 			}
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"is-unicode-supported": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc="
 		},
 		"is-weakref": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+			"version": "1.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha1-lSnzg6kzggXol2XgOS78LxAPBvI=",
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
 			}
 		},
 		"is-wsl": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
 			"requires": {
 				"is-docker": "^2.0.0"
 			}
 		},
 		"isarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isstream": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
 		},
 		"js-yaml": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
 			"requires": {
 				"argparse": "^2.0.1"
 			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"json-buffer": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM="
 		},
 		"json-schema": {
 			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha1-995M9u+rg4666zI2R0y7paGTCrU="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"jsprim": {
 			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha1-cSxlUzoVyHi6WentXw4m1bd8X+s=",
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -4492,119 +5022,133 @@
 			}
 		},
 		"keyv": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
-			"integrity": "sha512-vqNHbAc8BBsxk+7QBYLW0Y219rWcClspR6WSeoHYKG5mnsSoOH+BL1pWq02DDCVdvvuUny5rkBlzMRzoqc+GIg==",
+			"version": "4.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.3.2.tgz",
+			"integrity": "sha1-6DnfZ2oMfuWUyINefByDdCVY5cI=",
 			"requires": {
+				"compress-brotli": "^1.3.8",
 				"json-buffer": "3.0.1"
 			}
 		},
 		"listenercount": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/listenercount/-/listenercount-1.0.1.tgz",
 			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
 		},
 		"locate-path": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
 			"requires": {
 				"p-locate": "^5.0.0"
 			}
 		},
 		"lodash": {
 			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
 		},
 		"log-symbols": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
 			"requires": {
 				"chalk": "^4.1.0",
 				"is-unicode-supported": "^0.1.0"
 			}
 		},
+		"loupe": {
+			"version": "2.3.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/loupe/-/loupe-2.3.4.tgz",
+			"integrity": "sha1-fgub/8dvFI+b52nLEyHT3PPLJfM=",
+			"requires": {
+				"get-func-name": "^2.0.0"
+			}
+		},
 		"lowercase-keys": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk="
 		},
 		"mime-db": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-			"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
+			"version": "1.52.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A="
 		},
 		"mime-types": {
-			"version": "2.1.28",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-			"integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+			"version": "2.1.35",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
 			"requires": {
-				"mime-db": "1.45.0"
+				"mime-db": "1.52.0"
 			}
 		},
 		"mimic-response": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q="
 		},
 		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
 			"requires": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			}
 		},
 		"mocha": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-			"integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+			"version": "9.2.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mocha/-/mocha-9.2.2.tgz",
+			"integrity": "sha1-1w20a9uTyldALICTM+WoSXeoj7k=",
 			"requires": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.2",
-				"debug": "4.3.2",
+				"chokidar": "3.5.3",
+				"debug": "4.3.3",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
-				"glob": "7.1.7",
+				"glob": "7.2.0",
 				"growl": "1.10.5",
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
-				"minimatch": "3.0.4",
+				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
+				"nanoid": "3.3.1",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"workerpool": "6.1.5",
+				"workerpool": "6.2.0",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
 			},
 			"dependencies": {
+				"diff": {
+					"version": "5.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.0.0.tgz",
+					"integrity": "sha1-ftatdthZ0DB4fsNYVfWx2vMdhSs="
+				},
 				"glob": {
-					"version": "7.1.7",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-					"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+					"version": "7.2.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.0.tgz",
+					"integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -4612,49 +5156,67 @@
 						"minimatch": "^3.0.4",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
+					},
+					"dependencies": {
+						"minimatch": {
+							"version": "3.1.2",
+							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+							"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						}
+					}
+				},
+				"minimatch": {
+					"version": "4.2.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-4.2.1.tgz",
+					"integrity": "sha1-QNnVEaRr3E5WPCLDCAzenA2CmbQ=",
+					"requires": {
+						"brace-expansion": "^1.1.7"
 					}
 				}
 			}
 		},
 		"ms": {
 			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
 		},
 		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
+			"version": "3.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha1-Y0ehjKyIr4j1ivCzWUtyPV6ZuzU="
 		},
 		"normalize-path": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
 		},
 		"normalize-url": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo="
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
 		},
 		"object-inspect": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+			"version": "1.12.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-inspect/-/object-inspect-1.12.2.tgz",
+			"integrity": "sha1-wGQfJjlFMvKKuNeWq5VOQ8AJqOo="
 		},
 		"object-keys": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
 		},
 		"object.assign": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object.assign/-/object.assign-4.1.2.tgz",
+			"integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
 			"requires": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
@@ -4664,7 +5226,7 @@
 		},
 		"once": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
 				"wrappy": "1"
@@ -4672,8 +5234,8 @@
 		},
 		"open": {
 			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-			"integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-8.4.0.tgz",
+			"integrity": "sha1-NFMhrhj4E4+CVlqRD9xrOejCRPg=",
 			"requires": {
 				"define-lazy-prop": "^2.0.0",
 				"is-docker": "^2.1.1",
@@ -4682,8 +5244,8 @@
 		},
 		"p-any": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-any/-/p-any-3.0.0.tgz",
-			"integrity": "sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-3.0.0.tgz",
+			"integrity": "sha1-eYR67tcLXToQ6mJSlsDD0ukKh7k=",
 			"requires": {
 				"p-cancelable": "^2.0.0",
 				"p-some": "^5.0.0"
@@ -4691,43 +5253,43 @@
 		},
 		"p-cancelable": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8="
 		},
 		"p-finally": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
 			"requires": {
 				"yocto-queue": "^0.1.0"
 			}
 		},
 		"p-locate": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
 			"requires": {
 				"p-limit": "^3.0.2"
 			}
 		},
 		"p-retry": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-			"integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+			"version": "4.6.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha1-m6rnGEBX7dThcjHO4EJkEG4JKhY=",
 			"requires": {
-				"@types/retry": "^0.12.0",
+				"@types/retry": "0.12.0",
 				"retry": "^0.13.1"
 			}
 		},
 		"p-some": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
-			"integrity": "sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-5.0.0.tgz",
+			"integrity": "sha1-i3MMdLT+UWnXJkokCtAQtuvGhqQ=",
 			"requires": {
 				"aggregate-error": "^3.0.0",
 				"p-cancelable": "^2.0.0"
@@ -4735,61 +5297,61 @@
 		},
 		"p-timeout": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
 			"requires": {
 				"p-finally": "^1.0.0"
 			}
 		},
 		"path-exists": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-parse": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
 		},
 		"pathval": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha1-hTTnenfOesWiUS6iHg/bj89sPY0="
 		},
 		"performance-now": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+			"version": "2.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI="
 		},
 		"prepend-http": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prepend-http/-/prepend-http-2.0.0.tgz",
 			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
 		},
 		"psl": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+			"version": "1.9.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/psl/-/psl-1.9.0.tgz",
+			"integrity": "sha1-0N8qE38AeUVl/K87LADNCfjVpac="
 		},
 		"public-ip": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/public-ip/-/public-ip-4.0.4.tgz",
-			"integrity": "sha512-EJ0VMV2vF6Cu7BIPo3IMW1Maq6ME+fbR0NcPmqDfpfNGIRPue1X8QrGjrg/rfjDkOsIkKHIf2S5FlEa48hFMTA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-4.0.4.tgz",
+			"integrity": "sha1-s3hKWh/xuB0BW5oYRQvmX/2SnrM=",
 			"requires": {
 				"dns-socket": "^4.2.2",
 				"got": "^9.6.0",
@@ -4798,21 +5360,21 @@
 			"dependencies": {
 				"@sindresorhus/is": {
 					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-					"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-0.14.0.tgz",
+					"integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o="
 				},
 				"@szmarczak/http-timer": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-					"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+					"integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
 					"requires": {
 						"defer-to-connect": "^1.0.1"
 					}
 				},
 				"cacheable-request": {
 					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-					"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-6.1.0.tgz",
+					"integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
 					"requires": {
 						"clone-response": "^1.0.2",
 						"get-stream": "^5.1.0",
@@ -4825,7 +5387,7 @@
 				},
 				"decompress-response": {
 					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-3.3.0.tgz",
 					"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
 					"requires": {
 						"mimic-response": "^1.0.0"
@@ -4833,13 +5395,13 @@
 				},
 				"defer-to-connect": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-					"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+					"integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE="
 				},
 				"got": {
 					"version": "9.6.0",
-					"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-					"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-9.6.0.tgz",
+					"integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
 					"requires": {
 						"@sindresorhus/is": "^0.14.0",
 						"@szmarczak/http-timer": "^1.1.2",
@@ -4856,45 +5418,45 @@
 					"dependencies": {
 						"get-stream": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-							"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-4.1.0.tgz",
+							"integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
 							"requires": {
 								"pump": "^3.0.0"
 							}
 						},
 						"lowercase-keys": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-							"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+							"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
 						}
 					}
 				},
 				"json-buffer": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.0.tgz",
 					"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
 				},
 				"keyv": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-					"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-3.1.0.tgz",
+					"integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
 					"requires": {
 						"json-buffer": "3.0.0"
 					}
 				},
 				"normalize-url": {
 					"version": "4.5.1",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-					"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-4.5.1.tgz",
+					"integrity": "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo="
 				},
 				"p-cancelable": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-					"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-1.1.0.tgz",
+					"integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw="
 				},
 				"responselike": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-1.0.2.tgz",
 					"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
 					"requires": {
 						"lowercase-keys": "^1.0.0"
@@ -4902,8 +5464,8 @@
 					"dependencies": {
 						"lowercase-keys": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-							"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+							"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
 						}
 					}
 				}
@@ -4911,8 +5473,8 @@
 		},
 		"pump": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -4920,31 +5482,31 @@
 		},
 		"punycode": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"version": "6.5.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha1-Ou7/yRln7241wOSI70b7KWq3aq0="
 		},
 		"quick-lru": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha1-NmST5rPkKjpoheLpnRj4D7eoyTI="
 		},
 		"randombytes": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
 		},
 		"readable-stream": {
 			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -4957,31 +5519,41 @@
 			"dependencies": {
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
 				}
 			}
 		},
 		"readdirp": {
 			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
 		},
 		"rechoir": {
 			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
 				"resolve": "^1.1.6"
 			}
 		},
+		"regexp.prototype.flags": {
+			"version": "1.4.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+			"integrity": "sha1-h8qzD4D2ZmAYGju3v1mBqHKzZ6w=",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"functions-have-names": "^1.2.2"
+			}
+		},
 		"request": {
 			"version": "2.88.2",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/request/-/request-2.88.2.tgz",
+			"integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -5003,20 +5575,32 @@
 				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"form-data": {
+					"version": "2.3.3",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/form-data/-/form-data-2.3.3.tgz",
+					"integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				}
 			}
 		},
 		"request-promise-core": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-			"integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/request-promise-core/-/request-promise-core-1.1.4.tgz",
+			"integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
 			"requires": {
 				"lodash": "^4.17.19"
 			}
 		},
 		"request-promise-native": {
 			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-			"integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/request-promise-native/-/request-promise-native-1.0.9.tgz",
+			"integrity": "sha1-5AcSBSal79yaObKKVnm/R7nZ3Cg=",
 			"requires": {
 				"request-promise-core": "1.1.4",
 				"stealthy-require": "^1.1.1",
@@ -5025,76 +5609,77 @@
 		},
 		"require-directory": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"version": "1.22.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha1-J8suu1P5GrtJRwqSi7p1WAZqwXc=",
 			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
 		"resolve-alpn": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha1-t629rDVGqq7CC0Xn2CZZJwcnJvk="
 		},
 		"responselike": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-			"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-2.0.0.tgz",
+			"integrity": "sha1-JjkbzDF091D5p56sxAoSpcQtdyM=",
 			"requires": {
 				"lowercase-keys": "^2.0.0"
 			}
 		},
 		"retry": {
 			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha1-GFsVh6z2eRnWOzVzSeA1N7JIRlg="
 		},
 		"rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
 			"requires": {
 				"glob": "^7.1.3"
 			}
 		},
 		"safe-buffer": {
 			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
 		},
 		"semver": {
 			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
 		},
 		"serialize-javascript": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+			"integrity": "sha1-765diPRdeSQUHai1w6en5mP+/rg=",
 			"requires": {
 				"randombytes": "^2.1.0"
 			}
 		},
 		"setimmediate": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"shelljs": {
 			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-			"integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shelljs/-/shelljs-0.8.4.tgz",
+			"integrity": "sha1-3naE/ut2f4cWsyYHiooAh1iQ48I=",
 			"requires": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -5103,8 +5688,8 @@
 		},
 		"side-channel": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
 			"requires": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",
@@ -5113,13 +5698,13 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"version": "1.17.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha1-V4CC2S1P5hKxMAdJblQ/oPvL5MU=",
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -5134,72 +5719,97 @@
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			},
 			"dependencies": {
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
 				}
 			}
 		},
+		"string-width": {
+			"version": "4.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			}
+		},
 		"string.prototype.trimend": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+			"version": "1.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+			"integrity": "sha1-kUpluqqyX73U7ikcp93lfoacuNA=",
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			}
 		},
 		"string.prototype.trimstart": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+			"version": "1.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+			"integrity": "sha1-VGbZO6WM+iE0g5+B1/QkN+jAH+8=",
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
+			}
+		},
+		"strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+			"requires": {
+				"ansi-regex": "^5.0.1"
 			}
 		},
 		"strip-json-comments": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY="
 		},
 		"supports-color": {
 			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
 			"requires": {
 				"has-flag": "^4.0.0"
 			}
 		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk="
+		},
 		"to-readable-stream": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+			"integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E="
 		},
 		"to-regex-range": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
 			"requires": {
 				"is-number": "^7.0.0"
 			}
 		},
 		"tough-cookie": {
 			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
 			"requires": {
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
@@ -5207,18 +5817,18 @@
 		},
 		"traverse": {
 			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/traverse/-/traverse-0.3.9.tgz",
 			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
 		},
 		"tslib": {
 			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA="
 		},
 		"tslint": {
 			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslint/-/tslint-5.20.1.tgz",
+			"integrity": "sha1-5AHortoBUrxE3QfmFANPP4DGe30=",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"builtin-modules": "^1.1.1",
@@ -5237,24 +5847,24 @@
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
 				},
 				"argparse": {
 					"version": "1.0.10",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
 					"requires": {
 						"sprintf-js": "~1.0.2"
 					}
 				},
 				"chalk": {
 					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -5263,36 +5873,36 @@
 				},
 				"color-convert": {
 					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
 					"requires": {
 						"color-name": "1.1.3"
 					}
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
 				"diff": {
 					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0="
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"js-yaml": {
 					"version": "3.14.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
 					"requires": {
 						"argparse": "^1.0.7",
 						"esprima": "^4.0.0"
@@ -5300,25 +5910,25 @@
 				},
 				"supports-color": {
 					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 					"requires": {
 						"has-flag": "^3.0.0"
+					}
+				},
+				"tsutils": {
+					"version": "2.29.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tsutils/-/tsutils-2.29.0.tgz",
+					"integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+					"requires": {
+						"tslib": "^1.8.1"
 					}
 				}
 			}
 		},
-		"tsutils": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-			"requires": {
-				"tslib": "^1.8.1"
-			}
-		},
 		"tunnel-agent": {
 			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
 				"safe-buffer": "^5.0.1"
@@ -5326,34 +5936,34 @@
 		},
 		"tweetnacl": {
 			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type-detect": {
 			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw="
 		},
 		"typescript": {
 			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha1-LNAaGh8WBwTTEB/VpY/w+fy4Aww="
 		},
 		"unbox-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"version": "1.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha1-KQMgIQV9Xmzb0IxRKcIm3/jtb54=",
 			"requires": {
-				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.1",
-				"has-symbols": "^1.0.2",
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
 			}
 		},
 		"unzipper": {
 			"version": "0.10.11",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unzipper/-/unzipper-0.10.11.tgz",
+			"integrity": "sha1-C0mRRGRyy9uS7nQDkJ8mwkGceC4=",
 			"requires": {
 				"big-integer": "^1.6.17",
 				"binary": "~0.3.0",
@@ -5369,15 +5979,15 @@
 		},
 		"uri-js": {
 			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
 			"requires": {
 				"punycode": "^2.1.0"
 			}
 		},
 		"url-parse-lax": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
 			"requires": {
 				"prepend-http": "^2.0.0"
@@ -5385,17 +5995,17 @@
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"uuid": {
 			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
 		},
 		"verror": {
 			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
 				"assert-plus": "^1.0.0",
@@ -5404,14 +6014,14 @@
 			}
 		},
 		"vscode-extension-telemetry": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.3.tgz",
-			"integrity": "sha512-opiIFOaAwyfACYMXByDqFMAlJ2iFMJR65/vIogJ960aLZWp9zaMdwY9CsY02EOYjHxPpjI7QeOQM3sYCb3xtJg=="
+			"version": "0.4.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.5.tgz",
+			"integrity": "sha1-GVfVqLDNatmnnU8mD+A3+/mHMrs="
 		},
 		"vscode-test": {
 			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vscode-test/-/vscode-test-1.6.1.tgz",
+			"integrity": "sha1-RCVMZwNt6SsA/dcvas5fGFThpWM=",
 			"requires": {
 				"http-proxy-agent": "^4.0.1",
 				"https-proxy-agent": "^5.0.0",
@@ -5421,16 +6031,16 @@
 		},
 		"which": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
+			"integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
 			"requires": {
 				"isexe": "^2.0.0"
 			}
 		},
 		"which-boxed-primitive": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
 			"requires": {
 				"is-bigint": "^1.0.1",
 				"is-boolean-object": "^1.1.0",
@@ -5440,59 +6050,34 @@
 			}
 		},
 		"workerpool": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-			"integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw=="
+			"version": "6.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/workerpool/-/workerpool-6.2.0.tgz",
+			"integrity": "sha1-gn2Tyboj7iAZw/+v9cJ/zOoonos="
 		},
 		"wrap-ansi": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
 			"requires": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0"
-			},
-			"dependencies": {
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				}
 			}
 		},
 		"wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"y18n": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-			"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+			"version": "5.0.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU="
 		},
 		"yargs": {
 			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
 			"requires": {
 				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
@@ -5501,42 +6086,17 @@
 				"string-width": "^4.2.0",
 				"y18n": "^5.0.5",
 				"yargs-parser": "^20.2.2"
-			},
-			"dependencies": {
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				}
 			}
 		},
 		"yargs-parser": {
 			"version": "20.2.4",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-parser/-/yargs-parser-20.2.4.tgz",
+			"integrity": "sha1-tCiQ8UVmeW+Fro46JSkNIF8VSlQ="
 		},
 		"yargs-unparser": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
 			"requires": {
 				"camelcase": "^6.0.0",
 				"decamelize": "^4.0.0",
@@ -5546,8 +6106,8 @@
 		},
 		"yocto-queue": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs="
 		}
 	}
 }

--- a/vscode-dotnet-runtime-library/package-lock.json
+++ b/vscode-dotnet-runtime-library/package-lock.json
@@ -16,7 +16,7 @@
 				"@types/rimraf": "3.0.2",
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"chai": "^4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",
@@ -40,7 +40,7 @@
 				"glob": "^7.2.0"
 			},
 			"engines": {
-				"vscode": "^1.62.0"
+				"vscode": "1.62.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "^2.3.2"
@@ -342,9 +342,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.69.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.69.0.tgz",
-			"integrity": "sha1-pHIBGvOS+8+Cy7gvYLTCOcIbkhw=",
+			"version": "1.62.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.62.0.tgz",
+			"integrity": "sha1-tNbRktWut16R0K3vaJw+zvmHnac=",
 			"license": "MIT"
 		},
 		"node_modules/@ungap/promise-all-settled": {
@@ -3901,9 +3901,9 @@
 			"integrity": "sha1-Yoa0xyKNWKt4ZtGXFvNpbgOgk5c="
 		},
 		"@types/vscode": {
-			"version": "1.69.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.69.0.tgz",
-			"integrity": "sha1-pHIBGvOS+8+Cy7gvYLTCOcIbkhw="
+			"version": "1.62.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.62.0.tgz",
+			"integrity": "sha1-tNbRktWut16R0K3vaJw+zvmHnac="
 		},
 		"@ungap/promise-all-settled": {
 			"version": "1.1.2",

--- a/vscode-dotnet-runtime-library/package.json
+++ b/vscode-dotnet-runtime-library/package.json
@@ -8,7 +8,7 @@
 	},
 	"license": "MIT",
 	"engines": {
-		"vscode": "^1.62.0"
+		"vscode": "1.62.0"
 	},
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -32,7 +32,7 @@
 		"@types/rimraf": "3.0.2",
 		"@types/semver": "^7.3.9",
 		"@types/shelljs": "0.8.9",
-		"@types/vscode": "^1.62.0",
+		"@types/vscode": "1.62.0",
 		"chai": "^4.3.4",
 		"chai-as-promised": "^7.1.1",
 		"diff": ">=5.0.0",

--- a/vscode-dotnet-runtime-library/package.json
+++ b/vscode-dotnet-runtime-library/package.json
@@ -21,7 +21,7 @@
 		"clean": "rimraf dist"
 	},
 	"devDependencies": {
-		"@types/chai": "^4.2.22",
+		"@types/chai": "4.2.22",
 		"glob": "^7.2.0"
 	},
 	"dependencies": {
@@ -33,7 +33,7 @@
 		"@types/semver": "^7.3.9",
 		"@types/shelljs": "0.8.9",
 		"@types/vscode": "1.62.0",
-		"chai": "^4.3.4",
+		"chai": "4.3.4",
 		"chai-as-promised": "^7.1.1",
 		"diff": ">=5.0.0",
 		"eol": "^0.9.1",

--- a/vscode-dotnet-sdk-extension/.npmrc
+++ b/vscode-dotnet-sdk-extension/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/

--- a/vscode-dotnet-sdk-extension/package-lock.json
+++ b/vscode-dotnet-sdk-extension/package-lock.json
@@ -9,13 +9,13 @@
 			"version": "0.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"@types/chai": "^4.2.22",
+				"@types/chai": "4.2.22",
 				"@types/chai-as-promised": "^7.1.4",
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
 				"@types/vscode": "1.62.0",
-				"chai": "^4.3.4",
+				"chai": "4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"child_process": "^1.0.2",
 				"diff": ">=5.0.0",
@@ -53,7 +53,7 @@
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
 				"@types/vscode": "1.62.0",
-				"chai": "^4.3.4",
+				"chai": "4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",
 				"eol": "^0.9.1",
@@ -72,7 +72,7 @@
 				"vscode-test": "^1.6.1"
 			},
 			"devDependencies": {
-				"@types/chai": "^4.2.22",
+				"@types/chai": "4.2.22",
 				"glob": "^7.2.0"
 			},
 			"engines": {
@@ -83,30 +83,33 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-			"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha1-OyXTjIlgC6otzCGe36iKdOssQno=",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.16.0"
+				"@babel/highlight": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.15.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha1-nJfjDTGyuMcqHQiYTyyptXTXoHY=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-			"integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha1-gRWGAek+JWN5Wty/vfXWS+Py7N8=",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -116,8 +119,9 @@
 		},
 		"node_modules/@babel/highlight/node_modules/ansi-styles": {
 			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -127,8 +131,9 @@
 		},
 		"node_modules/@babel/highlight/node_modules/chalk": {
 			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -140,37 +145,42 @@
 		},
 		"node_modules/@babel/highlight/node_modules/color-convert": {
 			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/color-name": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"license": "MIT"
 		},
 		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/has-flag": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/supports-color": {
 			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -179,24 +189,85 @@
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
-			"integrity": "sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==",
+			"version": "0.5.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+			"integrity": "sha1-HVcr+74Ut3BOC6Dzm3SBW4SHDXA=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
 			}
 		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+			"integrity": "sha1-wa7cYehT8rufXf5tRELTtWWyU7k=",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+			"integrity": "sha1-IgOxGMFXchrd/mnUe3BGVGMGbXg=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"integrity": "sha1-fGz5mNbSC5FMClWpGuko/yWWXnI=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+			"integrity": "sha1-9FNRqu1FJ6KYUS7HL4EEDJmFgPs=",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha1-rdTJjTQUcqKJGQtCTvvbCWmRuyQ=",
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.14",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+			"integrity": "sha1-sjGggdj2Z5bkda1Yih70cxEnAe0=",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"node_modules/@leichtgewicht/ip-codec": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
-			"integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+			"version": "2.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+			"integrity": "sha1-sqxibWy5yHGKtFkWbUu0Bbj/p4s=",
+			"license": "MIT"
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
 				"run-parallel": "^1.1.9"
@@ -207,18 +278,20 @@
 		},
 		"node_modules/@nodelib/fs.stat": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
 			}
 		},
 		"node_modules/@nodelib/fs.walk": {
 			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
@@ -228,9 +301,10 @@
 			}
 		},
 		"node_modules/@sindresorhus/is": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-			"integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==",
+			"version": "4.6.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha1-PHycRuZ4/u/nouW7YJ09vWZf+z8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -240,8 +314,9 @@
 		},
 		"node_modules/@szmarczak/http-timer": {
 			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac=",
+			"license": "MIT",
 			"dependencies": {
 				"defer-to-connect": "^2.0.0"
 			},
@@ -251,16 +326,18 @@
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
 			}
 		},
 		"node_modules/@types/cacheable-request": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
-			"integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+			"integrity": "sha1-wyTaAZfeCpiiMSFWU2riYkKf9rk=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/http-cache-semantics": "*",
 				"@types/keyv": "*",
@@ -270,30 +347,34 @@
 		},
 		"node_modules/@types/chai": {
 			"version": "4.2.22",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
-			"integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai/-/chai-4.2.22.tgz",
+			"integrity": "sha1-RwINfkzxkZTUO1IC8191vSrTXOc=",
+			"license": "MIT"
 		},
 		"node_modules/@types/chai-as-promised": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.4.tgz",
-			"integrity": "sha512-1y3L1cHePcIm5vXkh1DSGf/zQq5n5xDKG1fpCvf18+uOkpce0Z1ozNFPkyWsVswK7ntN1sZBw3oU6gmN+pDUcA==",
+			"version": "7.1.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+			"integrity": "sha1-bgFoEfbHpk8u7YIxkcOmlVCU4lU=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/chai": "*"
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "7.28.2",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
-			"integrity": "sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==",
+			"version": "8.4.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/eslint/-/eslint-8.4.5.tgz",
+			"integrity": "sha1-rN+33Ta5HMXYEtfAk4Eajz2bMeQ=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
 			}
 		},
 		"node_modules/@types/eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+			"version": "3.7.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+			"integrity": "sha1-N/wSI/B4bDlicGihLpTW5vxh3hY=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -301,13 +382,15 @@
 		},
 		"node_modules/@types/estree": {
 			"version": "0.0.50",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/estree/-/estree-0.0.50.tgz",
+			"integrity": "sha1-Hgyqk2TT/M0pMcPtlv2+ql1MyoM=",
+			"license": "MIT"
 		},
 		"node_modules/@types/glob": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-vBtb86qS8lvV3TnzXFc2G9zlsus=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/minimatch": "*",
 				"@types/node": "*"
@@ -315,49 +398,63 @@
 		},
 		"node_modules/@types/http-cache-semantics": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+			"integrity": "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI=",
+			"license": "MIT"
+		},
+		"node_modules/@types/json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-hcH/DwlI/BWYENS1vjW/jCCHX2Q=",
+			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+			"version": "7.0.11",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha1-1CG2xSejA398hEM/0sQingFoY9M=",
+			"license": "MIT"
 		},
 		"node_modules/@types/keyv": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.3.tgz",
-			"integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
+			"version": "3.1.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha1-PM2xxnUbDH5SMAvNrNW8v4+qdbY=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/minimatch": {
 			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/minimatch/-/minimatch-3.0.5.tgz",
+			"integrity": "sha1-EAHMXmo3BLg8I2An538vWOoBD0A=",
+			"license": "MIT"
 		},
 		"node_modules/@types/mocha": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-			"integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA=="
+			"version": "9.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/mocha/-/mocha-9.1.1.tgz",
+			"integrity": "sha1-58TxAB7vpLivvR7uJ6I3/uO/KcQ=",
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "16.11.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-			"integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-16.11.7.tgz",
+			"integrity": "sha1-NoIJRQYTJpeMQqAeVrYc0iPf3EI=",
+			"license": "MIT"
 		},
 		"node_modules/@types/responselike": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha1-JR9P59FU0rrRJavhtCmyOv0mLik=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-pj0XWzMXSOUiCtSMkB17vx9E7vg=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/glob": "*",
 				"@types/node": "*"
@@ -365,18 +462,21 @@
 		},
 		"node_modules/@types/vscode": {
 			"version": "1.62.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.62.0.tgz",
+			"integrity": "sha1-tNbRktWut16R0K3vaJw+zvmHnac=",
+			"license": "MIT"
 		},
 		"node_modules/@ungap/promise-all-settled": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+			"integrity": "sha1-qlgEJxHW4ydd033Fl+XTHowpCkQ=",
+			"license": "ISC"
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+			"integrity": "sha1-K/12fq4aaZb0Mv9+jX/HVnnAtqc=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -384,23 +484,27 @@
 		},
 		"node_modules/@webassemblyjs/floating-point-hex-parser": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+			"integrity": "sha1-9sYacF8P16auyqToGY8j2dwXnk8=",
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+			"integrity": "sha1-GmMZLYeI5cASgAump6RscFKI/RY=",
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+			"integrity": "sha1-gyqQDrREiEzemnytRn+BUA9eWrU=",
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+			"integrity": "sha1-ZNgdohn7u6HjvRv8dPboxOEKYq4=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -409,13 +513,15 @@
 		},
 		"node_modules/@webassemblyjs/helper-wasm-bytecode": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+			"integrity": "sha1-8ygkHkHnsZnQsgwY6IQpxEMyleE=",
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+			"integrity": "sha1-Ie4GWntjXzGec48N1zv72igcCXo=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -425,29 +531,33 @@
 		},
 		"node_modules/@webassemblyjs/ieee754": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+			"integrity": "sha1-ljkp6bvQVwnn4SJDoJkYCBKZJhQ=",
+			"license": "MIT",
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"node_modules/@webassemblyjs/leb128": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+			"integrity": "sha1-zoFLRVdOk9drrh+yZEq5zdlSeqU=",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"node_modules/@webassemblyjs/utf8": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+			"integrity": "sha1-0fi3ZDaefG5rrjUOhU3smlnwo/8=",
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+			"integrity": "sha1-rSBuv0v5WgWM6YgKjAksXeyBk9Y=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -461,8 +571,9 @@
 		},
 		"node_modules/@webassemblyjs/wasm-gen": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+			"integrity": "sha1-hsXqMEhJdZt9iMR6MvTwOa48j3Y=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -473,8 +584,9 @@
 		},
 		"node_modules/@webassemblyjs/wasm-opt": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+			"integrity": "sha1-ZXtMIgL0zzs0X4pMZGHIwkGJhfI=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -484,8 +596,9 @@
 		},
 		"node_modules/@webassemblyjs/wasm-parser": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+			"integrity": "sha1-hspzRTT0F+m9PGfHocddi+QfsZk=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -497,63 +610,31 @@
 		},
 		"node_modules/@webassemblyjs/wast-printer": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+			"integrity": "sha1-0Mc77ajuxUJvEK6O9VzuXnCEwvA=",
+			"license": "MIT",
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@xtuc/long": "4.2.2"
 			}
 		},
-		"node_modules/@webpack-cli/configtest": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-			"dev": true,
-			"peerDependencies": {
-				"webpack": "4.x.x || 5.x.x",
-				"webpack-cli": "4.x.x"
-			}
-		},
-		"node_modules/@webpack-cli/info": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-			"integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
-			"dev": true,
-			"dependencies": {
-				"envinfo": "^7.7.3"
-			},
-			"peerDependencies": {
-				"webpack-cli": "4.x.x"
-			}
-		},
-		"node_modules/@webpack-cli/serve": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-			"dev": true,
-			"peerDependencies": {
-				"webpack-cli": "4.x.x"
-			},
-			"peerDependenciesMeta": {
-				"webpack-dev-server": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@xtuc/ieee754": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+			"integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@xtuc/long": {
 			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
+			"license": "Apache-2.0"
 		},
 		"node_modules/acorn": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-			"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+			"version": "8.7.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn/-/acorn-8.7.1.tgz",
+			"integrity": "sha1-AZcSLIQ9G/bQpegyIKeI8nj2PDA=",
+			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -563,16 +644,18 @@
 		},
 		"node_modules/acorn-import-assertions": {
 			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+			"integrity": "sha1-uitZOc5iwjjbbZPYHJsRGym4Vek=",
+			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8"
 			}
 		},
 		"node_modules/agent-base": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+			"license": "MIT",
 			"dependencies": {
 				"debug": "4"
 			},
@@ -582,8 +665,9 @@
 		},
 		"node_modules/aggregate-error": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+			"license": "MIT",
 			"dependencies": {
 				"clean-stack": "^2.0.0",
 				"indent-string": "^4.0.0"
@@ -594,8 +678,9 @@
 		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -609,32 +694,36 @@
 		},
 		"node_modules/ajv-keywords": {
 			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+			"integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
+			"license": "MIT",
 			"peerDependencies": {
 				"ajv": "^6.9.1"
 			}
 		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -647,8 +736,9 @@
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
+			"license": "ISC",
 			"dependencies": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -659,68 +749,74 @@
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
+			"license": "Python-2.0"
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/assertion-error": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+			"license": "MIT"
 		},
 		"node_modules/big-integer": {
-			"version": "1.6.50",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
-			"integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ==",
+			"version": "1.6.51",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/big-integer/-/big-integer-1.6.51.tgz",
+			"integrity": "sha1-DfkqXZiAVg0/8tX9ICRciJ0TBoY=",
+			"license": "Unlicense",
 			"engines": {
 				"node": ">=0.6"
 			}
 		},
 		"node_modules/binary": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary/-/binary-0.3.0.tgz",
 			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+			"license": "MIT",
 			"dependencies": {
 				"buffers": "~0.1.1",
 				"chainsaw": "~0.1.0"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/bluebird": {
 			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bluebird/-/bluebird-3.4.7.tgz",
+			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -728,8 +824,9 @@
 		},
 		"node_modules/braces": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.0.1"
 			},
@@ -739,47 +836,56 @@
 		},
 		"node_modules/browser-stdout": {
 			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+			"license": "ISC"
 		},
 		"node_modules/browserslist": {
-			"version": "4.17.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.6.tgz",
-			"integrity": "sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==",
+			"version": "4.21.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browserslist/-/browserslist-4.21.2.tgz",
+			"integrity": "sha1-WaQAdXRlU1lUlGpAC4Qe034rTs8=",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				}
+			],
+			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001274",
-				"electron-to-chromium": "^1.3.886",
-				"escalade": "^3.1.1",
-				"node-releases": "^2.0.1",
-				"picocolors": "^1.0.0"
+				"caniuse-lite": "^1.0.30001366",
+				"electron-to-chromium": "^1.4.188",
+				"node-releases": "^2.0.6",
+				"update-browserslist-db": "^1.0.4"
 			},
 			"bin": {
 				"browserslist": "cli.js"
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/browserslist"
 			}
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
+			"license": "MIT"
 		},
 		"node_modules/buffer-indexof-polyfill": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+			"integrity": "sha1-0nMhNcWZnGSyd/z5savjSYJUcpw=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10"
 			}
 		},
 		"node_modules/buffers": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffers/-/buffers-0.1.1.tgz",
 			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
 			"engines": {
 				"node": ">=0.2.0"
@@ -787,24 +893,27 @@
 		},
 		"node_modules/builtin-modules": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/cacheable-lookup": {
 			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha1-WmuGWyxENXvj1evCpGewMnGacAU=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.6.0"
 			}
 		},
 		"node_modules/cacheable-request": {
 			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-7.0.2.tgz",
+			"integrity": "sha1-6g0LiJNkolhUdXMByhKy2nf5HSc=",
+			"license": "MIT",
 			"dependencies": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -819,9 +928,10 @@
 			}
 		},
 		"node_modules/camelcase": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+			"version": "6.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -830,18 +940,26 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001279",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-			"integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/browserslist"
-			}
+			"version": "1.0.30001366",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001366.tgz",
+			"integrity": "sha1-xzNSyDgwqery3qD/cftLmku6qJw=",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				}
+			],
+			"license": "CC-BY-4.0"
 		},
 		"node_modules/chai": {
 			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chai/-/chai-4.3.4.tgz",
+			"integrity": "sha1-tV5lWzHh6scJm+TAjCGWT84ubEk=",
+			"license": "MIT",
 			"dependencies": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
@@ -856,8 +974,9 @@
 		},
 		"node_modules/chai-as-promised": {
 			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-			"integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+			"integrity": "sha1-CGRdgl3rhpbuYXJdv1kMAS6wDKA=",
+			"license": "WTFPL",
 			"dependencies": {
 				"check-error": "^1.0.2"
 			},
@@ -867,19 +986,18 @@
 		},
 		"node_modules/chainsaw": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chainsaw/-/chainsaw-0.1.0.tgz",
 			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+			"license": "MIT/X11",
 			"dependencies": {
 				"traverse": ">=0.3.0 <0.4"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -893,8 +1011,9 @@
 		},
 		"node_modules/chalk/node_modules/supports-color": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -904,21 +1023,30 @@
 		},
 		"node_modules/check-error": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/check-error/-/check-error-1.0.2.tgz",
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/child_process": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-			"integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/child_process/-/child_process-1.0.2.tgz",
+			"integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o=",
+			"license": "ISC"
 		},
 		"node_modules/chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha1-HPN8hwe5Mr0a8a4iwEMuKs0ZA70=",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			],
+			"license": "MIT",
 			"dependencies": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -937,8 +1065,9 @@
 		},
 		"node_modules/chokidar/node_modules/glob-parent": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
+			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
 			},
@@ -948,24 +1077,27 @@
 		},
 		"node_modules/chrome-trace-event": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
-			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+			"integrity": "sha1-EBXs7UdB4V0GZkqVfbv1DQQeJqw=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.0"
 			}
 		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
+			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
@@ -974,9 +1106,10 @@
 		},
 		"node_modules/clone-deep": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clone-deep/-/clone-deep-4.0.1.tgz",
+			"integrity": "sha1-wZ/Zvbv4WUK0/ZechNz31fB8I4c=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-plain-object": "^2.0.4",
 				"kind-of": "^6.0.2",
@@ -988,16 +1121,18 @@
 		},
 		"node_modules/clone-response": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^1.0.0"
 			}
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -1007,37 +1142,54 @@
 		},
 		"node_modules/color-name": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+			"license": "MIT"
 		},
 		"node_modules/colorette": {
-			"version": "2.0.16",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
-			"dev": true
+			"version": "2.0.19",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/colorette/-/colorette-2.0.19.tgz",
+			"integrity": "sha1-zfBE9HrUGg9LVrOg1bTm4aLVp5g=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/commander": {
 			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+			"license": "MIT"
+		},
+		"node_modules/compress-brotli": {
+			"version": "1.3.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/compress-brotli/-/compress-brotli-1.3.8.tgz",
+			"integrity": "sha1-DApgyXqYkUUxTsOB6E4maC57ONs=",
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-buffer": "~3.0.0",
+				"json-buffer": "~3.0.1"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"license": "MIT"
 		},
 		"node_modules/copy-webpack-plugin": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
-			"integrity": "sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==",
+			"version": "9.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/copy-webpack-plugin/-/copy-webpack-plugin-9.1.0.tgz",
+			"integrity": "sha1-LSxGDExGlewKWK+ygBoSBSVsTms=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"fast-glob": "^3.2.5",
-				"glob-parent": "^6.0.0",
+				"fast-glob": "^3.2.7",
+				"glob-parent": "^6.0.1",
 				"globby": "^11.0.3",
 				"normalize-path": "^3.0.0",
-				"p-limit": "^3.1.0",
-				"schema-utils": "^3.0.0",
+				"schema-utils": "^3.1.1",
 				"serialize-javascript": "^6.0.0"
 			},
 			"engines": {
@@ -1053,14 +1205,16 @@
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
+			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -1071,9 +1225,10 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
+			"license": "MIT",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -1088,13 +1243,15 @@
 		},
 		"node_modules/debug/node_modules/ms": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+			"license": "MIT"
 		},
 		"node_modules/decamelize": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1104,8 +1261,9 @@
 		},
 		"node_modules/decompress-response": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha1-yjh2Et234QS9FthaqwDV7PCcZvw=",
+			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^3.1.0"
 			},
@@ -1118,8 +1276,9 @@
 		},
 		"node_modules/decompress-response/node_modules/mimic-response": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1129,8 +1288,9 @@
 		},
 		"node_modules/deep-eql": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+			"license": "MIT",
 			"dependencies": {
 				"type-detect": "^4.0.0"
 			},
@@ -1140,33 +1300,37 @@
 		},
 		"node_modules/defer-to-connect": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/define-lazy-prop": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/diff": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"version": "5.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.1.0.tgz",
+			"integrity": "sha1-vFLSmMXqjfkZSAAiREXtQ//IfkA=",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-type": "^4.0.0"
 			},
@@ -1175,9 +1339,10 @@
 			}
 		},
 		"node_modules/dns-packet": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.0.tgz",
-			"integrity": "sha512-Nce7YLu6YCgWRvOmDBsJMo9M5/jV3lEZ5vUWnWXYmwURvPylHvq7nkDWhNmk1ZQoZZOP7oQh/S0lSxbisKOfHg==",
+			"version": "5.4.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dns-packet/-/dns-packet-5.4.0.tgz",
+			"integrity": "sha1-H4hHfPnyfniiE/ttEYrjjnWah5s=",
+			"license": "MIT",
 			"dependencies": {
 				"@leichtgewicht/ip-codec": "^2.0.1"
 			},
@@ -1187,8 +1352,9 @@
 		},
 		"node_modules/dns-socket": {
 			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.2.tgz",
-			"integrity": "sha512-BDeBd8najI4/lS00HSKpdFia+OvUMytaVjfzR9n5Lq8MlZRSvtbI+uLtx1+XmQFls5wFU9dssccTmQQ6nfpjdg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dns-socket/-/dns-socket-4.2.2.tgz",
+			"integrity": "sha1-WLAYbsBT6gcx/rBng8furEuVthY=",
+			"license": "MIT",
 			"dependencies": {
 				"dns-packet": "^5.2.4"
 			},
@@ -1198,39 +1364,45 @@
 		},
 		"node_modules/duplexer2": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer2/-/duplexer2-0.1.4.tgz",
 			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"readable-stream": "^2.0.2"
 			}
 		},
 		"node_modules/duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+			"version": "0.1.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer3/-/duplexer3-0.1.5.tgz",
+			"integrity": "sha1-C15Ne61d6JAepEQGJMjh0gCZIX4=",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.893",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.893.tgz",
-			"integrity": "sha512-ChtwF7qB03INq1SyMpue08wc6cve+ktj2UC/Y7se9vB+JryfzziJeYwsgb8jLaCA5GMkHCdn5M62PfSMWhifZg=="
+			"version": "1.4.191",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.191.tgz",
+			"integrity": "sha1-Ad1L8yUCpIziS/OJC1VTocX5NTk=",
+			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+			"license": "MIT"
 		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-			"integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+			"version": "5.10.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+			"integrity": "sha1-DcV5w7sqEDLjV6xFuPOm861PseY=",
+			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
 				"tapable": "^2.2.0"
@@ -1241,9 +1413,10 @@
 		},
 		"node_modules/envinfo": {
 			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
-			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/envinfo/-/envinfo-7.8.1.tgz",
+			"integrity": "sha1-Bjd+Pl9NN5/qesWS1a2JJ+DE1HU=",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"envinfo": "dist/cli.js"
 			},
@@ -1253,21 +1426,24 @@
 		},
 		"node_modules/es-module-lexer": {
 			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+			"integrity": "sha1-bxPbAMw4QXE32vdDZvU1yOtDjxk=",
+			"license": "MIT"
 		},
 		"node_modules/escalade": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1277,8 +1453,9 @@
 		},
 		"node_modules/eslint-scope": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
@@ -1289,8 +1466,9 @@
 		},
 		"node_modules/esprima": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+			"license": "BSD-2-Clause",
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -1301,8 +1479,9 @@
 		},
 		"node_modules/esrecurse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -1312,33 +1491,37 @@
 		},
 		"node_modules/esrecurse/node_modules/estraverse": {
 			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
 			}
 		},
 		"node_modules/estraverse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
 			}
 		},
 		"node_modules/events": {
 			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/events/-/events-3.3.0.tgz",
+			"integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.x"
 			}
 		},
 		"node_modules/execa": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cross-spawn": "^7.0.3",
 				"get-stream": "^6.0.0",
@@ -1359,9 +1542,10 @@
 		},
 		"node_modules/execa/node_modules/get-stream": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1371,14 +1555,16 @@
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-			"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+			"version": "3.2.11",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-glob/-/fast-glob-3.2.11.tgz",
+			"integrity": "sha1-oRcq2VzrihbiDKpcXlZIDlEpwdk=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -1387,14 +1573,15 @@
 				"micromatch": "^4.0.4"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=8.6.0"
 			}
 		},
 		"node_modules/fast-glob/node_modules/glob-parent": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
 			},
@@ -1404,28 +1591,32 @@
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+			"license": "MIT"
 		},
 		"node_modules/fastest-levenshtein": {
 			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
-			"integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+			"integrity": "sha1-mZD306iMxan/0fF0V0UlFwDUl+I=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fastq": {
 			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fastq/-/fastq-1.13.0.tgz",
+			"integrity": "sha1-YWdg+Ip1Jr38WWt8q4wYk4w2uYw=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
 			}
 		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -1435,8 +1626,9 @@
 		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
+			"license": "MIT",
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -1450,22 +1642,24 @@
 		},
 		"node_modules/flat": {
 			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE=",
+			"license": "BSD-3-Clause",
 			"bin": {
 				"flat": "cli.js"
 			}
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"license": "ISC"
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"hasInstallScript": true,
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1476,8 +1670,9 @@
 		},
 		"node_modules/fstream": {
 			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
+			"license": "ISC",
 			"dependencies": {
 				"graceful-fs": "^4.1.2",
 				"inherits": "~2.0.0",
@@ -1490,8 +1685,9 @@
 		},
 		"node_modules/fstream/node_modules/rimraf": {
 			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+			"license": "ISC",
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -1501,29 +1697,33 @@
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+			"license": "MIT"
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
 		"node_modules/get-func-name": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-func-name/-/get-func-name-2.0.0.tgz",
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/get-stream": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
+			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0"
 			},
@@ -1535,14 +1735,15 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+			"version": "7.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			},
@@ -1555,9 +1756,10 @@
 		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -1567,20 +1769,22 @@
 		},
 		"node_modules/glob-to-regexp": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+			"integrity": "sha1-x1KXCHyFG5pXi9IX3VmpL1n+VG4=",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/globby": {
-			"version": "11.0.4",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-			"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+			"version": "11.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha1-vUvpi7BC+D15b344EZkfvoKg00s=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.1.1",
-				"ignore": "^5.1.4",
-				"merge2": "^1.3.0",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -1591,16 +1795,17 @@
 			}
 		},
 		"node_modules/got": {
-			"version": "11.8.2",
-			"resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-			"integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+			"version": "11.8.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz",
+			"integrity": "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY=",
+			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/is": "^4.0.0",
 				"@szmarczak/http-timer": "^4.0.5",
 				"@types/cacheable-request": "^6.0.1",
 				"@types/responselike": "^1.0.0",
 				"cacheable-lookup": "^5.0.3",
-				"cacheable-request": "^7.0.1",
+				"cacheable-request": "^7.0.2",
 				"decompress-response": "^6.0.0",
 				"http2-wrapper": "^1.0.0-beta.5.2",
 				"lowercase-keys": "^2.0.0",
@@ -1615,22 +1820,25 @@
 			}
 		},
 		"node_modules/graceful-fs": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+			"version": "4.2.10",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha1-FH06AG2kyjzhRyjHrvwofDZ9emw=",
+			"license": "ISC"
 		},
 		"node_modules/growl": {
 			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.x"
 			}
 		},
 		"node_modules/has": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has/-/has-1.0.3.tgz",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.1"
 			},
@@ -1640,16 +1848,18 @@
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/hash.js": {
 			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -1657,16 +1867,18 @@
 		},
 		"node_modules/he": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/he/-/he-1.2.0.tgz",
+			"integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
+			"license": "MIT",
 			"bin": {
 				"he": "bin/he"
 			}
 		},
 		"node_modules/hmac-drbg": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"license": "MIT",
 			"dependencies": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -1675,13 +1887,15 @@
 		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+			"integrity": "sha1-SekcXL82yblLz81xwj1SSex045A=",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
+			"license": "MIT",
 			"dependencies": {
 				"@tootallnate/once": "1",
 				"agent-base": "6",
@@ -1693,8 +1907,9 @@
 		},
 		"node_modules/http2-wrapper": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha1-uPVeDB8l1OvQizsMLAeflZCACz0=",
+			"license": "MIT",
 			"dependencies": {
 				"quick-lru": "^5.1.1",
 				"resolve-alpn": "^1.0.0"
@@ -1704,9 +1919,10 @@
 			}
 		},
 		"node_modules/https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+			"license": "MIT",
 			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
@@ -1717,27 +1933,30 @@
 		},
 		"node_modules/human-signals": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.17.0"
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-			"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+			"version": "5.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ignore/-/ignore-5.2.0.tgz",
+			"integrity": "sha1-bTusj6f+DUXZ+b57rC/CeVd+NFo=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
 		},
 		"node_modules/import-local": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
-			"integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
+			"version": "3.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/import-local/-/import-local-3.1.0.tgz",
+			"integrity": "sha1-tEed+KX9RPbNziQHBnVnYGPJXLQ=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"pkg-dir": "^4.2.0",
 				"resolve-cwd": "^3.0.0"
@@ -1747,20 +1966,25 @@
 			},
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/indent-string": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"license": "ISC",
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1768,29 +1992,33 @@
 		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+			"license": "ISC"
 		},
 		"node_modules/interpret": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/interpret/-/interpret-1.4.0.tgz",
+			"integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
 			}
 		},
 		"node_modules/ip-regex": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-			"integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ip-regex/-/ip-regex-4.3.0.tgz",
+			"integrity": "sha1-aHJ1qw9X+naXj/j03dyKI9WZDbU=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+			"license": "MIT",
 			"dependencies": {
 				"binary-extensions": "^2.0.0"
 			},
@@ -1799,9 +2027,10 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-			"integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+			"version": "2.9.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha1-4cNEKc1Rxt2eCeB5njluJ7GanGk=",
+			"license": "MIT",
 			"dependencies": {
 				"has": "^1.0.3"
 			},
@@ -1811,8 +2040,9 @@
 		},
 		"node_modules/is-docker": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=",
+			"license": "MIT",
 			"bin": {
 				"is-docker": "cli.js"
 			},
@@ -1825,24 +2055,27 @@
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
+			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
 			},
@@ -1852,8 +2085,9 @@
 		},
 		"node_modules/is-ip": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-ip/-/is-ip-3.1.0.tgz",
+			"integrity": "sha1-KuXd+vrwXLgAimIJPPKXNPZXxdg=",
+			"license": "MIT",
 			"dependencies": {
 				"ip-regex": "^4.0.0"
 			},
@@ -1863,16 +2097,18 @@
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
 		},
 		"node_modules/is-online": {
 			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/is-online/-/is-online-9.0.1.tgz",
-			"integrity": "sha512-+08dRW0dcFOtleR2N3rHRVxDyZtQitUp9cC+KpKTds0mXibbQyW5js7xX0UGyQXkaLUJObe0w6uQ4ex34lX9LA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-9.0.1.tgz",
+			"integrity": "sha1-caNCAvqCa65vP/i+pCDFZXNEil8=",
+			"license": "MIT",
 			"dependencies": {
 				"got": "^11.8.0",
 				"p-any": "^3.0.0",
@@ -1888,17 +2124,19 @@
 		},
 		"node_modules/is-plain-obj": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/is-plain-object": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"isobject": "^3.0.1"
 			},
@@ -1908,9 +2146,10 @@
 		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -1920,8 +2159,9 @@
 		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1931,8 +2171,9 @@
 		},
 		"node_modules/is-wsl": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+			"license": "MIT",
 			"dependencies": {
 				"is-docker": "^2.0.0"
 			},
@@ -1942,27 +2183,31 @@
 		},
 		"node_modules/isarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"license": "MIT"
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"license": "ISC"
 		},
 		"node_modules/isobject": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/jest-worker": {
-			"version": "27.3.1",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
-			"integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
+			"version": "27.5.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jest-worker/-/jest-worker-27.5.1.tgz",
+			"integrity": "sha1-jRRvCQDolzsQa29zzB6ajLhvjbA=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -1974,13 +2219,15 @@
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
+			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -1990,53 +2237,62 @@
 		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
+			"license": "MIT"
 		},
 		"node_modules/json-parse-better-errors": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+			"license": "MIT"
 		},
 		"node_modules/keyv": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
-			"integrity": "sha512-vqNHbAc8BBsxk+7QBYLW0Y219rWcClspR6WSeoHYKG5mnsSoOH+BL1pWq02DDCVdvvuUny5rkBlzMRzoqc+GIg==",
+			"version": "4.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.3.2.tgz",
+			"integrity": "sha1-6DnfZ2oMfuWUyINefByDdCVY5cI=",
+			"license": "MIT",
 			"dependencies": {
+				"compress-brotli": "^1.3.8",
 				"json-buffer": "3.0.1"
 			}
 		},
 		"node_modules/kind-of": {
 			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/listenercount": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/listenercount/-/listenercount-1.0.1.tgz",
+			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+			"license": "ISC"
 		},
 		"node_modules/loader-runner": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
-			"integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
+			"version": "4.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/loader-runner/-/loader-runner-4.3.0.tgz",
+			"integrity": "sha1-wbShY7mfYUgwNTsWdV5xSawjFOE=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.11.5"
 			}
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
+			"license": "MIT",
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -2049,8 +2305,9 @@
 		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
+			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"is-unicode-supported": "^0.1.0"
@@ -2064,16 +2321,18 @@
 		},
 		"node_modules/lowercase-keys": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+			"license": "ISC",
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -2083,44 +2342,49 @@
 		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+			"license": "MIT"
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"version": "4.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/micromatch/-/micromatch-4.0.5.tgz",
+			"integrity": "sha1-vImZp8u/d83InxMvbkZwUbSQkMY=",
+			"license": "MIT",
 			"dependencies": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
+				"braces": "^3.0.2",
+				"picomatch": "^2.3.1"
 			},
 			"engines": {
 				"node": ">=8.6"
 			}
 		},
 		"node_modules/mime-db": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-			"integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+			"version": "1.52.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mime-types": {
-			"version": "2.1.34",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-			"integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+			"version": "2.1.35",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
+			"license": "MIT",
 			"dependencies": {
-				"mime-db": "1.51.0"
+				"mime-db": "1.52.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
@@ -2128,35 +2392,40 @@
 		},
 		"node_modules/mimic-fn": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/mimic-response": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/minimalistic-assert": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+			"license": "ISC"
 		},
 		"node_modules/minimalistic-crypto-utils": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+			"license": "MIT"
 		},
 		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -2165,47 +2434,50 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q=",
+			"license": "MIT"
 		},
 		"node_modules/mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
+			"license": "MIT",
 			"dependencies": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			},
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			}
 		},
 		"node_modules/mocha": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-			"integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+			"version": "9.2.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mocha/-/mocha-9.2.2.tgz",
+			"integrity": "sha1-1w20a9uTyldALICTM+WoSXeoj7k=",
+			"license": "MIT",
 			"dependencies": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.2",
-				"debug": "4.3.2",
+				"chokidar": "3.5.3",
+				"debug": "4.3.3",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
-				"glob": "7.1.7",
+				"glob": "7.2.0",
 				"growl": "1.10.5",
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
-				"minimatch": "3.0.4",
+				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
+				"nanoid": "3.3.1",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"workerpool": "6.1.5",
+				"workerpool": "6.2.0",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
@@ -2222,10 +2494,20 @@
 				"url": "https://opencollective.com/mochajs"
 			}
 		},
+		"node_modules/mocha/node_modules/diff": {
+			"version": "5.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha1-ftatdthZ0DB4fsNYVfWx2vMdhSs=",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/mocha/node_modules/glob": {
-			"version": "7.1.7",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"version": "7.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
+			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -2241,15 +2523,41 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/mocha/node_modules/minimatch": {
+			"version": "4.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-4.2.1.tgz",
+			"integrity": "sha1-QNnVEaRr3E5WPCLDCAzenA2CmbQ=",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+			"version": "3.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha1-Y0ehjKyIr4j1ivCzWUtyPV6ZuzU=",
+			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -2259,26 +2567,30 @@
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
+			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+			"version": "2.0.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-releases/-/node-releases-2.0.6.tgz",
+			"integrity": "sha1-inCIxjpV5JOEVoPr88go2MUcVQM=",
+			"license": "MIT"
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/normalize-url": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -2288,9 +2600,10 @@
 		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.0.0"
 			},
@@ -2300,17 +2613,19 @@
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
 			}
 		},
 		"node_modules/onetime": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"mimic-fn": "^2.1.0"
 			},
@@ -2323,8 +2638,9 @@
 		},
 		"node_modules/open": {
 			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-			"integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-8.4.0.tgz",
+			"integrity": "sha1-NFMhrhj4E4+CVlqRD9xrOejCRPg=",
+			"license": "MIT",
 			"dependencies": {
 				"define-lazy-prop": "^2.0.0",
 				"is-docker": "^2.1.1",
@@ -2339,8 +2655,9 @@
 		},
 		"node_modules/p-any": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-any/-/p-any-3.0.0.tgz",
-			"integrity": "sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-3.0.0.tgz",
+			"integrity": "sha1-eYR67tcLXToQ6mJSlsDD0ukKh7k=",
+			"license": "MIT",
 			"dependencies": {
 				"p-cancelable": "^2.0.0",
 				"p-some": "^5.0.0"
@@ -2354,24 +2671,27 @@
 		},
 		"node_modules/p-cancelable": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/p-finally": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
+			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -2384,8 +2704,9 @@
 		},
 		"node_modules/p-locate": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
+			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -2398,8 +2719,9 @@
 		},
 		"node_modules/p-some": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
-			"integrity": "sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-5.0.0.tgz",
+			"integrity": "sha1-i3MMdLT+UWnXJkokCtAQtuvGhqQ=",
+			"license": "MIT",
 			"dependencies": {
 				"aggregate-error": "^3.0.0",
 				"p-cancelable": "^2.0.0"
@@ -2413,8 +2735,9 @@
 		},
 		"node_modules/p-timeout": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
+			"license": "MIT",
 			"dependencies": {
 				"p-finally": "^1.0.0"
 			},
@@ -2424,69 +2747,78 @@
 		},
 		"node_modules/p-try": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
+			"license": "MIT"
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/pathval": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha1-hTTnenfOesWiUS6iHg/bj89sPY0=",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw=",
+			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+			"version": "2.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -2496,9 +2828,10 @@
 		},
 		"node_modules/pkg-dir": {
 			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"find-up": "^4.0.0"
 			},
@@ -2508,9 +2841,10 @@
 		},
 		"node_modules/pkg-dir/node_modules/find-up": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
@@ -2521,9 +2855,10 @@
 		},
 		"node_modules/pkg-dir/node_modules/locate-path": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-locate": "^4.1.0"
 			},
@@ -2533,9 +2868,10 @@
 		},
 		"node_modules/pkg-dir/node_modules/p-limit": {
 			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-try": "^2.0.0"
 			},
@@ -2548,9 +2884,10 @@
 		},
 		"node_modules/pkg-dir/node_modules/p-locate": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^2.2.0"
 			},
@@ -2560,21 +2897,24 @@
 		},
 		"node_modules/prepend-http": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prepend-http/-/prepend-http-2.0.0.tgz",
 			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+			"license": "MIT"
 		},
 		"node_modules/public-ip": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/public-ip/-/public-ip-4.0.4.tgz",
-			"integrity": "sha512-EJ0VMV2vF6Cu7BIPo3IMW1Maq6ME+fbR0NcPmqDfpfNGIRPue1X8QrGjrg/rfjDkOsIkKHIf2S5FlEa48hFMTA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-4.0.4.tgz",
+			"integrity": "sha1-s3hKWh/xuB0BW5oYRQvmX/2SnrM=",
+			"license": "MIT",
 			"dependencies": {
 				"dns-socket": "^4.2.2",
 				"got": "^9.6.0",
@@ -2589,16 +2929,18 @@
 		},
 		"node_modules/public-ip/node_modules/@sindresorhus/is": {
 			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-0.14.0.tgz",
+			"integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/public-ip/node_modules/@szmarczak/http-timer": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+			"integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
+			"license": "MIT",
 			"dependencies": {
 				"defer-to-connect": "^1.0.1"
 			},
@@ -2608,8 +2950,9 @@
 		},
 		"node_modules/public-ip/node_modules/cacheable-request": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-6.1.0.tgz",
+			"integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
+			"license": "MIT",
 			"dependencies": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -2625,8 +2968,9 @@
 		},
 		"node_modules/public-ip/node_modules/decompress-response": {
 			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-3.3.0.tgz",
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^1.0.0"
 			},
@@ -2636,13 +2980,15 @@
 		},
 		"node_modules/public-ip/node_modules/defer-to-connect": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+			"integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE=",
+			"license": "MIT"
 		},
 		"node_modules/public-ip/node_modules/got": {
 			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-9.6.0.tgz",
+			"integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
+			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/is": "^0.14.0",
 				"@szmarczak/http-timer": "^1.1.2",
@@ -2662,8 +3008,9 @@
 		},
 		"node_modules/public-ip/node_modules/got/node_modules/get-stream": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0"
 			},
@@ -2673,61 +3020,69 @@
 		},
 		"node_modules/public-ip/node_modules/got/node_modules/lowercase-keys": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/public-ip/node_modules/json-buffer": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+			"license": "MIT"
 		},
 		"node_modules/public-ip/node_modules/keyv": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-3.1.0.tgz",
+			"integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
+			"license": "MIT",
 			"dependencies": {
 				"json-buffer": "3.0.0"
 			}
 		},
 		"node_modules/public-ip/node_modules/normalize-url": {
 			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-4.5.1.tgz",
+			"integrity": "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/public-ip/node_modules/p-cancelable": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-1.1.0.tgz",
+			"integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/public-ip/node_modules/responselike": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-1.0.2.tgz",
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"license": "MIT",
 			"dependencies": {
 				"lowercase-keys": "^1.0.0"
 			}
 		},
 		"node_modules/public-ip/node_modules/responselike/node_modules/lowercase-keys": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -2735,174 +3090,17 @@
 		},
 		"node_modules/punycode": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/quick-lru": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
-		"node_modules/readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/readable-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-		},
-		"node_modules/readdirp": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-			"dependencies": {
-				"picomatch": "^2.2.1"
-			},
-			"engines": {
-				"node": ">=8.10.0"
-			}
-		},
-		"node_modules/rechoir": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-			"dependencies": {
-				"resolve": "^1.1.6"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dependencies": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/resolve-alpn": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
-		},
-		"node_modules/resolve-cwd": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-			"dev": true,
-			"dependencies": {
-				"resolve-from": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/responselike": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-			"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
-			"dependencies": {
-				"lowercase-keys": "^2.0.0"
-			}
-		},
-		"node_modules/reusify": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-			"dev": true,
-			"engines": {
-				"iojs": ">=1.0.0",
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/run-parallel": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
 			"dev": true,
 			"funding": [
 				{
@@ -2918,14 +3116,168 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
+			"license": "MIT"
+		},
+		"node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha1-NmST5rPkKjpoheLpnRj4D7eoyTI=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+		"node_modules/randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/readable-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+			"license": "MIT"
+		},
+		"node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
+			"license": "MIT",
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dependencies": {
+				"resolve": "^1.1.6"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.22.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha1-J8suu1P5GrtJRwqSi7p1WAZqwXc=",
+			"license": "MIT",
+			"dependencies": {
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve-alpn": {
+			"version": "1.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha1-t629rDVGqq7CC0Xn2CZZJwcnJvk=",
+			"license": "MIT"
+		},
+		"node_modules/resolve-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/responselike": {
+			"version": "2.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-2.0.0.tgz",
+			"integrity": "sha1-JjkbzDF091D5p56sxAoSpcQtdyM=",
+			"license": "MIT",
+			"dependencies": {
+				"lowercase-keys": "^2.0.0"
+			}
+		},
+		"node_modules/reusify": {
+			"version": "1.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2939,12 +3291,37 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"license": "MIT",
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/schema-utils": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/schema-utils/-/schema-utils-3.1.1.tgz",
+			"integrity": "sha1-vHTEtraZXB2I92qLd76nIZ4MgoE=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/json-schema": "^7.0.8",
 				"ajv": "^6.12.5",
@@ -2959,9 +3336,10 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha1-EsW2Sa/b+QSXB3luIqQCiBTOUj8=",
+			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -2974,22 +3352,25 @@
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+			"integrity": "sha1-765diPRdeSQUHai1w6en5mP+/rg=",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
 		},
 		"node_modules/setimmediate": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"license": "MIT"
 		},
 		"node_modules/shallow-clone": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shallow-clone/-/shallow-clone-3.0.1.tgz",
+			"integrity": "sha1-jymBrZJTH1UDWwH7IwdppA4C76M=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"kind-of": "^6.0.2"
 			},
@@ -2999,9 +3380,10 @@
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -3011,17 +3393,19 @@
 		},
 		"node_modules/shebang-regex": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/shelljs": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-			"integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+			"version": "0.8.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
+			"integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -3035,32 +3419,36 @@
 			}
 		},
 		"node_modules/signal-exit": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-			"integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
-			"dev": true
+			"version": "3.0.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/source-map-support": {
-			"version": "0.5.20",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-			"integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+			"version": "0.5.21",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha1-BP58f54e0tZiIzwoyys1ufY/bk8=",
+			"license": "MIT",
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -3068,26 +3456,30 @@
 		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/string_decoder/node_modules/safe-buffer": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+			"license": "MIT"
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -3099,8 +3491,9 @@
 		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -3110,17 +3503,19 @@
 		},
 		"node_modules/strip-final-newline": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -3130,8 +3525,9 @@
 		},
 		"node_modules/supports-color": {
 			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -3142,21 +3538,36 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/tapable": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha1-GWenPvQGCoLxKrlq+G1S/bdu7KA=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.9.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
-			"integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
+			"version": "5.14.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/terser/-/terser-5.14.2.tgz",
+			"integrity": "sha1-msnyKwaZTXNhdPQJGqNo24lvHBA=",
+			"license": "BSD-2-Clause",
 			"dependencies": {
+				"@jridgewell/source-map": "^0.3.2",
+				"acorn": "^8.5.0",
 				"commander": "^2.20.0",
-				"source-map": "~0.7.2",
 				"source-map-support": "~0.5.20"
 			},
 			"bin": {
@@ -3166,59 +3577,20 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/terser-webpack-plugin": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz",
-			"integrity": "sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==",
-			"dependencies": {
-				"jest-worker": "^27.0.6",
-				"schema-utils": "^3.1.1",
-				"serialize-javascript": "^6.0.0",
-				"source-map": "^0.6.1",
-				"terser": "^5.7.2"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "^5.1.0"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"esbuild": {
-					"optional": true
-				},
-				"uglify-js": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/terser/node_modules/source-map": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-			"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/to-readable-stream": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+			"integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -3228,16 +3600,15 @@
 		},
 		"node_modules/traverse": {
 			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/traverse/-/traverse-0.3.9.tgz",
 			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
-			"engines": {
-				"node": "*"
-			}
+			"license": "MIT/X11"
 		},
 		"node_modules/ts-loader": {
-			"version": "9.2.6",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
-			"integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
+			"version": "9.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ts-loader/-/ts-loader-9.3.1.tgz",
+			"integrity": "sha1-/iXMpW4+ccEIf+SNxn9N+MWbItQ=",
+			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"enhanced-resolve": "^5.0.0",
@@ -3254,13 +3625,15 @@
 		},
 		"node_modules/tslib": {
 			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
+			"license": "0BSD"
 		},
 		"node_modules/tslint": {
 			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslint/-/tslint-5.20.1.tgz",
+			"integrity": "sha1-5AHortoBUrxE3QfmFANPP4DGe30=",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
 				"builtin-modules": "^1.1.1",
@@ -3288,8 +3661,9 @@
 		},
 		"node_modules/tslint/node_modules/ansi-styles": {
 			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -3299,16 +3673,18 @@
 		},
 		"node_modules/tslint/node_modules/argparse": {
 			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+			"license": "MIT",
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
 		},
 		"node_modules/tslint/node_modules/chalk": {
 			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -3320,45 +3696,51 @@
 		},
 		"node_modules/tslint/node_modules/color-convert": {
 			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
 		},
 		"node_modules/tslint/node_modules/color-name": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"license": "MIT"
 		},
 		"node_modules/tslint/node_modules/diff": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/tslint/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/tslint/node_modules/has-flag": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/tslint/node_modules/js-yaml": {
 			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
+			"license": "MIT",
 			"dependencies": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -3369,16 +3751,18 @@
 		},
 		"node_modules/tslint/node_modules/semver": {
 			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
 			}
 		},
 		"node_modules/tslint/node_modules/supports-color": {
 			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -3386,10 +3770,11 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/tsutils": {
+		"node_modules/tslint/node_modules/tsutils": {
 			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "^1.8.1"
 			},
@@ -3399,16 +3784,18 @@
 		},
 		"node_modules/type-detect": {
 			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/typescript": {
 			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha1-LNAaGh8WBwTTEB/VpY/w+fy4Aww=",
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3419,8 +3806,9 @@
 		},
 		"node_modules/unzipper": {
 			"version": "0.10.11",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unzipper/-/unzipper-0.10.11.tgz",
+			"integrity": "sha1-C0mRRGRyy9uS7nQDkJ8mwkGceC4=",
+			"license": "MIT",
 			"dependencies": {
 				"big-integer": "^1.6.17",
 				"binary": "~0.3.0",
@@ -3434,18 +3822,46 @@
 				"setimmediate": "~1.0.4"
 			}
 		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
+			"integrity": "sha1-2/xaeJyqJrHbiZB5bCyOu84wSCQ=",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			},
+			"bin": {
+				"browserslist-lint": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
 		},
 		"node_modules/url-parse-lax": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+			"license": "MIT",
 			"dependencies": {
 				"prepend-http": "^2.0.0"
 			},
@@ -3455,8 +3871,9 @@
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"license": "MIT"
 		},
 		"node_modules/vscode-dotnet-runtime-library": {
 			"resolved": "../vscode-dotnet-runtime-library",
@@ -3464,8 +3881,9 @@
 		},
 		"node_modules/vscode-test": {
 			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vscode-test/-/vscode-test-1.6.1.tgz",
+			"integrity": "sha1-RCVMZwNt6SsA/dcvas5fGFThpWM=",
+			"license": "MIT",
 			"dependencies": {
 				"http-proxy-agent": "^4.0.1",
 				"https-proxy-agent": "^5.0.0",
@@ -3477,9 +3895,10 @@
 			}
 		},
 		"node_modules/watchpack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-			"integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+			"version": "2.4.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/watchpack/-/watchpack-2.4.0.tgz",
+			"integrity": "sha1-+jMDI3SWLHgRP5PH8vtMVMmGKl0=",
+			"license": "MIT",
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -3490,8 +3909,9 @@
 		},
 		"node_modules/webpack": {
 			"version": "5.63.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.63.0.tgz",
-			"integrity": "sha512-HYrw6bkj/MDmphAXvqLEvn2fVoDZsYu6O638WjK6lSNgIpjb5jl/KtOrqJyU9EC/ZV9mLUmZW5h4mASB+CVA4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack/-/webpack-5.63.0.tgz",
+			"integrity": "sha1-SwdBFYAOBSbYURKYXkbGS5XgSq8=",
+			"license": "MIT",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.0",
 				"@types/estree": "^0.0.50",
@@ -3536,9 +3956,10 @@
 		},
 		"node_modules/webpack-cli": {
 			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-			"integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-cli/-/webpack-cli-4.9.1.tgz",
+			"integrity": "sha1-tkvoJeLRsTDyhcMUyqOxuppGMrM=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^1.1.0",
@@ -3577,29 +3998,71 @@
 				}
 			}
 		},
+		"node_modules/webpack-cli/node_modules/@webpack-cli/configtest": {
+			"version": "1.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+			"integrity": "sha1-eyDOHBJTORLDshfqaCYjZfoppvU=",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"webpack": "4.x.x || 5.x.x",
+				"webpack-cli": "4.x.x"
+			}
+		},
+		"node_modules/webpack-cli/node_modules/@webpack-cli/info": {
+			"version": "1.5.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webpack-cli/info/-/info-1.5.0.tgz",
+			"integrity": "sha1-bHjBPFh0hS1uLdF/CKQfP+TCYbE=",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"envinfo": "^7.7.3"
+			},
+			"peerDependencies": {
+				"webpack-cli": "4.x.x"
+			}
+		},
+		"node_modules/webpack-cli/node_modules/@webpack-cli/serve": {
+			"version": "1.7.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webpack-cli/serve/-/serve-1.7.0.tgz",
+			"integrity": "sha1-4Zk2iaxC0rFukZQ3bPtnU/YlTbE=",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"webpack-cli": "4.x.x"
+			},
+			"peerDependenciesMeta": {
+				"webpack-dev-server": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/webpack-cli/node_modules/commander": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha1-o2y1fQtQHOEI5NIFWaFQo5HZerc=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 10"
 			}
 		},
 		"node_modules/webpack-cli/node_modules/interpret": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-			"integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/interpret/-/interpret-2.2.0.tgz",
+			"integrity": "sha1-GnigtZZcQKVBbQB61vUK0nxBffk=",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
 			}
 		},
 		"node_modules/webpack-cli/node_modules/rechoir": {
 			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-			"integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rechoir/-/rechoir-0.7.1.tgz",
+			"integrity": "sha1-lHipahyhNbXoj8An8D7pLWxkVoY=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"resolve": "^1.9.0"
 			},
@@ -3609,9 +4072,10 @@
 		},
 		"node_modules/webpack-merge": {
 			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-			"integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-merge/-/webpack-merge-5.8.0.tgz",
+			"integrity": "sha1-Kznb8ir4d3atdEw5AiNzHTCmj2E=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"clone-deep": "^4.0.1",
 				"wildcard": "^2.0.0"
@@ -3621,17 +4085,53 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-			"integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
+			"version": "3.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-sources/-/webpack-sources-3.2.3.tgz",
+			"integrity": "sha1-LU2quEUf1LJAzCcFX/agwszqDN4=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/webpack/node_modules/terser-webpack-plugin": {
+			"version": "5.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
+			"integrity": "sha1-gDPbh23Vh1SHIT6Hxie8oyPl7ZA=",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.7",
+				"jest-worker": "^27.4.5",
+				"schema-utils": "^3.1.1",
+				"serialize-javascript": "^6.0.0",
+				"terser": "^5.7.2"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"uglify-js": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
+			"integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -3644,19 +4144,22 @@
 		},
 		"node_modules/wildcard": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-			"integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
-			"dev": true
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wildcard/-/wildcard-2.0.0.tgz",
+			"integrity": "sha1-p30g5SAMb6qsl55LOq3Hs91/j+w=",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/workerpool": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-			"integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw=="
+			"version": "6.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/workerpool/-/workerpool-6.2.0.tgz",
+			"integrity": "sha1-gn2Tyboj7iAZw/+v9cJ/zOoonos=",
+			"license": "Apache-2.0"
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -3671,26 +4174,30 @@
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"license": "ISC"
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
+			"license": "ISC",
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+			"license": "ISC"
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
+			"license": "MIT",
 			"dependencies": {
 				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
@@ -3706,16 +4213,18 @@
 		},
 		"node_modules/yargs-parser": {
 			"version": "20.2.4",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-parser/-/yargs-parser-20.2.4.tgz",
+			"integrity": "sha1-tCiQ8UVmeW+Fro46JSkNIF8VSlQ=",
+			"license": "ISC",
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/yargs-unparser": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
+			"license": "MIT",
 			"dependencies": {
 				"camelcase": "^6.0.0",
 				"decamelize": "^4.0.0",
@@ -3728,8 +4237,9 @@
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -3740,40 +4250,40 @@
 	},
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-			"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha1-OyXTjIlgC6otzCGe36iKdOssQno=",
 			"requires": {
-				"@babel/highlight": "^7.16.0"
+				"@babel/highlight": "^7.18.6"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.15.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha1-nJfjDTGyuMcqHQiYTyyptXTXoHY="
 		},
 		"@babel/highlight": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-			"integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+			"version": "7.18.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha1-gRWGAek+JWN5Wty/vfXWS+Py7N8=",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
 					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -3782,31 +4292,31 @@
 				},
 				"color-convert": {
 					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
 					"requires": {
 						"color-name": "1.1.3"
 					}
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -3814,20 +4324,63 @@
 			}
 		},
 		"@discoveryjs/json-ext": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
-			"integrity": "sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==",
+			"version": "0.5.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+			"integrity": "sha1-HVcr+74Ut3BOC6Dzm3SBW4SHDXA=",
 			"dev": true
 		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+			"integrity": "sha1-wa7cYehT8rufXf5tRELTtWWyU7k=",
+			"requires": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+			"integrity": "sha1-IgOxGMFXchrd/mnUe3BGVGMGbXg="
+		},
+		"@jridgewell/set-array": {
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"integrity": "sha1-fGz5mNbSC5FMClWpGuko/yWWXnI="
+		},
+		"@jridgewell/source-map": {
+			"version": "0.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+			"integrity": "sha1-9FNRqu1FJ6KYUS7HL4EEDJmFgPs=",
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha1-rdTJjTQUcqKJGQtCTvvbCWmRuyQ="
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.14",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+			"integrity": "sha1-sjGggdj2Z5bkda1Yih70cxEnAe0=",
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"@leichtgewicht/ip-codec": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
-			"integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+			"version": "2.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+			"integrity": "sha1-sqxibWy5yHGKtFkWbUu0Bbj/p4s="
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "2.0.5",
@@ -3836,14 +4389,14 @@
 		},
 		"@nodelib/fs.stat": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
 			"dev": true
 		},
 		"@nodelib/fs.walk": {
 			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.5",
@@ -3851,27 +4404,27 @@
 			}
 		},
 		"@sindresorhus/is": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-			"integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
+			"version": "4.6.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha1-PHycRuZ4/u/nouW7YJ09vWZf+z8="
 		},
 		"@szmarczak/http-timer": {
 			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac=",
 			"requires": {
 				"defer-to-connect": "^2.0.0"
 			}
 		},
 		"@tootallnate/once": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I="
 		},
 		"@types/cacheable-request": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
-			"integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+			"integrity": "sha1-wyTaAZfeCpiiMSFWU2riYkKf9rk=",
 			"requires": {
 				"@types/http-cache-semantics": "*",
 				"@types/keyv": "*",
@@ -3881,30 +4434,30 @@
 		},
 		"@types/chai": {
 			"version": "4.2.22",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
-			"integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai/-/chai-4.2.22.tgz",
+			"integrity": "sha1-RwINfkzxkZTUO1IC8191vSrTXOc="
 		},
 		"@types/chai-as-promised": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.4.tgz",
-			"integrity": "sha512-1y3L1cHePcIm5vXkh1DSGf/zQq5n5xDKG1fpCvf18+uOkpce0Z1ozNFPkyWsVswK7ntN1sZBw3oU6gmN+pDUcA==",
+			"version": "7.1.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+			"integrity": "sha1-bgFoEfbHpk8u7YIxkcOmlVCU4lU=",
 			"requires": {
 				"@types/chai": "*"
 			}
 		},
 		"@types/eslint": {
-			"version": "7.28.2",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
-			"integrity": "sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==",
+			"version": "8.4.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/eslint/-/eslint-8.4.5.tgz",
+			"integrity": "sha1-rN+33Ta5HMXYEtfAk4Eajz2bMeQ=",
 			"requires": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
 			}
 		},
 		"@types/eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+			"version": "3.7.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+			"integrity": "sha1-N/wSI/B4bDlicGihLpTW5vxh3hY=",
 			"requires": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -3912,13 +4465,13 @@
 		},
 		"@types/estree": {
 			"version": "0.0.50",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/estree/-/estree-0.0.50.tgz",
+			"integrity": "sha1-Hgyqk2TT/M0pMcPtlv2+ql1MyoM="
 		},
 		"@types/glob": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha1-vBtb86qS8lvV3TnzXFc2G9zlsus=",
 			"requires": {
 				"@types/minimatch": "*",
 				"@types/node": "*"
@@ -3926,49 +4479,54 @@
 		},
 		"@types/http-cache-semantics": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+			"integrity": "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI="
+		},
+		"@types/json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-hcH/DwlI/BWYENS1vjW/jCCHX2Q="
 		},
 		"@types/json-schema": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+			"version": "7.0.11",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha1-1CG2xSejA398hEM/0sQingFoY9M="
 		},
 		"@types/keyv": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.3.tgz",
-			"integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
+			"version": "3.1.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha1-PM2xxnUbDH5SMAvNrNW8v4+qdbY=",
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@types/minimatch": {
 			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/minimatch/-/minimatch-3.0.5.tgz",
+			"integrity": "sha1-EAHMXmo3BLg8I2An538vWOoBD0A="
 		},
 		"@types/mocha": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-			"integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA=="
+			"version": "9.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/mocha/-/mocha-9.1.1.tgz",
+			"integrity": "sha1-58TxAB7vpLivvR7uJ6I3/uO/KcQ="
 		},
 		"@types/node": {
 			"version": "16.11.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-			"integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-16.11.7.tgz",
+			"integrity": "sha1-NoIJRQYTJpeMQqAeVrYc0iPf3EI="
 		},
 		"@types/responselike": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha1-JR9P59FU0rrRJavhtCmyOv0mLik=",
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@types/rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-pj0XWzMXSOUiCtSMkB17vx9E7vg=",
 			"requires": {
 				"@types/glob": "*",
 				"@types/node": "*"
@@ -3976,18 +4534,18 @@
 		},
 		"@types/vscode": {
 			"version": "1.62.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.62.0.tgz",
+			"integrity": "sha1-tNbRktWut16R0K3vaJw+zvmHnac="
 		},
 		"@ungap/promise-all-settled": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+			"integrity": "sha1-qlgEJxHW4ydd033Fl+XTHowpCkQ="
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+			"integrity": "sha1-K/12fq4aaZb0Mv9+jX/HVnnAtqc=",
 			"requires": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -3995,23 +4553,23 @@
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+			"integrity": "sha1-9sYacF8P16auyqToGY8j2dwXnk8="
 		},
 		"@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+			"integrity": "sha1-GmMZLYeI5cASgAump6RscFKI/RY="
 		},
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+			"integrity": "sha1-gyqQDrREiEzemnytRn+BUA9eWrU="
 		},
 		"@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+			"integrity": "sha1-ZNgdohn7u6HjvRv8dPboxOEKYq4=",
 			"requires": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -4020,13 +4578,13 @@
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+			"integrity": "sha1-8ygkHkHnsZnQsgwY6IQpxEMyleE="
 		},
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+			"integrity": "sha1-Ie4GWntjXzGec48N1zv72igcCXo=",
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -4036,29 +4594,29 @@
 		},
 		"@webassemblyjs/ieee754": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+			"integrity": "sha1-ljkp6bvQVwnn4SJDoJkYCBKZJhQ=",
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+			"integrity": "sha1-zoFLRVdOk9drrh+yZEq5zdlSeqU=",
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+			"integrity": "sha1-0fi3ZDaefG5rrjUOhU3smlnwo/8="
 		},
 		"@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+			"integrity": "sha1-rSBuv0v5WgWM6YgKjAksXeyBk9Y=",
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -4072,8 +4630,8 @@
 		},
 		"@webassemblyjs/wasm-gen": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+			"integrity": "sha1-hsXqMEhJdZt9iMR6MvTwOa48j3Y=",
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -4084,8 +4642,8 @@
 		},
 		"@webassemblyjs/wasm-opt": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+			"integrity": "sha1-ZXtMIgL0zzs0X4pMZGHIwkGJhfI=",
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -4095,8 +4653,8 @@
 		},
 		"@webassemblyjs/wasm-parser": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+			"integrity": "sha1-hspzRTT0F+m9PGfHocddi+QfsZk=",
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -4108,69 +4666,46 @@
 		},
 		"@webassemblyjs/wast-printer": {
 			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+			"integrity": "sha1-0Mc77ajuxUJvEK6O9VzuXnCEwvA=",
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@xtuc/long": "4.2.2"
 			}
 		},
-		"@webpack-cli/configtest": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-			"dev": true,
-			"requires": {}
-		},
-		"@webpack-cli/info": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-			"integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
-			"dev": true,
-			"requires": {
-				"envinfo": "^7.7.3"
-			}
-		},
-		"@webpack-cli/serve": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-			"dev": true,
-			"requires": {}
-		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+			"integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A="
 		},
 		"@xtuc/long": {
 			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0="
 		},
 		"acorn": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-			"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
+			"version": "8.7.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn/-/acorn-8.7.1.tgz",
+			"integrity": "sha1-AZcSLIQ9G/bQpegyIKeI8nj2PDA="
 		},
 		"acorn-import-assertions": {
 			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+			"integrity": "sha1-uitZOc5iwjjbbZPYHJsRGym4Vek=",
 			"requires": {}
 		},
 		"agent-base": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
 			"requires": {
 				"debug": "4"
 			}
 		},
 		"aggregate-error": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
 			"requires": {
 				"clean-stack": "^2.0.0",
 				"indent-string": "^4.0.0"
@@ -4178,8 +4713,8 @@
 		},
 		"ajv": {
 			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -4189,32 +4724,32 @@
 		},
 		"ajv-keywords": {
 			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+			"integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
 			"requires": {}
 		},
 		"ansi-colors": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g="
 		},
 		"ansi-regex": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
 		},
 		"ansi-styles": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
 		},
 		"anymatch": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
 			"requires": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -4222,33 +4757,33 @@
 		},
 		"argparse": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg="
 		},
 		"array-union": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
 			"dev": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs="
 		},
 		"balanced-match": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
 		},
 		"big-integer": {
-			"version": "1.6.50",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
-			"integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ=="
+			"version": "1.6.51",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/big-integer/-/big-integer-1.6.51.tgz",
+			"integrity": "sha1-DfkqXZiAVg0/8tX9ICRciJ0TBoY="
 		},
 		"binary": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary/-/binary-0.3.0.tgz",
 			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
 			"requires": {
 				"buffers": "~0.1.1",
@@ -4257,18 +4792,18 @@
 		},
 		"binary-extensions": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0="
 		},
 		"bluebird": {
 			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bluebird/-/bluebird-3.4.7.tgz",
 			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -4276,58 +4811,57 @@
 		},
 		"braces": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
 		},
 		"browser-stdout": {
 			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA="
 		},
 		"browserslist": {
-			"version": "4.17.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.6.tgz",
-			"integrity": "sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==",
+			"version": "4.21.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browserslist/-/browserslist-4.21.2.tgz",
+			"integrity": "sha1-WaQAdXRlU1lUlGpAC4Qe034rTs8=",
 			"requires": {
-				"caniuse-lite": "^1.0.30001274",
-				"electron-to-chromium": "^1.3.886",
-				"escalade": "^3.1.1",
-				"node-releases": "^2.0.1",
-				"picocolors": "^1.0.0"
+				"caniuse-lite": "^1.0.30001366",
+				"electron-to-chromium": "^1.4.188",
+				"node-releases": "^2.0.6",
+				"update-browserslist-db": "^1.0.4"
 			}
 		},
 		"buffer-from": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U="
 		},
 		"buffer-indexof-polyfill": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+			"integrity": "sha1-0nMhNcWZnGSyd/z5savjSYJUcpw="
 		},
 		"buffers": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffers/-/buffers-0.1.1.tgz",
 			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"cacheable-lookup": {
 			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha1-WmuGWyxENXvj1evCpGewMnGacAU="
 		},
 		"cacheable-request": {
 			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-7.0.2.tgz",
+			"integrity": "sha1-6g0LiJNkolhUdXMByhKy2nf5HSc=",
 			"requires": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -4339,19 +4873,19 @@
 			}
 		},
 		"camelcase": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
+			"version": "6.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001279",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-			"integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
+			"version": "1.0.30001366",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001366.tgz",
+			"integrity": "sha1-xzNSyDgwqery3qD/cftLmku6qJw="
 		},
 		"chai": {
 			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chai/-/chai-4.3.4.tgz",
+			"integrity": "sha1-tV5lWzHh6scJm+TAjCGWT84ubEk=",
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
@@ -4363,15 +4897,15 @@
 		},
 		"chai-as-promised": {
 			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-			"integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+			"integrity": "sha1-CGRdgl3rhpbuYXJdv1kMAS6wDKA=",
 			"requires": {
 				"check-error": "^1.0.2"
 			}
 		},
 		"chainsaw": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chainsaw/-/chainsaw-0.1.0.tgz",
 			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
 			"requires": {
 				"traverse": ">=0.3.0 <0.4"
@@ -4379,8 +4913,8 @@
 		},
 		"chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
 			"requires": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -4388,8 +4922,8 @@
 			"dependencies": {
 				"supports-color": {
 					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -4398,18 +4932,18 @@
 		},
 		"check-error": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/check-error/-/check-error-1.0.2.tgz",
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
 		},
 		"child_process": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/child_process/-/child_process-1.0.2.tgz",
 			"integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
 		},
 		"chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha1-HPN8hwe5Mr0a8a4iwEMuKs0ZA70=",
 			"requires": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -4423,8 +4957,8 @@
 			"dependencies": {
 				"glob-parent": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
 					"requires": {
 						"is-glob": "^4.0.1"
 					}
@@ -4433,18 +4967,18 @@
 		},
 		"chrome-trace-event": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
-			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+			"integrity": "sha1-EBXs7UdB4V0GZkqVfbv1DQQeJqw="
 		},
 		"clean-stack": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs="
 		},
 		"cliui": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
 			"requires": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
@@ -4453,8 +4987,8 @@
 		},
 		"clone-deep": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clone-deep/-/clone-deep-4.0.1.tgz",
+			"integrity": "sha1-wZ/Zvbv4WUK0/ZechNz31fB8I4c=",
 			"dev": true,
 			"requires": {
 				"is-plain-object": "^2.0.4",
@@ -4464,7 +4998,7 @@
 		},
 		"clone-response": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
 			"requires": {
 				"mimic-response": "^1.0.0"
@@ -4472,57 +5006,65 @@
 		},
 		"color-convert": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
 			"requires": {
 				"color-name": "~1.1.4"
 			}
 		},
 		"color-name": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
 		},
 		"colorette": {
-			"version": "2.0.16",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+			"version": "2.0.19",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/colorette/-/colorette-2.0.19.tgz",
+			"integrity": "sha1-zfBE9HrUGg9LVrOg1bTm4aLVp5g=",
 			"dev": true
 		},
 		"commander": {
 			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM="
+		},
+		"compress-brotli": {
+			"version": "1.3.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/compress-brotli/-/compress-brotli-1.3.8.tgz",
+			"integrity": "sha1-DApgyXqYkUUxTsOB6E4maC57ONs=",
+			"requires": {
+				"@types/json-buffer": "~3.0.0",
+				"json-buffer": "~3.0.1"
+			}
 		},
 		"concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"copy-webpack-plugin": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
-			"integrity": "sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==",
+			"version": "9.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/copy-webpack-plugin/-/copy-webpack-plugin-9.1.0.tgz",
+			"integrity": "sha1-LSxGDExGlewKWK+ygBoSBSVsTms=",
 			"dev": true,
 			"requires": {
-				"fast-glob": "^3.2.5",
-				"glob-parent": "^6.0.0",
+				"fast-glob": "^3.2.7",
+				"glob-parent": "^6.0.1",
 				"globby": "^11.0.3",
 				"normalize-path": "^3.0.0",
-				"p-limit": "^3.1.0",
-				"schema-utils": "^3.0.0",
+				"schema-utils": "^3.1.1",
 				"serialize-javascript": "^6.0.0"
 			}
 		},
 		"core-util-is": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U="
 		},
 		"cross-spawn": {
 			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
 			"dev": true,
 			"requires": {
 				"path-key": "^3.1.0",
@@ -4531,123 +5073,123 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
 			"requires": {
 				"ms": "2.1.2"
 			},
 			"dependencies": {
 				"ms": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
 				}
 			}
 		},
 		"decamelize": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc="
 		},
 		"decompress-response": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha1-yjh2Et234QS9FthaqwDV7PCcZvw=",
 			"requires": {
 				"mimic-response": "^3.1.0"
 			},
 			"dependencies": {
 				"mimic-response": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-					"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz",
+					"integrity": "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k="
 				}
 			}
 		},
 		"deep-eql": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
 			"requires": {
 				"type-detect": "^4.0.0"
 			}
 		},
 		"defer-to-connect": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc="
 		},
 		"define-lazy-prop": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8="
 		},
 		"diff": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
+			"version": "5.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.1.0.tgz",
+			"integrity": "sha1-vFLSmMXqjfkZSAAiREXtQ//IfkA="
 		},
 		"dir-glob": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
 			"dev": true,
 			"requires": {
 				"path-type": "^4.0.0"
 			}
 		},
 		"dns-packet": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.0.tgz",
-			"integrity": "sha512-Nce7YLu6YCgWRvOmDBsJMo9M5/jV3lEZ5vUWnWXYmwURvPylHvq7nkDWhNmk1ZQoZZOP7oQh/S0lSxbisKOfHg==",
+			"version": "5.4.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dns-packet/-/dns-packet-5.4.0.tgz",
+			"integrity": "sha1-H4hHfPnyfniiE/ttEYrjjnWah5s=",
 			"requires": {
 				"@leichtgewicht/ip-codec": "^2.0.1"
 			}
 		},
 		"dns-socket": {
 			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.2.tgz",
-			"integrity": "sha512-BDeBd8najI4/lS00HSKpdFia+OvUMytaVjfzR9n5Lq8MlZRSvtbI+uLtx1+XmQFls5wFU9dssccTmQQ6nfpjdg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dns-socket/-/dns-socket-4.2.2.tgz",
+			"integrity": "sha1-WLAYbsBT6gcx/rBng8furEuVthY=",
 			"requires": {
 				"dns-packet": "^5.2.4"
 			}
 		},
 		"duplexer2": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer2/-/duplexer2-0.1.4.tgz",
 			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
 			"requires": {
 				"readable-stream": "^2.0.2"
 			}
 		},
 		"duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+			"version": "0.1.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer3/-/duplexer3-0.1.5.tgz",
+			"integrity": "sha1-C15Ne61d6JAepEQGJMjh0gCZIX4="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.893",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.893.tgz",
-			"integrity": "sha512-ChtwF7qB03INq1SyMpue08wc6cve+ktj2UC/Y7se9vB+JryfzziJeYwsgb8jLaCA5GMkHCdn5M62PfSMWhifZg=="
+			"version": "1.4.191",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.191.tgz",
+			"integrity": "sha1-Ad1L8yUCpIziS/OJC1VTocX5NTk="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
 			"requires": {
 				"once": "^1.4.0"
 			}
 		},
 		"enhanced-resolve": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-			"integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+			"version": "5.10.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+			"integrity": "sha1-DcV5w7sqEDLjV6xFuPOm861PseY=",
 			"requires": {
 				"graceful-fs": "^4.2.4",
 				"tapable": "^2.2.0"
@@ -4655,29 +5197,29 @@
 		},
 		"envinfo": {
 			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
-			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/envinfo/-/envinfo-7.8.1.tgz",
+			"integrity": "sha1-Bjd+Pl9NN5/qesWS1a2JJ+DE1HU=",
 			"dev": true
 		},
 		"es-module-lexer": {
 			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+			"integrity": "sha1-bxPbAMw4QXE32vdDZvU1yOtDjxk="
 		},
 		"escalade": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA="
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ="
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
 			"requires": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
@@ -4685,38 +5227,38 @@
 		},
 		"esprima": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
 		},
 		"esrecurse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
 			"requires": {
 				"estraverse": "^5.2.0"
 			},
 			"dependencies": {
 				"estraverse": {
 					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM="
 				}
 			}
 		},
 		"estraverse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0="
 		},
 		"events": {
 			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/events/-/events-3.3.0.tgz",
+			"integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA="
 		},
 		"execa": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^7.0.3",
@@ -4732,21 +5274,21 @@
 			"dependencies": {
 				"get-stream": {
 					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
 					"dev": true
 				}
 			}
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
 		},
 		"fast-glob": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-			"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+			"version": "3.2.11",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-glob/-/fast-glob-3.2.11.tgz",
+			"integrity": "sha1-oRcq2VzrihbiDKpcXlZIDlEpwdk=",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -4758,8 +5300,8 @@
 			"dependencies": {
 				"glob-parent": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
@@ -4769,19 +5311,19 @@
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM="
 		},
 		"fastest-levenshtein": {
 			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
-			"integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+			"integrity": "sha1-mZD306iMxan/0fF0V0UlFwDUl+I=",
 			"dev": true
 		},
 		"fastq": {
 			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fastq/-/fastq-1.13.0.tgz",
+			"integrity": "sha1-YWdg+Ip1Jr38WWt8q4wYk4w2uYw=",
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
@@ -4789,16 +5331,16 @@
 		},
 		"fill-range": {
 			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
 			"requires": {
 				"to-regex-range": "^5.0.1"
 			}
 		},
 		"find-up": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
 			"requires": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -4806,24 +5348,24 @@
 		},
 		"flat": {
 			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
 			"optional": true
 		},
 		"fstream": {
 			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"inherits": "~2.0.0",
@@ -4833,8 +5375,8 @@
 			"dependencies": {
 				"rimraf": {
 					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
 					"requires": {
 						"glob": "^7.1.3"
 					}
@@ -4843,44 +5385,44 @@
 		},
 		"function-bind": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
 		},
 		"get-func-name": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-func-name/-/get-func-name-2.0.0.tgz",
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
 		},
 		"get-stream": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
 			"requires": {
 				"pump": "^3.0.0"
 			}
 		},
 		"glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+			"version": "7.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-parent": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.3"
@@ -4888,34 +5430,34 @@
 		},
 		"glob-to-regexp": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+			"integrity": "sha1-x1KXCHyFG5pXi9IX3VmpL1n+VG4="
 		},
 		"globby": {
-			"version": "11.0.4",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-			"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+			"version": "11.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha1-vUvpi7BC+D15b344EZkfvoKg00s=",
 			"dev": true,
 			"requires": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.1.1",
-				"ignore": "^5.1.4",
-				"merge2": "^1.3.0",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
 			}
 		},
 		"got": {
-			"version": "11.8.2",
-			"resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-			"integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+			"version": "11.8.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz",
+			"integrity": "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY=",
 			"requires": {
 				"@sindresorhus/is": "^4.0.0",
 				"@szmarczak/http-timer": "^4.0.5",
 				"@types/cacheable-request": "^6.0.1",
 				"@types/responselike": "^1.0.0",
 				"cacheable-lookup": "^5.0.3",
-				"cacheable-request": "^7.0.1",
+				"cacheable-request": "^7.0.2",
 				"decompress-response": "^6.0.0",
 				"http2-wrapper": "^1.0.0-beta.5.2",
 				"lowercase-keys": "^2.0.0",
@@ -4924,32 +5466,32 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+			"version": "4.2.10",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha1-FH06AG2kyjzhRyjHrvwofDZ9emw="
 		},
 		"growl": {
 			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4="
 		},
 		"has": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has/-/has-1.0.3.tgz",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
 		},
 		"hash.js": {
 			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -4957,12 +5499,12 @@
 		},
 		"he": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/he/-/he-1.2.0.tgz",
+			"integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"requires": {
 				"hash.js": "^1.0.3",
@@ -4972,13 +5514,13 @@
 		},
 		"http-cache-semantics": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+			"integrity": "sha1-SekcXL82yblLz81xwj1SSex045A="
 		},
 		"http-proxy-agent": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
 			"requires": {
 				"@tootallnate/once": "1",
 				"agent-base": "6",
@@ -4987,17 +5529,17 @@
 		},
 		"http2-wrapper": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha1-uPVeDB8l1OvQizsMLAeflZCACz0=",
 			"requires": {
 				"quick-lru": "^5.1.1",
 				"resolve-alpn": "^1.0.0"
 			}
 		},
 		"https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
 			"requires": {
 				"agent-base": "6",
 				"debug": "4"
@@ -5005,20 +5547,20 @@
 		},
 		"human-signals": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
 			"dev": true
 		},
 		"ignore": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-			"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+			"version": "5.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ignore/-/ignore-5.2.0.tgz",
+			"integrity": "sha1-bTusj6f+DUXZ+b57rC/CeVd+NFo=",
 			"dev": true
 		},
 		"import-local": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
-			"integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
+			"version": "3.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/import-local/-/import-local-3.1.0.tgz",
+			"integrity": "sha1-tEed+KX9RPbNziQHBnVnYGPJXLQ=",
 			"dev": true,
 			"requires": {
 				"pkg-dir": "^4.2.0",
@@ -5027,12 +5569,12 @@
 		},
 		"indent-string": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE="
 		},
 		"inflight": {
 			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
 				"once": "^1.3.0",
@@ -5041,75 +5583,75 @@
 		},
 		"inherits": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
 		},
 		"interpret": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/interpret/-/interpret-1.4.0.tgz",
+			"integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4="
 		},
 		"ip-regex": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-			"integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ip-regex/-/ip-regex-4.3.0.tgz",
+			"integrity": "sha1-aHJ1qw9X+naXj/j03dyKI9WZDbU="
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
 			"requires": {
 				"binary-extensions": "^2.0.0"
 			}
 		},
 		"is-core-module": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-			"integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+			"version": "2.9.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha1-4cNEKc1Rxt2eCeB5njluJ7GanGk=",
 			"requires": {
 				"has": "^1.0.3"
 			}
 		},
 		"is-docker": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-fullwidth-code-point": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
 		},
 		"is-glob": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
 		},
 		"is-ip": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-ip/-/is-ip-3.1.0.tgz",
+			"integrity": "sha1-KuXd+vrwXLgAimIJPPKXNPZXxdg=",
 			"requires": {
 				"ip-regex": "^4.0.0"
 			}
 		},
 		"is-number": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
 		},
 		"is-online": {
 			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/is-online/-/is-online-9.0.1.tgz",
-			"integrity": "sha512-+08dRW0dcFOtleR2N3rHRVxDyZtQitUp9cC+KpKTds0mXibbQyW5js7xX0UGyQXkaLUJObe0w6uQ4ex34lX9LA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-9.0.1.tgz",
+			"integrity": "sha1-caNCAvqCa65vP/i+pCDFZXNEil8=",
 			"requires": {
 				"got": "^11.8.0",
 				"p-any": "^3.0.0",
@@ -5119,13 +5661,13 @@
 		},
 		"is-plain-obj": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
@@ -5133,43 +5675,43 @@
 		},
 		"is-stream": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
 			"dev": true
 		},
 		"is-unicode-supported": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc="
 		},
 		"is-wsl": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
 			"requires": {
 				"is-docker": "^2.0.0"
 			}
 		},
 		"isarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
 		"jest-worker": {
-			"version": "27.3.1",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
-			"integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
+			"version": "27.5.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jest-worker/-/jest-worker-27.5.1.tgz",
+			"integrity": "sha1-jRRvCQDolzsQa29zzB6ajLhvjbA=",
 			"requires": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -5178,68 +5720,69 @@
 		},
 		"js-tokens": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
 		},
 		"js-yaml": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
 			"requires": {
 				"argparse": "^2.0.1"
 			}
 		},
 		"json-buffer": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
 		},
 		"keyv": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
-			"integrity": "sha512-vqNHbAc8BBsxk+7QBYLW0Y219rWcClspR6WSeoHYKG5mnsSoOH+BL1pWq02DDCVdvvuUny5rkBlzMRzoqc+GIg==",
+			"version": "4.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.3.2.tgz",
+			"integrity": "sha1-6DnfZ2oMfuWUyINefByDdCVY5cI=",
 			"requires": {
+				"compress-brotli": "^1.3.8",
 				"json-buffer": "3.0.1"
 			}
 		},
 		"kind-of": {
 			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
 			"dev": true
 		},
 		"listenercount": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/listenercount/-/listenercount-1.0.1.tgz",
 			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
 		},
 		"loader-runner": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
-			"integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw=="
+			"version": "4.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/loader-runner/-/loader-runner-4.3.0.tgz",
+			"integrity": "sha1-wbShY7mfYUgwNTsWdV5xSawjFOE="
 		},
 		"locate-path": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
 			"requires": {
 				"p-locate": "^5.0.0"
 			}
 		},
 		"log-symbols": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
 			"requires": {
 				"chalk": "^4.1.0",
 				"is-unicode-supported": "^0.1.0"
@@ -5247,127 +5790,132 @@
 		},
 		"lowercase-keys": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk="
 		},
 		"lru-cache": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
 			"requires": {
 				"yallist": "^4.0.0"
 			}
 		},
 		"merge-stream": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A="
 		},
 		"merge2": {
 			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
 			"dev": true
 		},
 		"micromatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"version": "4.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/micromatch/-/micromatch-4.0.5.tgz",
+			"integrity": "sha1-vImZp8u/d83InxMvbkZwUbSQkMY=",
 			"requires": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
+				"braces": "^3.0.2",
+				"picomatch": "^2.3.1"
 			}
 		},
 		"mime-db": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-			"integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+			"version": "1.52.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A="
 		},
 		"mime-types": {
-			"version": "2.1.34",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-			"integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+			"version": "2.1.35",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
 			"requires": {
-				"mime-db": "1.51.0"
+				"mime-db": "1.52.0"
 			}
 		},
 		"mimic-fn": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
 			"dev": true
 		},
 		"mimic-response": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
 			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q="
 		},
 		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
 			"requires": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			}
 		},
 		"mocha": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-			"integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+			"version": "9.2.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mocha/-/mocha-9.2.2.tgz",
+			"integrity": "sha1-1w20a9uTyldALICTM+WoSXeoj7k=",
 			"requires": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.2",
-				"debug": "4.3.2",
+				"chokidar": "3.5.3",
+				"debug": "4.3.3",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
-				"glob": "7.1.7",
+				"glob": "7.2.0",
 				"growl": "1.10.5",
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
-				"minimatch": "3.0.4",
+				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
+				"nanoid": "3.3.1",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"workerpool": "6.1.5",
+				"workerpool": "6.2.0",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
 			},
 			"dependencies": {
+				"diff": {
+					"version": "5.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-5.0.0.tgz",
+					"integrity": "sha1-ftatdthZ0DB4fsNYVfWx2vMdhSs="
+				},
 				"glob": {
-					"version": "7.1.7",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-					"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+					"version": "7.2.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.0.tgz",
+					"integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -5375,44 +5923,62 @@
 						"minimatch": "^3.0.4",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
+					},
+					"dependencies": {
+						"minimatch": {
+							"version": "3.1.2",
+							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+							"integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						}
+					}
+				},
+				"minimatch": {
+					"version": "4.2.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-4.2.1.tgz",
+					"integrity": "sha1-QNnVEaRr3E5WPCLDCAzenA2CmbQ=",
+					"requires": {
+						"brace-expansion": "^1.1.7"
 					}
 				}
 			}
 		},
 		"ms": {
 			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
 		},
 		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
+			"version": "3.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha1-Y0ehjKyIr4j1ivCzWUtyPV6ZuzU="
 		},
 		"neo-async": {
 			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8="
 		},
 		"node-releases": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+			"version": "2.0.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-releases/-/node-releases-2.0.6.tgz",
+			"integrity": "sha1-inCIxjpV5JOEVoPr88go2MUcVQM="
 		},
 		"normalize-path": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
 		},
 		"normalize-url": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo="
 		},
 		"npm-run-path": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
 			"dev": true,
 			"requires": {
 				"path-key": "^3.0.0"
@@ -5420,7 +5986,7 @@
 		},
 		"once": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
 				"wrappy": "1"
@@ -5428,8 +5994,8 @@
 		},
 		"onetime": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
 			"dev": true,
 			"requires": {
 				"mimic-fn": "^2.1.0"
@@ -5437,8 +6003,8 @@
 		},
 		"open": {
 			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-			"integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-8.4.0.tgz",
+			"integrity": "sha1-NFMhrhj4E4+CVlqRD9xrOejCRPg=",
 			"requires": {
 				"define-lazy-prop": "^2.0.0",
 				"is-docker": "^2.1.1",
@@ -5447,8 +6013,8 @@
 		},
 		"p-any": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-any/-/p-any-3.0.0.tgz",
-			"integrity": "sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-3.0.0.tgz",
+			"integrity": "sha1-eYR67tcLXToQ6mJSlsDD0ukKh7k=",
 			"requires": {
 				"p-cancelable": "^2.0.0",
 				"p-some": "^5.0.0"
@@ -5456,34 +6022,34 @@
 		},
 		"p-cancelable": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8="
 		},
 		"p-finally": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
 			"requires": {
 				"yocto-queue": "^0.1.0"
 			}
 		},
 		"p-locate": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
 			"requires": {
 				"p-limit": "^3.0.2"
 			}
 		},
 		"p-some": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
-			"integrity": "sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-5.0.0.tgz",
+			"integrity": "sha1-i3MMdLT+UWnXJkokCtAQtuvGhqQ=",
 			"requires": {
 				"aggregate-error": "^3.0.0",
 				"p-cancelable": "^2.0.0"
@@ -5491,64 +6057,64 @@
 		},
 		"p-timeout": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
 			"requires": {
 				"p-finally": "^1.0.0"
 			}
 		},
 		"p-try": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
 			"dev": true
 		},
 		"path-exists": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
 			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
 		},
 		"path-type": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
 			"dev": true
 		},
 		"pathval": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha1-hTTnenfOesWiUS6iHg/bj89sPY0="
 		},
 		"picocolors": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw="
 		},
 		"picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+			"version": "2.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI="
 		},
 		"pkg-dir": {
 			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
 			"dev": true,
 			"requires": {
 				"find-up": "^4.0.0"
@@ -5556,8 +6122,8 @@
 			"dependencies": {
 				"find-up": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
 					"dev": true,
 					"requires": {
 						"locate-path": "^5.0.0",
@@ -5566,8 +6132,8 @@
 				},
 				"locate-path": {
 					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
 					"dev": true,
 					"requires": {
 						"p-locate": "^4.1.0"
@@ -5575,8 +6141,8 @@
 				},
 				"p-limit": {
 					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -5584,8 +6150,8 @@
 				},
 				"p-locate": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
 					"dev": true,
 					"requires": {
 						"p-limit": "^2.2.0"
@@ -5595,18 +6161,18 @@
 		},
 		"prepend-http": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prepend-http/-/prepend-http-2.0.0.tgz",
 			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
 		},
 		"public-ip": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/public-ip/-/public-ip-4.0.4.tgz",
-			"integrity": "sha512-EJ0VMV2vF6Cu7BIPo3IMW1Maq6ME+fbR0NcPmqDfpfNGIRPue1X8QrGjrg/rfjDkOsIkKHIf2S5FlEa48hFMTA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-4.0.4.tgz",
+			"integrity": "sha1-s3hKWh/xuB0BW5oYRQvmX/2SnrM=",
 			"requires": {
 				"dns-socket": "^4.2.2",
 				"got": "^9.6.0",
@@ -5615,21 +6181,21 @@
 			"dependencies": {
 				"@sindresorhus/is": {
 					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-					"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-0.14.0.tgz",
+					"integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o="
 				},
 				"@szmarczak/http-timer": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-					"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+					"integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
 					"requires": {
 						"defer-to-connect": "^1.0.1"
 					}
 				},
 				"cacheable-request": {
 					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-					"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-6.1.0.tgz",
+					"integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
 					"requires": {
 						"clone-response": "^1.0.2",
 						"get-stream": "^5.1.0",
@@ -5642,7 +6208,7 @@
 				},
 				"decompress-response": {
 					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-3.3.0.tgz",
 					"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
 					"requires": {
 						"mimic-response": "^1.0.0"
@@ -5650,13 +6216,13 @@
 				},
 				"defer-to-connect": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-					"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+					"integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE="
 				},
 				"got": {
 					"version": "9.6.0",
-					"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-					"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-9.6.0.tgz",
+					"integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
 					"requires": {
 						"@sindresorhus/is": "^0.14.0",
 						"@szmarczak/http-timer": "^1.1.2",
@@ -5673,45 +6239,45 @@
 					"dependencies": {
 						"get-stream": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-							"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-4.1.0.tgz",
+							"integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
 							"requires": {
 								"pump": "^3.0.0"
 							}
 						},
 						"lowercase-keys": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-							"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+							"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
 						}
 					}
 				},
 				"json-buffer": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.0.tgz",
 					"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
 				},
 				"keyv": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-					"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-3.1.0.tgz",
+					"integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
 					"requires": {
 						"json-buffer": "3.0.0"
 					}
 				},
 				"normalize-url": {
 					"version": "4.5.1",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-					"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-4.5.1.tgz",
+					"integrity": "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo="
 				},
 				"p-cancelable": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-					"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-1.1.0.tgz",
+					"integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw="
 				},
 				"responselike": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-1.0.2.tgz",
 					"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
 					"requires": {
 						"lowercase-keys": "^1.0.0"
@@ -5719,8 +6285,8 @@
 					"dependencies": {
 						"lowercase-keys": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-							"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+							"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
 						}
 					}
 				}
@@ -5728,8 +6294,8 @@
 		},
 		"pump": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -5737,32 +6303,32 @@
 		},
 		"punycode": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
 		},
 		"queue-microtask": {
 			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
 			"dev": true
 		},
 		"quick-lru": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha1-NmST5rPkKjpoheLpnRj4D7eoyTI="
 		},
 		"randombytes": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
 		},
 		"readable-stream": {
 			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -5775,22 +6341,22 @@
 			"dependencies": {
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
 				}
 			}
 		},
 		"readdirp": {
 			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
 		},
 		"rechoir": {
 			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
 				"resolve": "^1.1.6"
@@ -5798,27 +6364,28 @@
 		},
 		"require-directory": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"version": "1.22.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha1-J8suu1P5GrtJRwqSi7p1WAZqwXc=",
 			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
 		"resolve-alpn": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha1-t629rDVGqq7CC0Xn2CZZJwcnJvk="
 		},
 		"resolve-cwd": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
 			"dev": true,
 			"requires": {
 				"resolve-from": "^5.0.0"
@@ -5826,36 +6393,36 @@
 		},
 		"resolve-from": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
 			"dev": true
 		},
 		"responselike": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-			"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-2.0.0.tgz",
+			"integrity": "sha1-JjkbzDF091D5p56sxAoSpcQtdyM=",
 			"requires": {
 				"lowercase-keys": "^2.0.0"
 			}
 		},
 		"reusify": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
 			"dev": true
 		},
 		"rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
 			"requires": {
 				"glob": "^7.1.3"
 			}
 		},
 		"run-parallel": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
 			"dev": true,
 			"requires": {
 				"queue-microtask": "^1.2.2"
@@ -5863,13 +6430,13 @@
 		},
 		"safe-buffer": {
 			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
 		},
 		"schema-utils": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/schema-utils/-/schema-utils-3.1.1.tgz",
+			"integrity": "sha1-vHTEtraZXB2I92qLd76nIZ4MgoE=",
 			"requires": {
 				"@types/json-schema": "^7.0.8",
 				"ajv": "^6.12.5",
@@ -5877,30 +6444,30 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha1-EsW2Sa/b+QSXB3luIqQCiBTOUj8=",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
 		},
 		"serialize-javascript": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+			"integrity": "sha1-765diPRdeSQUHai1w6en5mP+/rg=",
 			"requires": {
 				"randombytes": "^2.1.0"
 			}
 		},
 		"setimmediate": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"shallow-clone": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shallow-clone/-/shallow-clone-3.0.1.tgz",
+			"integrity": "sha1-jymBrZJTH1UDWwH7IwdppA4C76M=",
 			"dev": true,
 			"requires": {
 				"kind-of": "^6.0.2"
@@ -5908,8 +6475,8 @@
 		},
 		"shebang-command": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
 			"dev": true,
 			"requires": {
 				"shebang-regex": "^3.0.0"
@@ -5917,14 +6484,14 @@
 		},
 		"shebang-regex": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
 			"dev": true
 		},
 		"shelljs": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-			"integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+			"version": "0.8.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
+			"integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
 			"requires": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -5932,26 +6499,26 @@
 			}
 		},
 		"signal-exit": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-			"integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+			"version": "3.0.7",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
 			"dev": true
 		},
 		"slash": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
 			"dev": true
 		},
 		"source-map": {
 			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
 		},
 		"source-map-support": {
-			"version": "0.5.20",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-			"integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+			"version": "0.5.21",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha1-BP58f54e0tZiIzwoyys1ufY/bk8=",
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -5959,28 +6526,28 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			},
 			"dependencies": {
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
 				}
 			}
 		},
 		"string-width": {
 			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -5989,87 +6556,74 @@
 		},
 		"strip-ansi": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
 			"requires": {
 				"ansi-regex": "^5.0.1"
 			}
 		},
 		"strip-final-newline": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
 			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY="
 		},
 		"supports-color": {
 			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
 			"requires": {
 				"has-flag": "^4.0.0"
 			}
 		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk="
+		},
 		"tapable": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha1-GWenPvQGCoLxKrlq+G1S/bdu7KA="
 		},
 		"terser": {
-			"version": "5.9.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
-			"integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
+			"version": "5.14.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/terser/-/terser-5.14.2.tgz",
+			"integrity": "sha1-msnyKwaZTXNhdPQJGqNo24lvHBA=",
 			"requires": {
+				"@jridgewell/source-map": "^0.3.2",
+				"acorn": "^8.5.0",
 				"commander": "^2.20.0",
-				"source-map": "~0.7.2",
 				"source-map-support": "~0.5.20"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.7.3",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-				}
-			}
-		},
-		"terser-webpack-plugin": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz",
-			"integrity": "sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==",
-			"requires": {
-				"jest-worker": "^27.0.6",
-				"schema-utils": "^3.1.1",
-				"serialize-javascript": "^6.0.0",
-				"source-map": "^0.6.1",
-				"terser": "^5.7.2"
 			}
 		},
 		"to-readable-stream": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+			"integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E="
 		},
 		"to-regex-range": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
 			"requires": {
 				"is-number": "^7.0.0"
 			}
 		},
 		"traverse": {
 			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/traverse/-/traverse-0.3.9.tgz",
 			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
 		},
 		"ts-loader": {
-			"version": "9.2.6",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
-			"integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
+			"version": "9.3.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ts-loader/-/ts-loader-9.3.1.tgz",
+			"integrity": "sha1-/iXMpW4+ccEIf+SNxn9N+MWbItQ=",
 			"requires": {
 				"chalk": "^4.1.0",
 				"enhanced-resolve": "^5.0.0",
@@ -6079,13 +6633,13 @@
 		},
 		"tslib": {
 			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA="
 		},
 		"tslint": {
 			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslint/-/tslint-5.20.1.tgz",
+			"integrity": "sha1-5AHortoBUrxE3QfmFANPP4DGe30=",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"builtin-modules": "^1.1.1",
@@ -6104,24 +6658,24 @@
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
 				},
 				"argparse": {
 					"version": "1.0.10",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
 					"requires": {
 						"sprintf-js": "~1.0.2"
 					}
 				},
 				"chalk": {
 					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -6130,36 +6684,36 @@
 				},
 				"color-convert": {
 					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
 					"requires": {
 						"color-name": "1.1.3"
 					}
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
 				"diff": {
 					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0="
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
 					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"js-yaml": {
 					"version": "3.14.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
 					"requires": {
 						"argparse": "^1.0.7",
 						"esprima": "^4.0.0"
@@ -6167,41 +6721,41 @@
 				},
 				"semver": {
 					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
 				},
 				"supports-color": {
 					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 					"requires": {
 						"has-flag": "^3.0.0"
+					}
+				},
+				"tsutils": {
+					"version": "2.29.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tsutils/-/tsutils-2.29.0.tgz",
+					"integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+					"requires": {
+						"tslib": "^1.8.1"
 					}
 				}
 			}
 		},
-		"tsutils": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-			"requires": {
-				"tslib": "^1.8.1"
-			}
-		},
 		"type-detect": {
 			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw="
 		},
 		"typescript": {
 			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha1-LNAaGh8WBwTTEB/VpY/w+fy4Aww="
 		},
 		"unzipper": {
 			"version": "0.10.11",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unzipper/-/unzipper-0.10.11.tgz",
+			"integrity": "sha1-C0mRRGRyy9uS7nQDkJ8mwkGceC4=",
 			"requires": {
 				"big-integer": "^1.6.17",
 				"binary": "~0.3.0",
@@ -6215,17 +6769,26 @@
 				"setimmediate": "~1.0.4"
 			}
 		},
+		"update-browserslist-db": {
+			"version": "1.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
+			"integrity": "sha1-2/xaeJyqJrHbiZB5bCyOu84wSCQ=",
+			"requires": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			}
+		},
 		"uri-js": {
 			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
 			"requires": {
 				"punycode": "^2.1.0"
 			}
 		},
 		"url-parse-lax": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
 			"requires": {
 				"prepend-http": "^2.0.0"
@@ -6233,13 +6796,13 @@
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"vscode-dotnet-runtime-library": {
 			"version": "file:../vscode-dotnet-runtime-library",
 			"requires": {
-				"@types/chai": "^4.2.22",
+				"@types/chai": "4.2.22",
 				"@types/chai-as-promised": "^7.1.4",
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
@@ -6248,7 +6811,7 @@
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
 				"@types/vscode": "1.62.0",
-				"chai": "^4.3.4",
+				"chai": "4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",
 				"eol": "^0.9.1",
@@ -6271,8 +6834,8 @@
 		},
 		"vscode-test": {
 			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vscode-test/-/vscode-test-1.6.1.tgz",
+			"integrity": "sha1-RCVMZwNt6SsA/dcvas5fGFThpWM=",
 			"requires": {
 				"http-proxy-agent": "^4.0.1",
 				"https-proxy-agent": "^5.0.0",
@@ -6281,9 +6844,9 @@
 			}
 		},
 		"watchpack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-			"integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+			"version": "2.4.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/watchpack/-/watchpack-2.4.0.tgz",
+			"integrity": "sha1-+jMDI3SWLHgRP5PH8vtMVMmGKl0=",
 			"requires": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -6291,8 +6854,8 @@
 		},
 		"webpack": {
 			"version": "5.63.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.63.0.tgz",
-			"integrity": "sha512-HYrw6bkj/MDmphAXvqLEvn2fVoDZsYu6O638WjK6lSNgIpjb5jl/KtOrqJyU9EC/ZV9mLUmZW5h4mASB+CVA4A==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack/-/webpack-5.63.0.tgz",
+			"integrity": "sha1-SwdBFYAOBSbYURKYXkbGS5XgSq8=",
 			"requires": {
 				"@types/eslint-scope": "^3.7.0",
 				"@types/estree": "^0.0.50",
@@ -6318,12 +6881,26 @@
 				"terser-webpack-plugin": "^5.1.3",
 				"watchpack": "^2.2.0",
 				"webpack-sources": "^3.2.0"
+			},
+			"dependencies": {
+				"terser-webpack-plugin": {
+					"version": "5.3.3",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
+					"integrity": "sha1-gDPbh23Vh1SHIT6Hxie8oyPl7ZA=",
+					"requires": {
+						"@jridgewell/trace-mapping": "^0.3.7",
+						"jest-worker": "^27.4.5",
+						"schema-utils": "^3.1.1",
+						"serialize-javascript": "^6.0.0",
+						"terser": "^5.7.2"
+					}
+				}
 			}
 		},
 		"webpack-cli": {
 			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-			"integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-cli/-/webpack-cli-4.9.1.tgz",
+			"integrity": "sha1-tkvoJeLRsTDyhcMUyqOxuppGMrM=",
 			"dev": true,
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
@@ -6340,22 +6917,45 @@
 				"webpack-merge": "^5.7.3"
 			},
 			"dependencies": {
+				"@webpack-cli/configtest": {
+					"version": "1.2.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+					"integrity": "sha1-eyDOHBJTORLDshfqaCYjZfoppvU=",
+					"dev": true,
+					"requires": {}
+				},
+				"@webpack-cli/info": {
+					"version": "1.5.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webpack-cli/info/-/info-1.5.0.tgz",
+					"integrity": "sha1-bHjBPFh0hS1uLdF/CKQfP+TCYbE=",
+					"dev": true,
+					"requires": {
+						"envinfo": "^7.7.3"
+					}
+				},
+				"@webpack-cli/serve": {
+					"version": "1.7.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@webpack-cli/serve/-/serve-1.7.0.tgz",
+					"integrity": "sha1-4Zk2iaxC0rFukZQ3bPtnU/YlTbE=",
+					"dev": true,
+					"requires": {}
+				},
 				"commander": {
 					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-					"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-7.2.0.tgz",
+					"integrity": "sha1-o2y1fQtQHOEI5NIFWaFQo5HZerc=",
 					"dev": true
 				},
 				"interpret": {
 					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-					"integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/interpret/-/interpret-2.2.0.tgz",
+					"integrity": "sha1-GnigtZZcQKVBbQB61vUK0nxBffk=",
 					"dev": true
 				},
 				"rechoir": {
 					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-					"integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rechoir/-/rechoir-0.7.1.tgz",
+					"integrity": "sha1-lHipahyhNbXoj8An8D7pLWxkVoY=",
 					"dev": true,
 					"requires": {
 						"resolve": "^1.9.0"
@@ -6365,8 +6965,8 @@
 		},
 		"webpack-merge": {
 			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-			"integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-merge/-/webpack-merge-5.8.0.tgz",
+			"integrity": "sha1-Kznb8ir4d3atdEw5AiNzHTCmj2E=",
 			"dev": true,
 			"requires": {
 				"clone-deep": "^4.0.1",
@@ -6374,33 +6974,33 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-			"integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA=="
+			"version": "3.2.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-sources/-/webpack-sources-3.2.3.tgz",
+			"integrity": "sha1-LU2quEUf1LJAzCcFX/agwszqDN4="
 		},
 		"which": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
+			"integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
 			"requires": {
 				"isexe": "^2.0.0"
 			}
 		},
 		"wildcard": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-			"integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wildcard/-/wildcard-2.0.0.tgz",
+			"integrity": "sha1-p30g5SAMb6qsl55LOq3Hs91/j+w=",
 			"dev": true
 		},
 		"workerpool": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-			"integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw=="
+			"version": "6.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/workerpool/-/workerpool-6.2.0.tgz",
+			"integrity": "sha1-gn2Tyboj7iAZw/+v9cJ/zOoonos="
 		},
 		"wrap-ansi": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
 			"requires": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -6409,23 +7009,23 @@
 		},
 		"wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"y18n": {
 			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU="
 		},
 		"yallist": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
 		},
 		"yargs": {
 			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
 			"requires": {
 				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
@@ -6438,13 +7038,13 @@
 		},
 		"yargs-parser": {
 			"version": "20.2.4",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-parser/-/yargs-parser-20.2.4.tgz",
+			"integrity": "sha1-tCiQ8UVmeW+Fro46JSkNIF8VSlQ="
 		},
 		"yargs-unparser": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
 			"requires": {
 				"camelcase": "^6.0.0",
 				"decamelize": "^4.0.0",
@@ -6454,8 +7054,8 @@
 		},
 		"yocto-queue": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs="
 		}
 	}
 }

--- a/vscode-dotnet-sdk-extension/package-lock.json
+++ b/vscode-dotnet-sdk-extension/package-lock.json
@@ -14,7 +14,7 @@
 				"@types/mocha": "^9.0.0",
 				"@types/node": "16.11.7",
 				"@types/rimraf": "3.0.2",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"chai": "^4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"child_process": "^1.0.2",
@@ -38,7 +38,7 @@
 				"webpack-cli": "4.9.1"
 			},
 			"engines": {
-				"vscode": "^1.62.0"
+				"vscode": "1.62.0"
 			}
 		},
 		"../vscode-dotnet-runtime-library": {
@@ -52,7 +52,7 @@
 				"@types/rimraf": "3.0.2",
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"chai": "^4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",
@@ -76,7 +76,7 @@
 				"glob": "^7.2.0"
 			},
 			"engines": {
-				"vscode": "^1.62.0"
+				"vscode": "1.62.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "^2.3.2"
@@ -6247,7 +6247,7 @@
 				"@types/rimraf": "3.0.2",
 				"@types/semver": "^7.3.9",
 				"@types/shelljs": "0.8.9",
-				"@types/vscode": "^1.62.0",
+				"@types/vscode": "1.62.0",
 				"chai": "^4.3.4",
 				"chai-as-promised": "^7.1.1",
 				"diff": ">=5.0.0",

--- a/vscode-dotnet-sdk-extension/package.json
+++ b/vscode-dotnet-sdk-extension/package.json
@@ -105,5 +105,11 @@
 		"copy-webpack-plugin": "^9.0.1",
 		"webpack": "5.63.0",
 		"webpack-cli": "4.9.1"
+	},
+	"__metadata": {
+		"id": "bdf86aba-ad9d-4593-b780-5829a4423823",
+		"publisherDisplayName": "Microsoft",
+		"publisherId": "d05e23de-3974-4ff0-8d47-23ee77830092",
+		"isPreReleaseVersion": false
 	}
 }

--- a/vscode-dotnet-sdk-extension/package.json
+++ b/vscode-dotnet-sdk-extension/package.json
@@ -78,13 +78,13 @@
 		"webpack": "webpack --mode development"
 	},
 	"dependencies": {
-		"@types/chai": "^4.2.22",
+		"@types/chai": "4.2.22",
 		"@types/chai-as-promised": "^7.1.4",
 		"@types/mocha": "^9.0.0",
 		"@types/node": "16.11.7",
 		"@types/rimraf": "3.0.2",
 		"@types/vscode": "1.62.0",
-		"chai": "^4.3.4",
+		"chai": "4.3.4",
 		"chai-as-promised": "^7.1.1",
 		"child_process": "^1.0.2",
 		"diff": ">=5.0.0",

--- a/vscode-dotnet-sdk-extension/package.json
+++ b/vscode-dotnet-sdk-extension/package.json
@@ -16,7 +16,7 @@
 	"version": "0.9.0",
 	"publisher": "ms-dotnettools",
 	"engines": {
-		"vscode": "^1.62.0"
+		"vscode": "1.62.0"
 	},
 	"preview": true,
 	"categories": [
@@ -83,7 +83,7 @@
 		"@types/mocha": "^9.0.0",
 		"@types/node": "16.11.7",
 		"@types/rimraf": "3.0.2",
-		"@types/vscode": "^1.62.0",
+		"@types/vscode": "1.62.0",
 		"chai": "^4.3.4",
 		"chai-as-promised": "^7.1.1",
 		"child_process": "^1.0.2",


### PR DESCRIPTION
Cleaner version of https://github.com/dotnet/vscode-dotnet-runtime/pull/512.
Arcade folks reached out because we need to use their new registries. The main fix involved was adding this registry to .npmrc files. Windows 2016 was deprecated between the last time this codebase was pushed to prod. :shipit:  ? 