### PR TITLE
Remove arch from 1.7.4 changelog

### DIFF
--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning].
 
 ## [1.7.4] - 2023-08-24
 
-Install using node.arch() instead of environment variable architecture from root terminal to prevent mismatching shell architecture with vs code architecture.
 Don't read registry for proxy lookup if permission is unavailable to do so, requires manual proxy setting in this case.
 
 ## [1.7.3] - 2023-08-24


### PR DESCRIPTION
The arch is a big breaking change and so it will go in a major version release.