### PR TITLE
Set the download timeout to a default of 10 minutes from 5 minutes.

### DIFF
--- a/Documentation/troubleshooting-runtime.md
+++ b/Documentation/troubleshooting-runtime.md
@@ -2,7 +2,7 @@
 
 ## Install Script Timeouts
 
-Please note that, depending on your network speed, installing the .NET Core runtime might take some time. By default, the installation terminates unsuccessfully if it takes longer than 2 minutes to finish. If you believe this is too little (or too much) time to allow for the download, you can change the timeout value by setting `dotnetAcquisitionExtension.installTimeoutValue` to a custom value.
+Please note that, depending on your network speed, installing the .NET Core runtime might take some time. By default, the installation terminates unsuccessfully if it takes longer than 10 minutes to finish. If you believe this is too little (or too much) time to allow for the download, you can change the timeout value by setting `dotnetAcquisitionExtension.installTimeoutValue` to a custom value.
 
 Learn more about configuring Visual Studio Code settings [here](https://code.visualstudio.com/docs/getstarted/settings) and see below for an example of a custom timeout in a `settings.json` file. In this example the custom timeout value is 180 seconds, or 3 minutes.
 

--- a/Documentation/troubleshooting-sdk.md
+++ b/Documentation/troubleshooting-sdk.md
@@ -20,7 +20,7 @@ To manually set the PATH, edit your `.bash_profile` file to include the followin
 
 ## Install Script Timeouts
 
-Please note that, depending on your network speed, installing the .NET SDK might take some time. By default, the installation terminates unsuccessfully if it takes longer than 4 minutes to finish. If you believe this is too little (or too much) time to allow for the download, you can change the timeout value by setting `dotnetSDKAcquisitionExtension.installTimeoutValue` to a custom value.
+Please note that, depending on your network speed, installing the .NET SDK might take some time. By default, the installation terminates unsuccessfully if it takes longer than 10 minutes to finish. If you believe this is too little (or too much) time to allow for the download, you can change the timeout value by setting `dotnetSDKAcquisitionExtension.installTimeoutValue` to a custom value.
 
 Learn more about configuring Visual Studio Code settings [here](https://code.visualstudio.com/docs/getstarted/settings) and see below for an example of a custom timeout in a `settings.json` file. In this example the custom timeout value is 300 seconds, or 5 minutes.
 

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -60,7 +60,7 @@
 				},
 				"dotnetAcquisitionExtension.installTimeoutValue": {
 					"type": "number",
-					"default": 300,
+					"default": 600,
 					"description": "Timeout for installing .NET in seconds."
 				},
 				"dotnetAcquisitionExtension.existingDotnetPath": {

--- a/vscode-dotnet-sdk-extension/package.json
+++ b/vscode-dotnet-sdk-extension/package.json
@@ -61,7 +61,7 @@
 				},
 				"dotnetSDKAcquisitionExtension.installTimeoutValue": {
 					"type": "number",
-					"default": 300,
+					"default": 600,
 					"description": "Timeout for installing .NET SDK in seconds."
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/dotnet/vscode-dotnet-runtime/issues/1301

This extends the default configuration values and updates documentation examples to be in-line.