### PR TITLE
1.8.1 Add Garbage Collection for Failed Uninstalls + Fix Uninstalls

### DIFF
--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -34,7 +34,7 @@
 		},
 		"../vscode-dotnet-runtime-extension": {
 			"name": "vscode-dotnet-runtime",
-			"version": "1.8.0",
+			"version": "1.8.1",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^1.3.4",

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -1277,7 +1277,7 @@
 
 "vscode-dotnet-runtime@file:../vscode-dotnet-runtime-extension":
   "resolved" "file:../vscode-dotnet-runtime-extension"
-  "version" "1.8.0"
+  "version" "1.8.1"
   dependencies:
     "axios" "^1.3.4"
     "axios-cache-interceptor" "^1.0.1"

--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
+## [1.8.1] - 2023-09-18
+
+Don't report failure if the .NET we try to uninstall is in use, and mark it to be uninstalled again next time, as before, we would not attempt to uninstall again later.
+
 ## [1.8.0] - 2023-09-18
 
 Relies on node.arch() to determine .NET installation architecture for local runtimes instead of architecture-related environment variables.

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-dotnet-runtime",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-dotnet-runtime",
-			"version": "1.8.0",
+			"version": "1.8.1",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^1.3.4",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -13,7 +13,7 @@
 	"description": "This extension installs and manages different versions of the .NET Runtime.",
 	"appInsightsKey": "02dc18e0-7494-43b2-b2a3-18ada5fcb522",
 	"icon": "images/dotnetIcon.png",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"publisher": "ms-dotnettools",
 	"engines": {
 		"vscode": "^1.72.0"

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -80,7 +80,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function() {
     assert.include(result!.dotnetPath, context.version);
     await vscode.commands.executeCommand<string>('dotnet.uninstallAll', context.version);
     assert.isFalse(fs.existsSync(result!.dotnetPath));
-  }).timeout(40000);
+  }).timeout(400000);
 
   test('Install and Uninstall Multiple Versions', async () => {
     const versions = ['2.2', '3.0', '3.1'];

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -265,8 +265,8 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
 
     private async tryCleanUpInstallGraveyard() : Promise<void>
     {
-        let graveyard = this.getGraveyard();
-        for(const installKey in graveyard)
+        const graveyard = this.getGraveyard();
+        for(const installKey of Object.keys(graveyard))
         {
             this.context.eventStream.post(new DotnetInstallGraveyardEvent(
                 `Attempting to remove .NET at ${installKey} again, as it was left in the graveyard.`));
@@ -285,7 +285,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
      */
     protected async updateGraveyard(installKey : string, newPath? : string | undefined)
     {
-        let graveyard = this.getGraveyard();
+        const graveyard = this.getGraveyard();
         if(newPath)
         {
             graveyard[installKey] = newPath;

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -29,6 +29,7 @@ import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IDotnetCoreAcquisitionWorker } from './IDotnetCoreAcquisitionWorker';
 import { IDotnetInstallationContext } from './IDotnetInstallationContext';
 import { IDotnetAcquireContext } from '..';
+/* tslint:disable:no-any */
 
 export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker {
     private readonly installingVersionsKey = 'installing';

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -15,6 +15,7 @@ import {
     DotnetAcquisitionStatusResolved,
     DotnetAcquisitionStatusUndefined,
     DotnetCustomMessageEvent,
+    DotnetInstallGraveyardEvent,
     DotnetInstallKeyCreatedEvent,
     DotnetLegacyInstallDetectedEvent,
     DotnetLegacyInstallRemovalRequestEvent,
@@ -34,11 +35,16 @@ import { IDotnetAcquireContext } from '..';
 export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker {
     private readonly installingVersionsKey = 'installing';
     private readonly installedVersionsKey = 'installed';
+    // The 'graveyard' includes failed uninstall paths and their install key.
+    // These will become marked for attempted 'garbage collection' at the end of every acquisition.
+    private readonly installPathsGraveyardKey = 'installPathsGraveyard';
     public installingArchitecture : string | null;
     private readonly dotnetExecutable: string;
     private readonly timeoutValue: number;
 
-    private acquisitionPromises: { [version: string]: Promise<string> | undefined };
+    private acquisitionPromises: { [installKeys: string]: Promise<string> | undefined };
+
+
 
     constructor(private readonly context: IAcquisitionWorkerContext) {
         const dotnetExtension = os.platform() === 'win32' ? '.exe' : '';
@@ -51,7 +57,6 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
 
     public async uninstallAll() {
         this.context.eventStream.post(new DotnetUninstallAllStarted());
-
         this.acquisitionPromises = {};
 
         this.removeFolderRecursively(this.context.installDirectoryProvider.getStoragePath());
@@ -151,7 +156,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             // uninstall everything and then re-install.
             this.context.eventStream.post(new DotnetAcquisitionPartialInstallation(installKey));
 
-            await this.uninstallRuntimeOrSDK(version, installKey);
+            await this.uninstallRuntimeOrSDK(installKey);
         } else if (partialInstall) {
             this.context.eventStream.post(new DotnetAcquisitionPartialInstallation(installKey));
             await this.uninstallAll();
@@ -192,6 +197,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         this.context.installationValidator.validateDotnetInstall(installKey, dotnetPath);
 
         await this.removeMatchingLegacyInstall(installedVersions, version);
+        await this.tryCleanUpInstallGraveyard();
 
         await this.removeVersionFromExtensionState(this.installingVersionsKey, installKey);
         await this.addVersionToExtensionState(this.installedVersionsKey, installKey);
@@ -232,7 +238,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             if(legacyInstall.includes(version))
             {
                 this.context.eventStream.post(new DotnetLegacyInstallRemovalRequestEvent(`Trying to remove legacy install: ${legacyInstall} of ${version}.`));
-                await this.uninstallRuntimeOrSDK(version, legacyInstall);
+                await this.uninstallRuntimeOrSDK(legacyInstall);
             }
         }
     }
@@ -257,19 +263,60 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         return legacyInstalls;
     }
 
-    public async uninstallRuntimeOrSDK(version: string, installKey : string) {
+    private async tryCleanUpInstallGraveyard() : Promise<void>
+    {
+        let graveyard = this.getGraveyard();
+        for(const installKey in graveyard)
+        {
+            this.context.eventStream.post(new DotnetInstallGraveyardEvent(
+                `Attempting to remove .NET at ${installKey} again, as it was left in the graveyard.`));
+            await this.uninstallRuntimeOrSDK(installKey);
+        }
+    }
+
+    protected getGraveyard() : { [installKeys: string]: string }
+    {
+        return this.context.extensionState.get<{ [installKeys: string]: string }>(this.installPathsGraveyardKey, {});
+    }
+
+    /**
+     *
+     * @param newPath Leaving this empty will delete the key from the graveyard.
+     */
+    protected async updateGraveyard(installKey : string, newPath? : string | undefined)
+    {
+        let graveyard = this.getGraveyard();
+        if(newPath)
+        {
+            graveyard[installKey] = newPath;
+        }
+        else
+        {
+            delete graveyard[installKey];
+        }
+        await this.context.extensionState.update(this.installPathsGraveyardKey, graveyard);
+    }
+
+    public async uninstallRuntimeOrSDK(installKey : string) {
         try
         {
+            delete this.acquisitionPromises[installKey];
             const dotnetInstallDir = this.context.installDirectoryProvider.getInstallDir(installKey);
+
+            this.updateGraveyard(installKey, dotnetInstallDir);
+            this.context.eventStream.post(new DotnetInstallGraveyardEvent(`Attempting to remove .NET at ${installKey} in path ${dotnetInstallDir}`));
+
             this.removeFolderRecursively(dotnetInstallDir);
 
-            delete this.acquisitionPromises[installKey];
             await this.removeVersionFromExtensionState(this.installedVersionsKey, installKey);
             await this.removeVersionFromExtensionState(this.installingVersionsKey, installKey);
+
+            this.updateGraveyard(installKey);
+            this.context.eventStream.post(new DotnetInstallGraveyardEvent(`Success at uninstalling ${installKey} in path ${dotnetInstallDir}`));
         }
         catch(error : any)
         {
-            this.context.eventStream.post(new SuppressedAcquisitionError(error, `The attempt to uninstall .NET ${version} failed - was .NET in use?`))
+            this.context.eventStream.post(new SuppressedAcquisitionError(error, `The attempt to uninstall .NET ${installKey} failed - was .NET in use?`))
         }
     }
 
@@ -290,7 +337,23 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
 
     private removeFolderRecursively(folderPath: string) {
         this.context.eventStream.post(new DotnetAcquisitionDeletion(folderPath));
-        rimraf.sync(folderPath);
+        try
+        {
+            fs.chmodSync(folderPath, 0o744);
+        }
+        catch(error : any)
+        {
+            this.context.eventStream.post(new SuppressedAcquisitionError(error, `Failed to chmod +x on .NET folder ${folderPath} when marked for deletion.`));
+        }
+
+        try
+        {
+            rimraf.sync(folderPath);
+        }
+        catch(error : any)
+        {
+            this.context.eventStream.post(new SuppressedAcquisitionError(error, `Failed to delete .NET folder ${folderPath} when marked for deletion.`));
+        }
     }
 
     private async managePreinstalledVersion(dotnetInstallDir: string, installedInstallKeys: string[]): Promise<string[]> {

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -130,6 +130,7 @@ export class DotnetInstallScriptAcquisitionError extends DotnetAcquisitionError 
     public readonly eventName = 'DotnetInstallScriptAcquisitionError';
 }
 
+
 export class WebRequestError extends DotnetAcquisitionError {
     public readonly eventName = 'WebRequestError';
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -130,7 +130,6 @@ export class DotnetInstallScriptAcquisitionError extends DotnetAcquisitionError 
     public readonly eventName = 'DotnetInstallScriptAcquisitionError';
 }
 
-
 export class WebRequestError extends DotnetAcquisitionError {
     public readonly eventName = 'WebRequestError';
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -323,6 +323,10 @@ export class DotnetCommandNotFoundEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetCommandNotFoundEvent';
 }
 
+export class DotnetInstallGraveyardEvent extends DotnetCustomMessageEvent {
+    public readonly eventName = 'DotnetInstallGraveyardEvent';
+}
+
 export class DotnetAlternativeCommandFoundEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetAlternativeCommandFoundEvent';
 }

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -66,6 +66,14 @@ export class NoInstallAcquisitionInvoker extends IAcquisitionInvoker {
     }
 }
 
+export class MockDotnetCoreAcquisitionWorker extends DotnetCoreAcquisitionWorker
+{
+    public AddToGraveyard(installKey : string, installPath : string)
+    {
+        this.updateGraveyard(installKey, installPath);
+    }
+}
+
 export class RejectingAcquisitionInvoker extends IAcquisitionInvoker {
     public installDotnet(installContext: IDotnetInstallationContext): Promise<void> {
         return new Promise<void>((resolve, reject) => {
@@ -194,7 +202,8 @@ export class MockApostropheScriptAcquisitionWorker extends MockInstallScriptWork
     }
 }
 
-export class MockAcquisitionInvoker extends AcquisitionInvoker{
+export class MockAcquisitionInvoker extends AcquisitionInvoker
+{
     protected readonly scriptWorker: MockApostropheScriptAcquisitionWorker
     constructor(extensionState: IExtensionState, eventStream: IEventStream, timeoutTime : number ,installFolder : string) {
         super(extensionState, eventStream, timeoutTime);

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -41,8 +41,8 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
     const installedVersionsKey = 'installed';
     const dotnetFolderName = `.dotnet O'Hare O'Donald`;
 
-    function getTestAcquisitionWorker(runtimeInstall: boolean, arch : string | null | undefined = undefined,
-        customEventStream? : MockEventStream , customContext? : MockExtensionContext): [MockDotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext]
+    function getTestAcquisitionWorker(runtimeInstall: boolean, arch? : string | null,
+        customEventStream? : MockEventStream, customContext? : MockExtensionContext): [MockDotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext]
     {
         const context =  customContext ?? new MockExtensionContext();
         const eventStream = customEventStream ?? new MockEventStream();

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -36,6 +36,8 @@ import {
 const assert = chai.assert;
 chai.use(chaiAsPromised);
 
+const expectedTimeoutTime = 6000;
+
 suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
     const installingVersionsKey = 'installing';
     const installedVersionsKey = 'installed';
@@ -328,7 +330,7 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
             assert.equal(result.dotnetPath, expectedPath);
             deleteFolderRecursive(path.join(process.cwd(), installApostropheFolder));
         }
-    });
+    }).timeout(expectedTimeoutTime);
 
     function deleteFolderRecursive(folderPath: string) {
         if (fs.existsSync(folderPath)) {

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -17,6 +17,7 @@ import {
     DotnetAcquisitionStarted,
     DotnetAcquisitionStatusResolved,
     DotnetAcquisitionStatusUndefined,
+    DotnetInstallGraveyardEvent,
     DotnetUninstallAllCompleted,
     DotnetUninstallAllStarted,
     TestAcquireCalled,
@@ -25,6 +26,7 @@ import { EventType } from '../../EventStream/EventType';
 import {
     ErrorAcquisitionInvoker,
     MockAcquisitionInvoker,
+    MockDotnetCoreAcquisitionWorker,
     MockEventStream,
     MockExtensionContext,
     MockInstallationValidator,
@@ -40,11 +42,11 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
     const dotnetFolderName = `.dotnet O'Hare O'Donald`;
 
     function getTestAcquisitionWorker(runtimeInstall: boolean, arch : string | null | undefined = undefined,
-        customEventStream? : MockEventStream , customContext? : MockExtensionContext): [DotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext]
+        customEventStream? : MockEventStream , customContext? : MockExtensionContext): [MockDotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext]
     {
         const context =  customContext ?? new MockExtensionContext();
         const eventStream = customEventStream ?? new MockEventStream();
-        const acquisitionWorker = new DotnetCoreAcquisitionWorker({
+        const acquisitionWorker = new MockDotnetCoreAcquisitionWorker({
             storagePath: '',
             extensionState: context,
             eventStream,
@@ -220,6 +222,23 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
         assert.exists(eventStream.events.find(event => event instanceof DotnetUninstallAllCompleted));
         assert.isEmpty(context.get<string[]>(installingVersionsKey, []));
         assert.isEmpty(context.get<string[]>(installedVersionsKey, []));
+    });
+
+    test('Graveyard Removes Failed Uninstalls', async () => {
+        const [acquisitionWorker, eventStream, context] = getTestAcquisitionWorker(true);
+        const version = '1.0';
+        const installKey = acquisitionWorker.getInstallKey(version);
+        const res = await acquisitionWorker.acquireRuntime(version);
+        await assertAcquisitionSucceeded(installKey, res.dotnetPath, eventStream, context);
+        acquisitionWorker.AddToGraveyard(installKey, 'Not applicable');
+
+        const versionToKeep = '5.0';
+        const versionToKeepKey = acquisitionWorker.getInstallKey(versionToKeep);
+        await acquisitionWorker.acquireRuntime(versionToKeep);
+
+        assert.exists(eventStream.events.find(event => event instanceof DotnetInstallGraveyardEvent), 'The graveyard tried to uninstall .NET');
+        assert.isEmpty(context.get<string[]>(installingVersionsKey, []), 'We did not hang/ get interrupted during the install.');
+        assert.deepEqual(context.get<string[]>(installedVersionsKey, []), [versionToKeepKey], '.NET was successfully uninstalled and cleaned up properly when marked to be.');
     });
 
     test('Correctly Removes Legacy (No-Architecture) Installs', async () =>

--- a/vscode-dotnet-runtime-library/src/test/unit/WebRequestWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WebRequestWorker.test.ts
@@ -112,6 +112,6 @@ suite('WebRequestWorker Unit Tests', () => {
         assert.exists(uncachedResult);
         const requestCount = webWorker.getRequestCount();
         assert.isAtLeast(requestCount, 2);
-    }).timeout((maxTimeoutTime*5) + 2000);
+    }).timeout((maxTimeoutTime*7) + 2000);
 });
 


### PR DESCRIPTION
Users can experience failure to uninstall, which our extension reports as an 'acquisition failure', however, based on the code and logs it returns as success and finishes installing successfully. It never tries to uninstall a 'legacy' no arch install unless the install succeeded. We would like to remove this failure and report it silently for our records, then try to uninstall again later when .net may not be in use. 

resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1413

We dont just delete the promise even if uninstall fails because it could be picked up as a legitimiate install or partial install and cause a lot of bugs, so it gets moved to a separate 'graveyard' for GCollection