### PR TITLE
Add Global SDK Acquistion to the Runtime Extension

### DIFF
--- a/Documentation/troubleshooting-runtime.md
+++ b/Documentation/troubleshooting-runtime.md
@@ -1,4 +1,4 @@
-# Troubleshooting Issues with the .NET Runtime Install Tool
+# Troubleshooting Issues with the .NET Install Tool
 
 ## Install Script Timeouts
 
@@ -14,7 +14,7 @@ Learn more about configuring Visual Studio Code settings [here](https://code.vis
 
 ## Windows 7 Failures
 
-The .NET Runtime Install Tool requires TLS 1.2 to be enabled in order to install .NET. For more information on TLS1.2, see [the documentation](https://docs.microsoft.com/mem/configmgr/core/plan-design/security/enable-tls-1-2-client).
+The .NET Install Tool requires TLS 1.2 to be enabled in order to install .NET. For more information on TLS1.2, see [the documentation](https://docs.microsoft.com/mem/configmgr/core/plan-design/security/enable-tls-1-2-client).
 
 ## Manually Installing .NET
 
@@ -37,4 +37,4 @@ If .NET installation is failing or you want to reuse an existing installation of
 
 ## Other Issues
 
-Haven't found a solution? Check out our [open issues](https://github.com/dotnet/vscode-dotnet-runtime/issues). If you don't see your issue there, please file a new issue by evoking the `.NET Install Tool: Report an issue with the .NET Runtime Install Tool` command from Visual Studio Code.
+Haven't found a solution? Check out our [open issues](https://github.com/dotnet/vscode-dotnet-runtime/issues). If you don't see your issue there, please file a new issue by evoking the `.NET Install Tool: Report an issue with the .NET Install Tool` command from Visual Studio Code.

--- a/sample/package.json
+++ b/sample/package.json
@@ -52,13 +52,18 @@
 				"category": "Sample"
 			},
 			{
+				"command": "sample.dotnet.acquireGlobalSDK",
+				"title": "Install .NET SDK Globally via .NET Install Tool (Former Runtime Extension)",
+				"category": "Sample"
+			},
+			{
 				"command": "sample.dotnet-sdk.acquire",
 				"title": "Acquire .NET SDK",
 				"category": "Sample"
 			},
 			{
 				"command": "sample.dotnet-sdk.acquireGlobal",
-				"title": "Acquire .NET SDK on the machine globally. Requires admin.",
+				"title": "Acquire .NET SDK on the machine globally using the SDK Extension. Requires admin.",
 				"category": "Sample"
 			},
 			{

--- a/sample/src/extension.ts
+++ b/sample/src/extension.ts
@@ -154,6 +154,27 @@ ${stderr}`);
         sampleShowAcquisitionLogRegistration,
     );
 
+    const sampleGlobalSDKFromRuntimeRegistration = vscode.commands.registerCommand('sample.dotnet.acquireGlobalSDK', async (version) => {
+        if (!version) {
+            version = await vscode.window.showInputBox({
+                placeHolder: '7.0.103',
+                value: '7.0.103',
+                prompt: 'The .NET SDK version. You can use different formats: 5, 3.1, 7.0.3xx, 6.0.201, etc.',
+            });
+        }
+
+        try
+        {
+            await vscode.commands.executeCommand('dotnet-sdk.showAcquisitionLog');
+            let commandContext : IDotnetAcquireContext = { version, requestingExtensionId, installType: 'global' };
+            await vscode.commands.executeCommand('dotnet.acquireGlobalSDK', commandContext);
+        }
+        catch (error)
+        {
+            vscode.window.showErrorMessage((error as Error).toString());
+        }
+    });
+
     // --------------------------------------------------------------------------
 
     // ---------------------sdk extension registrations--------------------------
@@ -264,5 +285,6 @@ ${stderr}`);
         sampleSDKlistVersions,
         sampleSDKrecommendedVersion,
         sampleSDKDotnetUninstallAllRegistration,
-        sampleSDKShowAcquisitionLogRegistration);
+        sampleSDKShowAcquisitionLogRegistration,
+        sampleGlobalSDKFromRuntimeRegistration);
 }

--- a/vscode-dotnet-runtime-extension/README.md
+++ b/vscode-dotnet-runtime-extension/README.md
@@ -1,8 +1,8 @@
-# .NET Runtime Install Tool
+# .NET Install Tool
 
 [![Version](https://img.shields.io/visual-studio-marketplace/v/ms-dotnettools.vscode-dotnet-runtime?style=for-the-badge)](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.vscode-dotnet-runtime) [![Installs](https://img.shields.io/visual-studio-marketplace/i/ms-dotnettools.vscode-dotnet-runtime?style=for-the-badge)](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.vscode-dotnet-runtime)
 
-This extension provides a unified way for other extensions like the [C#] and [C# Dev Kit] extensions to install local, private versions of the .NET Runtime. This extension is not intended to be used directly by users to install .NET for development purposes because it only includes the .NET Runtime and not the entire .NET SDK.
+This extension provides a unified way for other extensions like the [C#] and [C# Dev Kit] extensions to install local versions of the .NET Runtime, and machine-wide versions of the .NET SDK. Those extensions tell the .NET Install Tool when they would like a .NET SDK to be on the machine, and we install one for them if there's not already one that matches the SDK they need to run properly. In the future, this tool may support allowing users to call the API via VS Code to install .NET and pick a version of the SDK to install themselves.
 
 ## Why do I have this extension?
 
@@ -15,7 +15,7 @@ This extension was probably included as a dependency of one of the following ext
 * [CMake]
 * [Bicep]
 
-These extensions call into this extension to provide a unified way of downloading per-extension copies of the .NET Runtime for those extensions to use internally. If you already have an installation of .NET that you'd like to use, see [the troubleshooting section below](#i-already-have-a-net-runtime-or-sdk-installed-and-i-want-to-use-it). If you want to remove this extension completely, you will need to uninstall any extensions that depend on it first. If this extension is uninstalled, any .NET Runtimes installed by it will also be removed.
+The above extensions call into this extension to provide a unified way of downloading shared .NET Runtimes or .NET SDKs. If you already have an installation of .NET that you'd like to use, see [the troubleshooting section below](#i-already-have-a-net-runtime-or-sdk-installed-and-i-want-to-use-it). If you want to remove this extension completely, you will need to uninstall any extensions that depend on it first. If this extension is uninstalled, any .NET Runtimes installed by it will also be removed.
 
 ## Troubleshooting
 
@@ -38,9 +38,9 @@ For [C# Dev Kit] you would use the same thing, but with the extension ID `ms-dot
 > You'll need to make a new item in the settings array for each extension that uses this extension to acquire .NET.
 
 
-### Downloading the .NET Runtime times out
+### Downloading .NET times out
 
-It can sometimes take a while to download the .NET Runtime. While the default download time is 600 seconds, if you need more time you can set the `dotnetAcquisitionExtension.installTimeoutValue` setting to change that timeout. Here's an example of increasing the download timeout to 11 minutes:
+It can sometimes take a while to download .NET. While the default download time is 600 seconds, if you need more time you can set the `dotnetAcquisitionExtension.installTimeoutValue` setting to change that timeout. Here's an example of increasing the download timeout to 11 minutes:
 
 ```json
 {
@@ -84,7 +84,7 @@ This extension attempts to solve the above issues.
 
 ## .NET Foundation
 
-The .NET Runtime Install Tool is a [.NET Foundation](https://www.dotnetfoundation.org/projects) project.
+The .NET Install Tool is a [.NET Foundation](https://www.dotnetfoundation.org/projects) project.
 
 See the [.NET home repo](https://github.com/Microsoft/dotnet) to find other .NET-related projects.
 

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -9,7 +9,7 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft Corporation",
-	"displayName": ".NET Runtime Install Tool",
+	"displayName": ".NET Install Tool",
 	"description": "This extension installs and manages different versions of the .NET Runtime.",
 	"appInsightsKey": "02dc18e0-7494-43b2-b2a3-18ada5fcb522",
 	"icon": "images/dotnetIcon.png",
@@ -47,17 +47,17 @@
 		"commands": [
 			{
 				"command": "dotnet.reportIssue",
-				"title": "Report an issue with the .NET Runtime Install Tool.",
-				"category": ".NET Runtime Install Tool"
+				"title": "Report an issue with the .NET Install Tool.",
+				"category": ".NET Install Tool"
 			}
 		],
 		"configuration": {
-			"title": ".NET Runtime Install Tool",
+			"title": ".NET Install Tool",
 			"properties": {
 				"dotnetAcquisitionExtension.enableTelemetry": {
 					"type": "boolean",
 					"default": true,
-					"description": "Enable Telemetry for the .NET Runtime Install Tool. Restart VS Code to apply changes."
+					"description": "Enable Telemetry for the .NET Install Tool. Restart VS Code to apply changes."
 				},
 				"dotnetAcquisitionExtension.installTimeoutValue": {
 					"type": "number",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -67,11 +67,8 @@
 				},
 				"dotnetAcquisitionExtension.existingDotnetPath": {
 					"type": "array",
-					"description": "File Path to an existing installation of a .NET Runtime."
-				},
-				"dotnetAcquisitionExtension.existingDotnetSDKPath": {
-					"type": "array",
-					"description": "File Path to an existing installation of a .NET SDK Folder."
+					"description": "File Path to an existing installation of .NET. Used for both the .NET SDK and .NET Runtime.",
+					"examples": ["C:\\Program Files\\dotnet\\dotnet.exe", "/usr/local/share/dotnet/dotnet", "/usr/lib/dotnet/dotnet"]
 				},
 				"dotnetAcquisitionExtension.proxyUrl": {
 					"type": "string",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -37,6 +37,7 @@
 	"activationEvents": [
 		"onCommand:dotnet.acquire",
 		"onCommand:dotnet.acquireStatus",
+		"onCommand:dotnet.acquireGlobalSDK",
 		"onCommand:dotnet.uninstallAll",
 		"onCommand:dotnet.showAcquisitionLog",
 		"onCommand:dotnet.ensureDotnetDependencies"
@@ -66,7 +67,11 @@
 				},
 				"dotnetAcquisitionExtension.existingDotnetPath": {
 					"type": "array",
-					"description": "File Path to an existing installation of .NET."
+					"description": "File Path to an existing installation of a .NET Runtime."
+				},
+				"dotnetAcquisitionExtension.existingDotnetSDKPath": {
+					"type": "array",
+					"description": "File Path to an existing installation of a .NET SDK Folder."
 				},
 				"dotnetAcquisitionExtension.proxyUrl": {
 					"type": "string",

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -112,10 +112,10 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
     // Setting up command-shared classes for Runtime & SDK Acquisition
     const existingPathConfigWorker = new ExtensionConfigurationWorker(extensionConfiguration, configKeys.existingPath);
     const runtimeIssueContextFunctor = getIssueContext(existingPathConfigWorker);
-    const runtimeAcquisitionWorker = getAcquisitonWorker(true);
+    const runtimeAcquisitionWorker = getAcquisitionWorker(true);
 
     const sdkIssueContextFunctor = getIssueContext(existingPathConfigWorker);
-    const sdkAcquisitionWorker = getAcquisitonWorker(false);
+    const sdkAcquisitionWorker = getAcquisitionWorker(false);
 
     // Creating API Surfaces
     const dotnetAcquireRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquire}`, async (commandContext: IDotnetAcquireContext) => {
@@ -241,7 +241,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         });
     }
 
-    function getAcquisitonWorker(isRuntimeWorker : boolean) : DotnetCoreAcquisitionWorker
+    function getAcquisitionWorker(isRuntimeWorker : boolean) : DotnetCoreAcquisitionWorker
     {
         return new DotnetCoreAcquisitionWorker({
             storagePath: context.globalStoragePath,

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -54,7 +54,6 @@ namespace configKeys {
     export const installTimeoutValue = 'installTimeoutValue';
     export const enableTelemetry = 'enableTelemetry';
     export const existingPath = 'existingDotnetPath';
-    export const existingSDKPath = 'existingDotnetSDKPath';
     export const proxyUrl = 'proxyUrl';
 }
 namespace commandKeys {
@@ -111,12 +110,11 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
     const versionResolver = new VersionResolver(context.globalState, eventStream, resolvedTimeoutSeconds, proxyLink);
 
     // Setting up command-shared classes for Runtime & SDK Acquisition
-    const runtimeExistingPathConfigWorker = new ExtensionConfigurationWorker(extensionConfiguration, configKeys.existingPath);
-    const runtimeIssueContextFunctor = getIssueContext(runtimeExistingPathConfigWorker);
+    const existingPathConfigWorker = new ExtensionConfigurationWorker(extensionConfiguration, configKeys.existingPath);
+    const runtimeIssueContextFunctor = getIssueContext(existingPathConfigWorker);
     const runtimeAcquisitionWorker = getAcquisitonWorker(true);
 
-    const sdkExistingPathConfigWorker = new ExtensionConfigurationWorker(extensionConfiguration, configKeys.existingSDKPath);
-    const sdkIssueContextFunctor = getIssueContext(sdkExistingPathConfigWorker);
+    const sdkIssueContextFunctor = getIssueContext(existingPathConfigWorker);
     const sdkAcquisitionWorker = getAcquisitonWorker(false);
 
     // Creating API Surfaces
@@ -132,7 +130,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
                 throw new Error(`Cannot acquire .NET version "${commandContext.version}". Please provide a valid version.`);
             }
 
-            const existingPath = await resolveExistingPathIfExists(runtimeExistingPathConfigWorker, commandContext);
+            const existingPath = await resolveExistingPathIfExists(existingPathConfigWorker, commandContext);
             if(existingPath)
             {
                 return existingPath;
@@ -165,7 +163,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
             eventStream.post(new DotnetSDKAcquisitionStarted(commandContext.requestingExtensionId));
             eventStream.post(new DotnetAcquisitionRequested(commandContext.version, commandContext.requestingExtensionId));
 
-            const existingPath = await resolveExistingPathIfExists(sdkExistingPathConfigWorker, commandContext);
+            const existingPath = await resolveExistingPathIfExists(existingPathConfigWorker, commandContext);
             if(existingPath)
             {
                 return Promise.resolve(existingPath);

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -39,6 +39,10 @@ import {
     VSCodeExtensionContext,
     VSCodeEnvironment,
     WindowDisplayWorker,
+    DotnetSDKAcquisitionStarted,
+    GlobalInstallerResolver,
+    SdkInstallationDirectoryProvider,
+    CommandExecutor,
 } from 'vscode-dotnet-runtime-library';
 import { dotnetCoreAcquisitionExtensionId } from './DotnetCoreAcquisitionId';
 
@@ -50,10 +54,12 @@ namespace configKeys {
     export const installTimeoutValue = 'installTimeoutValue';
     export const enableTelemetry = 'enableTelemetry';
     export const existingPath = 'existingDotnetPath';
+    export const existingSDKPath = 'existingDotnetSDKPath';
     export const proxyUrl = 'proxyUrl';
 }
 namespace commandKeys {
     export const acquire = 'acquire';
+    export const acquireGlobalSDK = 'acquireGlobalSDK';
     export const acquireStatus = 'acquireStatus';
     export const uninstallAll = 'uninstallAll';
     export const showAcquisitionLog = 'showAcquisitionLog';
@@ -67,83 +73,69 @@ const displayChannelName = '.NET Runtime';
 const defaultTimeoutValue = 600;
 const moreInfoUrl = 'https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md';
 
-export function activate(context: vscode.ExtensionContext, extensionContext?: IExtensionContext) {
+export function activate(context: vscode.ExtensionContext, extensionContext?: IExtensionContext)
+{
+    // Loading Extension Configuration
     const extensionConfiguration = extensionContext !== undefined && extensionContext.extensionConfiguration ?
-        extensionContext.extensionConfiguration :
-        vscode.workspace.getConfiguration(configPrefix);
+    extensionContext.extensionConfiguration :
+    vscode.workspace.getConfiguration(configPrefix);
 
-    const extensionTelemetryEnabled = enableExtensionTelemetry(extensionConfiguration, configKeys.enableTelemetry);
-    const displayWorker = extensionContext ? extensionContext.displayWorker : new WindowDisplayWorker();
-
-    const utilContext = {
-        ui : displayWorker,
-        vsCodeEnv: new VSCodeEnvironment()
-    }
-
-    const eventStreamContext = {
-        displayChannelName,
-        logPath: context.logPath,
-        extensionId: dotnetCoreAcquisitionExtensionId,
-        enableTelemetry: extensionTelemetryEnabled,
-        telemetryReporter: extensionContext ? extensionContext.telemetryReporter : undefined,
-        showLogCommand: `${commandPrefix}.${commandKeys.showAcquisitionLog}`,
-        packageJson
-    } as IEventStreamContext;
-    const [eventStream, outputChannel, loggingObserver, eventStreamObservers] = registerEventStream(eventStreamContext, new VSCodeExtensionContext(context), utilContext);
-
-    const extensionConfigWorker = new ExtensionConfigurationWorker(extensionConfiguration, configKeys.existingPath);
-    const issueContext = (errorConfiguration: ErrorConfiguration | undefined, commandName: string, version?: string) => {
-        return {
-            logger: loggingObserver,
-            errorConfiguration: errorConfiguration || AcquireErrorConfiguration.DisplayAllErrorPopups,
-            displayWorker,
-            extensionConfigWorker,
-            eventStream,
-            commandName,
-            version,
-            moreInfoUrl,
-            timeoutInfoUrl: `${moreInfoUrl}#install-script-timeouts`
-        } as IIssueContext;
-    };
+    // Reading Extension Configuration
     const timeoutValue = extensionConfiguration.get<number>(configKeys.installTimeoutValue);
     if (!fs.existsSync(context.globalStoragePath)) {
         fs.mkdirSync(context.globalStoragePath);
     }
     const resolvedTimeoutSeconds = timeoutValue === undefined ? defaultTimeoutValue : timeoutValue;
-
     const proxyLink = extensionConfiguration.get<string>(configKeys.proxyUrl);
+    const isExtensionTelemetryEnabled = enableExtensionTelemetry(extensionConfiguration, configKeys.enableTelemetry);
+    const displayWorker = extensionContext ? extensionContext.displayWorker : new WindowDisplayWorker();
 
-    const acquisitionWorker = new DotnetCoreAcquisitionWorker({
-        storagePath: context.globalStoragePath,
-        extensionState: context.globalState,
-        eventStream,
-        acquisitionInvoker: new AcquisitionInvoker(context.globalState, eventStream, resolvedTimeoutSeconds, utilContext),
-        installationValidator: new InstallationValidator(eventStream),
-        timeoutValue: resolvedTimeoutSeconds,
-        installDirectoryProvider: new RuntimeInstallationDirectoryProvider(context.globalStoragePath),
-        proxyUrl: proxyLink,
-        isExtensionTelemetryInitiallyEnabled: extensionTelemetryEnabled
-    }, utilContext, new VSCodeExtensionContext(context));
-    const existingPathResolver = new ExistingPathResolver();
+    // Creating Contexts to Execute Under
+    const utilContext = {
+        ui : displayWorker,
+        vsCodeEnv: new VSCodeEnvironment()
+    }
+
+    const vsCodeExtensionContext = new VSCodeExtensionContext(context);
+    const eventStreamContext = {
+        displayChannelName,
+        logPath: context.logPath,
+        extensionId: dotnetCoreAcquisitionExtensionId,
+        enableTelemetry: isExtensionTelemetryEnabled,
+        telemetryReporter: extensionContext ? extensionContext.telemetryReporter : undefined,
+        showLogCommand: `${commandPrefix}.${commandKeys.showAcquisitionLog}`,
+        packageJson
+    } as IEventStreamContext;
+    const [eventStream, outputChannel, loggingObserver, eventStreamObservers] = registerEventStream(eventStreamContext, vsCodeExtensionContext, utilContext);
+
     const versionResolver = new VersionResolver(context.globalState, eventStream, resolvedTimeoutSeconds, proxyLink);
 
+    // Setting up command-shared classes for Runtime & SDK Acquisition
+    const runtimeExistingPathConfigWorker = new ExtensionConfigurationWorker(extensionConfiguration, configKeys.existingPath);
+    const runtimeIssueContextFunctor = getIssueContext(runtimeExistingPathConfigWorker);
+    const runtimeAcquisitionWorker = getAcquisitonWorker(true);
+
+    const sdkExistingPathConfigWorker = new ExtensionConfigurationWorker(extensionConfiguration, configKeys.existingSDKPath);
+    const sdkIssueContextFunctor = getIssueContext(sdkExistingPathConfigWorker);
+    const sdkAcquisitionWorker = getAcquisitonWorker(false);
+
+    // Creating API Surfaces
     const dotnetAcquireRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquire}`, async (commandContext: IDotnetAcquireContext) => {
         let fullyResolvedVersion = '';
         const dotnetPath = await callWithErrorHandling<Promise<IDotnetAcquireResult>>(async () => {
             eventStream.post(new DotnetRuntimeAcquisitionStarted(commandContext.requestingExtensionId));
             eventStream.post(new DotnetAcquisitionRequested(commandContext.version, commandContext.requestingExtensionId));
-            acquisitionWorker.setAcquisitionContext(commandContext);
+
+            runtimeAcquisitionWorker.setAcquisitionContext(commandContext);
 
             if (!commandContext.version || commandContext.version === 'latest') {
                 throw new Error(`Cannot acquire .NET version "${commandContext.version}". Please provide a valid version.`);
             }
 
-            const existingPath = existingPathResolver.resolveExistingPath(extensionConfigWorker.getPathConfigurationValue(), commandContext.requestingExtensionId, displayWorker);
-            if (existingPath) {
-                eventStream.post(new DotnetExistingPathResolutionCompleted(existingPath.dotnetPath));
-                return new Promise((resolve) => {
-                    resolve(existingPath);
-                });
+            const existingPath = await resolveExistingPathIfExists(runtimeExistingPathConfigWorker, commandContext);
+            if(existingPath)
+            {
+                return existingPath;
             }
 
             const version = await versionResolver.getFullRuntimeVersion(commandContext.version);
@@ -151,28 +143,63 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
 
             if(commandContext.architecture !== undefined)
             {
-                acquisitionWorker.installingArchitecture = commandContext.architecture;
+                runtimeAcquisitionWorker.installingArchitecture = commandContext.architecture;
             }
-            return acquisitionWorker.acquireRuntime(version);
-        }, issueContext(commandContext.errorConfiguration, 'acquire', commandContext.version), commandContext.requestingExtensionId);
+            return runtimeAcquisitionWorker.acquireRuntime(version);
+        }, runtimeIssueContextFunctor(commandContext.errorConfiguration, 'acquire', commandContext.version), commandContext.requestingExtensionId);
 
-        const installKey = acquisitionWorker.getInstallKey(fullyResolvedVersion);
+        const installKey = runtimeAcquisitionWorker.getInstallKey(fullyResolvedVersion);
         eventStream.post(new DotnetRuntimeAcquisitionTotalSuccessEvent(commandContext.version, installKey, commandContext.requestingExtensionId ?? '', dotnetPath?.dotnetPath ?? ''));
         return dotnetPath;
+    });
+
+    const dotnetAcquireGlobalSDKRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquireGlobalSDK}`, async (commandContext: IDotnetAcquireContext) =>
+    {
+        if (commandContext.requestingExtensionId === undefined)
+        {
+            return Promise.reject('No requesting extension id was provided.');
+        }
+
+        const pathResult = callWithErrorHandling(async () =>
+        {
+            eventStream.post(new DotnetSDKAcquisitionStarted(commandContext.requestingExtensionId));
+            eventStream.post(new DotnetAcquisitionRequested(commandContext.version, commandContext.requestingExtensionId));
+
+            const existingPath = await resolveExistingPathIfExists(sdkExistingPathConfigWorker, commandContext);
+            if(existingPath)
+            {
+                return Promise.resolve(existingPath);
+            }
+
+            sdkAcquisitionWorker.setAcquisitionContext(commandContext);
+
+            if(commandContext.version === '' || !commandContext.version)
+            {
+                throw Error(`No version was defined to install.`);
+            }
+
+            const globalInstallerResolver = new GlobalInstallerResolver(context.globalState, eventStream, commandContext.version, resolvedTimeoutSeconds, proxyLink);
+            const dotnetPath = await sdkAcquisitionWorker.acquireGlobalSDK(globalInstallerResolver);
+
+            new CommandExecutor(eventStream, utilContext).setPathEnvVar(dotnetPath.dotnetPath, moreInfoUrl, displayWorker, vsCodeExtensionContext, true);
+            return dotnetPath;
+        }, sdkIssueContextFunctor(commandContext.errorConfiguration, commandKeys.acquireGlobalSDK));
+
+        return pathResult;
     });
 
     const dotnetAcquireStatusRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquireStatus}`, async (commandContext: IDotnetAcquireContext) => {
         const pathResult = callWithErrorHandling(async () => {
             eventStream.post(new DotnetAcquisitionStatusRequested(commandContext.version, commandContext.requestingExtensionId));
             const resolvedVersion = await versionResolver.getFullRuntimeVersion(commandContext.version);
-            const dotnetPath = await acquisitionWorker.acquireStatus(resolvedVersion, true);
+            const dotnetPath = await runtimeAcquisitionWorker.acquireStatus(resolvedVersion, true);
             return dotnetPath;
-        }, issueContext(commandContext.errorConfiguration, 'acquireRuntimeStatus'));
+        }, runtimeIssueContextFunctor(commandContext.errorConfiguration, 'acquireRuntimeStatus'));
         return pathResult;
     });
 
     const dotnetUninstallAllRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.uninstallAll}`, async (commandContext: IDotnetUninstallContext | undefined) => {
-        await callWithErrorHandling(() => acquisitionWorker.uninstallAll(), issueContext(commandContext ? commandContext.errorConfiguration : undefined, 'uninstallAll'));
+        await callWithErrorHandling(() => runtimeAcquisitionWorker.uninstallAll(), runtimeIssueContextFunctor(commandContext ? commandContext.errorConfiguration : undefined, 'uninstallAll'));
     });
 
     const showOutputChannelRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.showAcquisitionLog}`, () => outputChannel.show(/* preserveFocus */ false));
@@ -190,18 +217,69 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
                 eventStream.post(new DotnetAcquisitionMissingLinuxDependencies());
                 await installer.promptLinuxDependencyInstall('Failed to run .NET runtime.');
             }
-        }, issueContext(commandContext.errorConfiguration, 'ensureDependencies'));
+        }, runtimeIssueContextFunctor(commandContext.errorConfiguration, 'ensureDependencies'));
     });
 
     const reportIssueRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.reportIssue}`, async () => {
-        const [url, issueBody] = formatIssueUrl(undefined, issueContext(AcquireErrorConfiguration.DisableErrorPopups, 'reportIssue'));
+        const [url, issueBody] = formatIssueUrl(undefined, runtimeIssueContextFunctor(AcquireErrorConfiguration.DisableErrorPopups, 'reportIssue'));
         await vscode.env.clipboard.writeText(issueBody);
         open(url);
     });
 
+    // Helper Functions
+    function resolveExistingPathIfExists(configResolver : ExtensionConfigurationWorker, commandContext : IDotnetAcquireContext) : Promise<IDotnetAcquireResult | null>
+    {
+        const existingPathResolver = new ExistingPathResolver();
+
+        const existingPath = existingPathResolver.resolveExistingPath(configResolver.getPathConfigurationValue(), commandContext.requestingExtensionId, displayWorker);
+        if (existingPath) {
+            eventStream.post(new DotnetExistingPathResolutionCompleted(existingPath.dotnetPath));
+            return new Promise((resolve) => {
+                resolve(existingPath);
+            });
+        }
+        return new Promise((resolve) => {
+            resolve(null);
+        });
+    }
+
+    function getAcquisitonWorker(isRuntimeWorker : boolean) : DotnetCoreAcquisitionWorker
+    {
+        return new DotnetCoreAcquisitionWorker({
+            storagePath: context.globalStoragePath,
+            extensionState: context.globalState,
+            eventStream,
+            acquisitionInvoker: new AcquisitionInvoker(context.globalState, eventStream, resolvedTimeoutSeconds, utilContext),
+            installationValidator: new InstallationValidator(eventStream),
+            timeoutValue: resolvedTimeoutSeconds,
+            installDirectoryProvider: isRuntimeWorker ? new RuntimeInstallationDirectoryProvider(context.globalStoragePath): new SdkInstallationDirectoryProvider(context.globalStoragePath),
+            proxyUrl: proxyLink,
+            isExtensionTelemetryInitiallyEnabled: isExtensionTelemetryEnabled
+        }, utilContext, vsCodeExtensionContext);
+    }
+
+    function getIssueContext(configResolver : ExtensionConfigurationWorker)
+    {
+        return (errorConfiguration: ErrorConfiguration | undefined, commandName: string, version?: string) => {
+            return {
+                logger: loggingObserver,
+                errorConfiguration: errorConfiguration || AcquireErrorConfiguration.DisplayAllErrorPopups,
+                displayWorker,
+                extensionConfigWorker: configResolver,
+                eventStream,
+                commandName,
+                version,
+                moreInfoUrl,
+                timeoutInfoUrl: `${moreInfoUrl}#install-script-timeouts`
+            } as IIssueContext;
+        };
+    }
+
+    // Exposing API Endpoints
     context.subscriptions.push(
         dotnetAcquireRegistration,
         dotnetAcquireStatusRegistration,
+        dotnetAcquireGlobalSDKRegistration,
         dotnetUninstallAllRegistration,
         showOutputChannelRegistration,
         ensureDependenciesRegistration,

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -22,6 +22,8 @@ import {
 import * as extension from '../../extension';
 import { warn } from 'console';
 /* tslint:disable:no-any */
+/* tslint:disable:no-unsafe-finally */
+
 const assert : any = chai.assert;
 const standardTimeoutTime = 40000;
 

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -10,6 +10,7 @@ import * as rimraf from 'rimraf';
 import * as vscode from 'vscode';
 import {
   DotnetCoreAcquisitionWorker,
+  FileUtilities,
   IDotnetAcquireContext,
   IDotnetAcquireResult,
   ITelemetryEvent,
@@ -19,6 +20,7 @@ import {
   MockWindowDisplayWorker
 } from 'vscode-dotnet-runtime-library';
 import * as extension from '../../extension';
+import { warn } from 'console';
 /* tslint:disable:no-any */
 const assert : any = chai.assert;
 const standardTimeoutTime = 40000;
@@ -62,7 +64,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function() {
     assert.isAbove(extensionContext.subscriptions.length, 0);
   }).timeout(standardTimeoutTime);
 
-  test('Install Command', async () => {
+  test('Install Local Runtime Command', async () => {
     const context: IDotnetAcquireContext = { version: '2.2', requestingExtensionId };
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
     assert.exists(result);
@@ -72,7 +74,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function() {
     assert.include(result!.dotnetPath, context.version);
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall Command', async () => {
+  test('Uninstall Local Runtime Command', async () => {
     const context: IDotnetAcquireContext = { version: '2.1', requestingExtensionId };
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
     assert.exists(result);
@@ -84,7 +86,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function() {
   }).timeout(standardTimeoutTime);
 
 
-  test('Install and Uninstall Multiple Versions', async () => {
+  test('Install and Uninstall Multiple Local Runtime Versions', async () => {
     const versions = ['2.2', '3.0', '3.1'];
     let dotnetPaths: string[] = [];
     for (const version of versions) {
@@ -101,6 +103,57 @@ suite('DotnetCoreAcquisitionExtension End to End', function() {
       assert.isTrue(fs.existsSync(dotnetPath));
     }
   }).timeout(standardTimeoutTime * 2);
+
+  test('Install SDK Globally E2E (Requires Admin)', async () => {
+    // We only test if the process is running under ADMIN because non-admin requires user-intervention.
+    if(new FileUtilities().isElevated())
+    {
+      const originalPath = process.env.PATH;
+      const sdkVersion = '7.0.103';
+      const context : IDotnetAcquireContext = { version: sdkVersion, requestingExtensionId: 'sample-extension', installType: 'global' };
+
+      // We cannot use the describe pattern to restore the environment variables using vscodes extension testing infrastructure.
+      // So we must set and unset it ourselves, which isn't ideal as this variable could remain.
+      let result : IDotnetAcquireResult;
+      let error : any;
+      let pathAfterInstall;
+
+      // We cannot test much as we don't want to leave global installs on dev boxes. But we do want to make sure the e-2-e goes through the right path. Vendors can test the rest.
+      // So we have this environment variable that tells us to stop before running any real install.
+      process.env.VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH = 'true';
+      try
+      {
+        result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquireGlobalSDK', context);
+      }
+      catch(err)
+      {
+        error = err;
+      }
+      finally
+      {
+        pathAfterInstall = process.env.PATH;
+        process.env.VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH = undefined;
+        process.env.PATH = originalPath;
+
+        if(error)
+        {
+          throw(new Error(`The test failed to run the acquire command successfully. Error: ${error}`));
+        }
+      }
+
+      assert.exists(result!, 'The global acquisition command did not provide a result?');
+      assert.exists(result!.dotnetPath);
+      assert.equal(result!.dotnetPath, 'fake-sdk');
+      assert.exists(pathAfterInstall, 'The environment variable PATH for DOTNET was not found?');
+      assert.include(pathAfterInstall, result!.dotnetPath, 'Is the PATH correctly set by the global installer?');
+    }
+    else
+    {
+      // We could run the installer without privilege but it would require human interaction to use the UAC
+      // And we wouldn't be able to kill the process so the test would leave a lot of hanging processes on the machine
+      warn('The Global SDK E2E Install test cannot run as the machine is unprivileged.');
+    }
+  }).timeout(standardTimeoutTime*1000);
 
   test('Telemetry Sent During Install and Uninstall', async () => {
     const rntVersion = '2.2';
@@ -151,7 +204,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function() {
     }
   }).timeout(standardTimeoutTime/2);
 
-  test('Install Command Passes With Warning With No RequestingExtensionId', async () => {
+  test('Install Local Runtime Command Passes With Warning With No RequestingExtensionId', async () => {
     const context: IDotnetAcquireContext = { version: '3.1' };
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
     assert.exists(result);
@@ -160,7 +213,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function() {
     assert.include(mockDisplayWorker.warningMessage, 'Ignoring existing .NET paths');
   }).timeout(standardTimeoutTime);
 
-  test('Install Command With Path Config Defined', async () => {
+  test('Install Local Runtime Command With Path Config Defined', async () => {
     const context: IDotnetAcquireContext = { version: '0.1', requestingExtensionId: 'alternative.extension' };
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
     assert.exists(result);

--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -51,8 +51,8 @@
 				"commandParts": ["-l", "{packageName}"]
 			}
 		],
-		"expectedDistroFeedInstallDirectory" : "/usr/lib/dotnet/sdk",
-        "expectedMicrosoftFeedInstallDirectory" : "/usr/bin/dotnet",
+		"expectedDistroFeedInstallDirectory" : "/usr/lib/dotnet/dotnet",
+        "expectedMicrosoftFeedInstallDirectory" : "/usr/bin/dotnet/dotnet",
 		"installedSDKVersionsCommand":
 		[
 			{

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -320,7 +320,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
 
         TelemetryUtilities.setDotnetSDKTelemetryToMatch(this.context.isExtensionTelemetryInitiallyEnabled, this.extensionContext, this.context.eventStream, this.utilityContext);
 
-        this.context.installationValidator.validateDotnetInstall(installingVersion, installedSDKPath, true);
+        this.context.installationValidator.validateDotnetInstall(installingVersion, installedSDKPath);
 
         this.context.eventStream.post(new DotnetAcquisitionCompleted(installKey, installedSDKPath, installingVersion));
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -167,13 +167,13 @@ We cannot verify .NET is safe to download at this time. Please try again later.`
             // The program files should always be set, but in the off chance they are wiped, we can try to use the default as backup.
             // Both ia32 and x64 machines will use 'Program Files'
             // We don't anticipate a user would need to install the x86 SDK, and we don't have any routes that support that yet.
-            return process.env.programfiles ? path.resolve(path.join(process.env.programfiles, 'dotnet', 'sdk')) : path.resolve(`C:\\Program Files\\dotnet\\sdk\\`);
+            return process.env.programfiles ? path.resolve(path.join(process.env.programfiles, 'dotnet', 'dotnet.exe')) : path.resolve(`C:\\Program Files\\dotnet\\dotnet.exe`);
         }
         else if(os.platform() === 'darwin')
         {
             // On an arm machine we would install to /usr/local/share/dotnet/x64/dotnet/sdk` for a 64 bit sdk
             // but we don't currently allow customizing the install architecture so that would never happen.
-            return path.resolve(`/usr/local/share/dotnet/sdk`);
+            return path.resolve(`/usr/local/share/dotnet/dotnet`);
         }
 
         const err = new DotnetUnexpectedInstallerOSError(new Error(`The operating system ${os.platform()} is unsupported.`));

--- a/vscode-dotnet-runtime-library/src/IVSCodeExtensionContext.ts
+++ b/vscode-dotnet-runtime-library/src/IVSCodeExtensionContext.ts
@@ -5,7 +5,7 @@
 
 export abstract class IVSCodeExtensionContext
 {
-    /**
-     */
     abstract setVSCodeEnvironmentVariable(variable : string, value : string) : void;
+
+    abstract appendToEnvironmentVariable(variable : string, pathAdditionWithDelimiter : string) : void;
 }

--- a/vscode-dotnet-runtime-library/src/VSCodeExtensionContext.ts
+++ b/vscode-dotnet-runtime-library/src/VSCodeExtensionContext.ts
@@ -22,4 +22,9 @@ export class VSCodeExtensionContext extends IVSCodeExtensionContext
         environment.replace(variable, value);
     }
 
+    appendToEnvironmentVariable(variable: string, appendingValue: string): void
+    {
+        const environment = this.context.environmentVariableCollection;
+        environment.append(variable, appendingValue);
+    }
 }

--- a/vscode-dotnet-runtime-library/src/VSCodeExtensionContext.ts
+++ b/vscode-dotnet-runtime-library/src/VSCodeExtensionContext.ts
@@ -25,6 +25,6 @@ export class VSCodeExtensionContext extends IVSCodeExtensionContext
     appendToEnvironmentVariable(variable: string, appendingValue: string): void
     {
         const environment = this.context.environmentVariableCollection;
-        environment.append(variable, appendingValue);
+        environment?.append(variable, appendingValue);
     }
 }

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -203,6 +203,10 @@ export class MockIndexWebRequestWorker extends WebRequestWorker {
 
 export class MockVSCodeExtensionContext extends IVSCodeExtensionContext
 {
+    appendToEnvironmentVariable(variable: string, pathAdditionWithDelimiter: string): void {
+        // Do nothing.
+    }
+
     setVSCodeEnvironmentVariable(variable: string, value: string): void {
         // Do nothing.
     }

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -51,7 +51,7 @@ suite('Linux Distro Logic Unit Tests', () =>
         if(shouldRun)
         {
             const distroFeedDir = await provider.getExpectedDotnetDistroFeedInstallationDirectory();
-            assert.equal(distroFeedDir, '/usr/lib/dotnet/sdk');
+            assert.equal(distroFeedDir, '/usr/lib/dotnet/dotnet');
         }
     });
 
@@ -59,7 +59,7 @@ suite('Linux Distro Logic Unit Tests', () =>
         if(shouldRun)
         {
             const microsoftFeedDir = await provider.getExpectedDotnetMicrosoftFeedInstallationDirectory();
-            assert.equal(microsoftFeedDir, '/usr/bin/dotnet');
+            assert.equal(microsoftFeedDir, '/usr/bin/dotnet/dotnet');
         }
     });
 

--- a/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -302,58 +302,6 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.strictEqual(await resolver.getFullySpecifiedVersion(), fullVersion);
   }).timeout(standardTimeoutTime);
 
-
-  test('Install Globally E2E (Requires Admin)', async () => {
-    // We only test if the process is running under ADMIN because non-admin requires user-intervention.
-    if(new FileUtilities().isElevated())
-    {
-      const originalPath = process.env.PATH;
-      const sdkVersion = '7.0.103';
-      const context : IDotnetAcquireContext = { version: sdkVersion, requestingExtensionId: 'ms-dotnettools.sample-extension', installType: 'global' };
-
-      // We cannot use the describe pattern to restore the environment variables using vscodes extension testing infrastructure.
-      // So we must set and unset it ourselves, which isn't ideal as this variable could remain.
-      let result : IDotnetAcquireResult;
-      let error : any;
-      let pathAfterInstall;
-
-      // We cannot test much as we don't want to leave global installs on dev boxes. But we do want to make sure the e-2-e goes through the right path. Vendors can test the rest.
-      // So we have this environment variable that tells us to stop before running any real install.
-      process.env.VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH = 'true';
-      try
-      {
-        result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet-sdk.acquire', context);
-      }
-      catch(err)
-      {
-        error = err;
-      }
-      finally
-      {
-        pathAfterInstall = process.env.PATH;
-        process.env.VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH = undefined;
-        process.env.PATH = originalPath;
-
-        if(error)
-        {
-          throw(new Error(`The test failed to run the acquire command successfully. Error: ${error}`));
-        }
-      }
-
-      assert.exists(result!, 'The global acquisition command did not provide a result?');
-      assert.exists(result!.dotnetPath);
-      assert.equal(result!.dotnetPath, 'fake-sdk');
-      assert.exists(pathAfterInstall, 'The environment variable PATH for DOTNET was not found?');
-      assert.include(pathAfterInstall, result!.dotnetPath, 'Is the PATH correctly set by the global installer?');
-    }
-    else
-    {
-      // We could run the installer without privilege but it would require human interaction to use the UAC
-      // And we wouldn't be able to kill the process so the test would leave a lot of hanging processes on the machine
-      warn('The Global SDK E2E Install test cannot run as the machine is unprivileged.');
-    }
-  }).timeout(standardTimeoutTime*1000);
-
   test('Install Command Sets the PATH', async () =>
   {
     const existingPath = process.env.PATH;


### PR DESCRIPTION
Rebrands the runtime extension to the .NET Install Tool so users dont need two extensions to download both the local runtime and global SDK separately.

PR changes look like a lot, but github is not showing the diff super well -- almost all of it is a 1-1 copy/move of functions to shared places / different files, with some slight modifications to allow calling from either a runtime context or sdk context.