### PR TITLE
Move version to 1.6.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,7 @@ stages:
       displayName: 'Install Node.js'
     - bash: |
         npm install --cache /temp/empty-cache
-        npm install tslint --verbose
+        npm install tslint --reg https://registry.npmjs.org/ --verbose
         npm run lint
       displayName: Run Lint
   ##### Verify NPM and Yarn are in sync #####

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -29,7 +29,7 @@
 		},
 		"../vscode-dotnet-runtime-extension": {
 			"name": "vscode-dotnet-runtime",
-			"version": "1.6.1",
+			"version": "1.6.0",
 			"license": "MIT",
 			"dependencies": {
 				"chai": "4.3.4",

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -799,7 +799,7 @@
 
 "vscode-dotnet-runtime@file:../vscode-dotnet-runtime-extension":
   "resolved" "file:../vscode-dotnet-runtime-extension"
-  "version" "1.6.1"
+  "version" "1.6.0"
   dependencies:
     "chai" "4.3.4"
     "child_process" "^1.0.2"

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -810,6 +810,7 @@
     "mocha" "^9.1.3"
     "open" "^8.4.0"
     "rimraf" "3.0.2"
+    "safe-regex-test" "^1.0.0"
     "shelljs" "^0.8.5"
     "ts-loader" "^9.2.6"
     "tslint" "^5.20.1"

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-dotnet-runtime",
-	"version": "1.6.1",
+	"version": "1.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-dotnet-runtime",
-			"version": "1.6.1",
+			"version": "1.6.0",
 			"license": "MIT",
 			"dependencies": {
 				"chai": "4.3.4",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -13,7 +13,7 @@
 	"description": "Allows acquisition of the .NET runtime specifically for VS Code extension authors.",
 	"appInsightsKey": "02dc18e0-7494-43b2-b2a3-18ada5fcb522",
 	"icon": "images/dotnetIcon.png",
-	"version": "1.6.1",
+	"version": "1.6.0",
 	"publisher": "ms-dotnettools",
 	"engines": {
 		"vscode": "^1.72.0"


### PR DESCRIPTION
1.6.1 was an internal preview version, the latest released version was 1.5.0, so changing it so the public versioning remains consistent for the release. 