### PR TITLE
Rewrite Command Execution API & Command Parsing

### DIFF
--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -1,17 +1,90 @@
 {
 	"$schema": "../../Documentation/json-schema/distro-support-schema.json",
 	"Ubuntu": {
-		"installCommand": "sudo apt-get update && sudo apt-get install -y {0}",
-		"uninstallCommand": "sudo apt-get remove {0}",
-		"updateCommand": "sudo apt-get update && apt-get upgrade -y {0}",
-		"isInstalledCommand": "sudo apt list --installed {0}",
-		"packageLookupCommand": "dpkg -l {0}",
+		"installCommand":
+		[
+			{
+				"runUnderSudo": true,
+				"commandRoot": "apt-get",
+				"commandParts": ["update"]
+			},
+			{
+				"runUnderSudo": true,
+				"commandRoot": "apt-get",
+				"commandParts": ["install", "-y", "{0}"]
+			}
+		],
+		"uninstallCommand":
+		[
+			{
+				"runUnderSudo": true,
+				"commandRoot": "apt-get",
+				"commandParts": ["remove", "{0}"]
+			}
+		],
+		"updateCommand":
+		[
+			{
+				"runUnderSudo": true,
+				"commandRoot": "apt-get",
+				"commandParts": ["update"]
+			},
+			{
+				"runUnderSudo": true,
+				"commandRoot": "apt-get",
+				"commandParts": ["upgrade", "-y", "{0}"]
+			}
+		],
+		"isInstalledCommand":
+		[
+			{
+				"runUnderSudo": true,
+				"commandRoot": "apt",
+				"commandParts": ["list", "--installed", "{0}"]
+			}
+		],
+		"packageLookupCommand":
+		[
+			{
+				"runUnderSudo": false,
+				"commandRoot": "dpkg",
+				"commandParts": ["-l", "{0}"]
+			}
+		],
 		"expectedDistroFeedInstallDirectory" : "/usr/lib/dotnet/sdk",
         "expectedMicrosoftFeedInstallDirectory" : "/usr/bin/dotnet",
-		"installedSDKVersionsCommand": "dotnet --list-sdks",
-		"installedRuntimeVersionsCommand": "dotnet --list-runtimes",
-		"currentInstallationVersionCommand": "dotnet --version",
-		"currentInstallPathCommand" : "which dotnet",
+		"installedSDKVersionsCommand":
+		[
+			{
+				"runUnderSudo": false,
+				"commandRoot": "dotnet",
+				"commandParts": ["--list-sdks"]
+			}
+		],
+		"installedRuntimeVersionsCommand":
+		[
+			{
+				"runUnderSudo": false,
+				"commandRoot": "dotnet",
+				"commandParts": ["--list-runtimes"]
+			}
+		],
+		"currentInstallationVersionCommand":
+		[
+			{
+				"runUnderSudo": false,
+				"commandRoot": "dotnet",
+				"commandParts": ["--version"]
+			}
+		],
+		"currentInstallPathCommand":
+		[
+			{
+				"runUnderSudo": false,
+				"commandRoot": "which",
+				"commandParts": ["dotnet"]
+			}
+		],
 		"versions": [{
 				"version": "18.04",
 				"dotnet": [{
@@ -27,10 +100,28 @@
 						"aspnetcore": "aspnetcore-runtime-7.0"
 					}
 				],
-				"preInstallCommands": [
-					"sudo apt-get update && sudo apt install -y wget",
-					"sudo wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb",
-					"sudo dpkg -i packages-microsoft-prod.deb"
+				"preInstallCommands":
+				[
+					{
+						"runUnderSudo": true,
+						"commandRoot": "apt-get",
+						"commandParts": ["update"]
+					},
+					{
+						"runUnderSudo": true,
+						"commandRoot": "apt",
+						"commandParts": ["install", "-y", "wget"]
+					},
+					{
+						"runUnderSudo": true,
+						"commandRoot": "wget",
+						"commandParts": ["https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb", "-O", "packages-microsoft-prod.deb"]
+					},
+					{
+						"runUnderSudo": true,
+						"commandRoot": "dpkg",
+						"commandParts": ["-i", "packages-microsoft-prod.deb"]
+					}
 				]
 			},
 			{
@@ -48,10 +139,28 @@
 						"aspnetcore": "aspnetcore-runtime-7.0"
 					}
 				],
-				"preInstallCommands": [
-					"sudo apt-get update && sudo apt install -y wget",
-					"sudo wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb",
-					"sudo dpkg -i packages-microsoft-prod.deb"
+				"preInstallCommands":
+				[
+					{
+						"runUnderSudo": true,
+						"commandRoot": "apt-get",
+						"commandParts": ["update"]
+					},
+					{
+						"runUnderSudo": true,
+						"commandRoot": "apt",
+						"commandParts": ["install", "-y", "wget"]
+					},
+					{
+						"runUnderSudo": true,
+						"commandRoot": "wget",
+						"commandParts": ["https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb", "-O", "packages-microsoft-prod.deb"]
+					},
+					{
+						"runUnderSudo": true,
+						"commandRoot": "dpkg",
+						"commandParts": ["-i", "packages-microsoft-prod.deb"]
+					}
 				]
 			},
 			{

--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -11,7 +11,7 @@
 			{
 				"runUnderSudo": true,
 				"commandRoot": "apt-get",
-				"commandParts": ["install", "-y", "{0}"]
+				"commandParts": ["install", "-y", "{packageName}"]
 			}
 		],
 		"uninstallCommand":
@@ -19,7 +19,7 @@
 			{
 				"runUnderSudo": true,
 				"commandRoot": "apt-get",
-				"commandParts": ["remove", "{0}"]
+				"commandParts": ["remove", "{packageName}"]
 			}
 		],
 		"updateCommand":
@@ -32,7 +32,7 @@
 			{
 				"runUnderSudo": true,
 				"commandRoot": "apt-get",
-				"commandParts": ["upgrade", "-y", "{0}"]
+				"commandParts": ["upgrade", "-y", "{packageName}"]
 			}
 		],
 		"isInstalledCommand":
@@ -40,7 +40,7 @@
 			{
 				"runUnderSudo": true,
 				"commandRoot": "apt",
-				"commandParts": ["list", "--installed", "{0}"]
+				"commandParts": ["list", "--installed", "{packageName}"]
 			}
 		],
 		"packageLookupCommand":

--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -48,7 +48,7 @@
 			{
 				"runUnderSudo": false,
 				"commandRoot": "dpkg",
-				"commandParts": ["-l", "{0}"]
+				"commandParts": ["-l", "{packageName}"]
 			}
 		],
 		"expectedDistroFeedInstallDirectory" : "/usr/lib/dotnet/sdk",

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -152,31 +152,23 @@ You will need to restart VS Code after these changes. If PowerShell is still not
         try
         {
             // Check if PowerShell exists and is on the path.
-            const workingCommandIndex = await new CommandExecutor(this.eventStream, this.utilityContext).tryFindWorkingCommand(possibleCommands);
-
-            if(workingCommandIndex === -1)
+            command = await new CommandExecutor(this.eventStream, this.utilityContext).tryFindWorkingCommand(possibleCommands);
+            if(!command)
             {
                 knownError = true;
                 const err = Error(this.noPowershellError);
                 error = err;
             }
-            else
-            {
-                command = possibleCommands[workingCommandIndex];
-            }
 
             // Check Execution Policy
-            if(command)
+            const execPolicyOutput = cp.spawnSync(command!.commandRoot, [`-command`, `$ExecutionContext.SessionState.LanguageMode`], {cwd : path.resolve(__dirname), shell: true});
+            const languageMode = execPolicyOutput.stdout.toString().trim();
+            if(languageMode === 'ConstrainedLanguage' || languageMode === 'NoLanguage')
             {
-                const execPolicyOutput = cp.spawnSync(command.commandRoot, [`-command`, `$ExecutionContext.SessionState.LanguageMode`], {cwd : path.resolve(__dirname), shell: true});
-                const languageMode = execPolicyOutput.stdout.toString().trim();
-                if(languageMode === 'ConstrainedLanguage' || languageMode === 'NoLanguage')
-                {
-                    knownError = true;
-                    const err = Error(`Your machine policy disables PowerShell language features that may be needed to install .NET. Read more at: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7.3.
+                knownError = true;
+                const err = Error(`Your machine policy disables PowerShell language features that may be needed to install .NET. Read more at: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7.3.
 If you cannot safely and confidently change the execution policy, try setting a custom existingDotnetPath following our instructions here: https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md.`);
-                    error = err;
-                }
+                error = err;
             }
         }
         catch(err)

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -118,14 +118,14 @@ You will need to restart VS Code after these changes. If PowerShell is still not
         return `${ this.escapeFilePath(scriptPath) } ${ args.join(' ') }`;
     }
 
-    private escapeFilePath(path: string): string {
+    private escapeFilePath(pathToEsc: string): string {
         if (os.platform() === 'win32') {
             // Need to escape apostrophes with two apostrophes
-            const dotnetInstallDirEscaped = path.replace(/'/g, `''`);
+            const dotnetInstallDirEscaped = pathToEsc.replace(/'/g, `''`);
             // Surround with single quotes instead of double quotes (see https://github.com/dotnet/cli/issues/11521)
             return `'${dotnetInstallDirEscaped}'`;
         } else {
-            return `"${path}"`;
+            return `"${pathToEsc}"`;
         }
     }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -291,7 +291,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         this.checkForPartialInstalls(installKey, installingVersion, false, false);
 
         const installer : IGlobalInstaller = os.platform() === 'linux' ?
-            new LinuxGlobalInstaller(this.context, this.utilityContext, installingVersion) :
+            new LinuxGlobalInstaller(this.context, this.utilityContext, this.context.acquisitionContext!, installingVersion) :
             new WinMacGlobalInstaller(this.context, this.utilityContext, installingVersion, await globalInstallerResolver.getInstallerUrl(), await globalInstallerResolver.getInstallerHash());
 
         // Indicate that we're beginning to do the install.

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -83,7 +83,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider {
         const command = this.myDistroCommands(this.installedSDKVersionsCommandKey);
         const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
-        const outputLines : string[] = commandResult[0].split('\n');
+        const outputLines : string[] = commandResult.split('\n');
         const versions : string[]  = [];
 
         for(const line of outputLines)
@@ -103,7 +103,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider {
         const command = this.myDistroCommands(this.installedRuntimeVersionsCommandKey);
         const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
-        const outputLines : string[] = commandResult[0].split('\n');
+        const outputLines : string[] = commandResult.split('\n');
         const versions : string[]  = [];
 
         for(const line of outputLines)

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -3,6 +3,7 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
+import { CommandExecutor } from '../Utils/CommandExecutor';
 import { IDistroDotnetSDKProvider } from './IDistroDotnetSDKProvider';
 import { DotnetDistroSupportStatus } from './LinuxVersionResolver';
 import { VersionResolver } from './VersionResolver';
@@ -18,69 +19,69 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider {
             const preinstallCommands = this.myVersionPackages()[this.preinstallCommandKey];
             for(const feedCommand of preinstallCommands)
             {
-                const preparationResult = (await this.commandRunner.execute(feedCommand))[0];
+                const preparationResult = (await this.commandRunner.executeMultipleCommands(feedCommand))[0];
             }
         }
 
-        let command = this.myDistroCommands()[this.installCommandKey];
+        let command = this.myDistroCommands(this.installCommandKey);
         const sdkPackage = this.myDotnetVersionPackages(fullySpecifiedVersion)[this.sdkKey];
-        command = command.replace('{0}', sdkPackage);
-        const commandResult = await this.commandRunner.execute(command);
+        command = CommandExecutor.replaceSubstringsInCommands(command, '{0}', sdkPackage);
+        const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
         return commandResult[0];
     }
 
     public async getInstalledGlobalDotnetPathIfExists() : Promise<string | null>
     {
-        const commandResult = await this.commandRunner.execute(this.myDistroCommands()[this.currentInstallPathCommandKey]);
+        const commandResult = await this.commandRunner.executeMultipleCommands(this.myDistroCommands(this.currentInstallPathCommandKey));
         return commandResult[0];
     }
 
     public async dotnetPackageExistsOnSystem(fullySpecifiedDotnetVersion : string) : Promise<boolean>
     {
-        let command = this.myDistroCommands()[this.packageLookupCommandKey];
+        let command = this.myDistroCommands(this.packageLookupCommandKey);
         const sdkPackage = this.myDotnetVersionPackages(this.JsonDotnetVersion(fullySpecifiedDotnetVersion))[this.sdkKey];
-        command = command.replace('{0}', sdkPackage);
-        const commandResult = await this.commandRunner.execute(command);
+        command = CommandExecutor.replaceSubstringsInCommands(command, '{0}', sdkPackage);
+        const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
         const noPackageResult = 'no packages found';
         return commandResult[0].toLowerCase().includes(noPackageResult);
     }
 
-    public getExpectedDotnetDistroFeedInstallationDirectory(): Promise<string>
+    public getExpectedDotnetDistroFeedInstallationDirectory(): string
     {
-        return this.myDistroCommands()[this.expectedDistroFeedInstallDirKey];
+        return this.myDistroStrings(this.expectedDistroFeedInstallDirKey);
     }
 
-    public getExpectedDotnetMicrosoftFeedInstallationDirectory(): Promise<string>
+    public getExpectedDotnetMicrosoftFeedInstallationDirectory(): string
     {
-        return this.myDistroCommands()[this.expectedMicrosoftFeedInstallDirKey];
+        return this.myDistroStrings(this.expectedMicrosoftFeedInstallDirKey);
     }
 
     public async upgradeDotnet(versionToUpgrade : string): Promise<string>
     {
-        let command = this.myDistroCommands()[this.updateCommandKey];
+        let command = this.myDistroCommands(this.updateCommandKey);
         const sdkPackage = this.myDotnetVersionPackages(versionToUpgrade)[this.sdkKey];
-        command = command.replace('{0}', sdkPackage);
-        const commandResult = await this.commandRunner.execute(command);
+        command = CommandExecutor.replaceSubstringsInCommands(command, '{0}',sdkPackage);
+        const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
         return commandResult[0];
     }
 
     public async uninstallDotnet(versionToUninstall : string): Promise<string>
     {
-        let command = this.myDistroCommands()[this.uninstallCommandKey];
+        let command = this.myDistroCommands(this.uninstallCommandKey);
         const sdkPackage = this.myDotnetVersionPackages(versionToUninstall)[this.sdkKey];
-        command = command.replace('{0}', sdkPackage);
-        const commandResult = await this.commandRunner.execute(command);
+        command = CommandExecutor.replaceSubstringsInCommands(command, '{0}', sdkPackage);
+        const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
         return commandResult[0];
     }
 
     public async getInstalledDotnetSDKVersions(): Promise<string[]>
     {
-        const command = this.myDistroCommands()[this.installedSDKVersionsCommandKey];
-        const commandResult = await this.commandRunner.execute(command);
+        const command = this.myDistroCommands(this.installedSDKVersionsCommandKey);
+        const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
         const outputLines : string[] = commandResult[0].split('\n');
         const versions : string[]  = [];
@@ -99,8 +100,8 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider {
 
     public async getInstalledDotnetRuntimeVersions(): Promise<string[]>
     {
-        const command = this.myDistroCommands()[this.installedRuntimeVersionsCommandKey];
-        const commandResult = await this.commandRunner.execute(command);
+        const command = this.myDistroCommands(this.installedRuntimeVersionsCommandKey);
+        const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
         const outputLines : string[] = commandResult[0].split('\n');
         const versions : string[]  = [];
@@ -119,11 +120,11 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider {
 
     public async getInstalledGlobalDotnetVersionIfExists(): Promise<string | null>
     {
-        const command = this.myDistroCommands()[this.currentInstallVersionCommandKey];
+        const command = this.myDistroCommands(this.currentInstallVersionCommandKey);
 
         // we need to run this command in the root directory otherwise local dotnets on the path may interfere
         const rootDir = path.parse(__dirname).root;
-        let commandResult = (await this.commandRunner.execute(command, rootDir))[0];
+        let commandResult = (await this.commandRunner.executeMultipleCommands(command, rootDir))[0];
 
         commandResult = commandResult.replace('\n', '');
         if(!this.versionResolver.isValidLongFormVersionFormat(commandResult))

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -25,7 +25,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider {
 
         let command = this.myDistroCommands(this.installCommandKey);
         const sdkPackage = this.myDotnetVersionPackages(fullySpecifiedVersion)[this.sdkKey];
-        command = CommandExecutor.replaceSubstringsInCommands(command, '{0}', sdkPackage);
+        command = CommandExecutor.replaceSubstringsInCommands(command, this.missingPackageNameKey, sdkPackage);
         const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
         return commandResult[0];
@@ -41,7 +41,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider {
     {
         let command = this.myDistroCommands(this.packageLookupCommandKey);
         const sdkPackage = this.myDotnetVersionPackages(this.JsonDotnetVersion(fullySpecifiedDotnetVersion))[this.sdkKey];
-        command = CommandExecutor.replaceSubstringsInCommands(command, '{0}', sdkPackage);
+        command = CommandExecutor.replaceSubstringsInCommands(command, this.missingPackageNameKey, sdkPackage);
         const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
         const noPackageResult = 'no packages found';
@@ -62,7 +62,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider {
     {
         let command = this.myDistroCommands(this.updateCommandKey);
         const sdkPackage = this.myDotnetVersionPackages(versionToUpgrade)[this.sdkKey];
-        command = CommandExecutor.replaceSubstringsInCommands(command, '{0}',sdkPackage);
+        command = CommandExecutor.replaceSubstringsInCommands(command, this.missingPackageNameKey, sdkPackage);
         const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
         return commandResult[0];
@@ -72,7 +72,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider {
     {
         let command = this.myDistroCommands(this.uninstallCommandKey);
         const sdkPackage = this.myDotnetVersionPackages(versionToUninstall)[this.sdkKey];
-        command = CommandExecutor.replaceSubstringsInCommands(command, '{0}', sdkPackage);
+        command = CommandExecutor.replaceSubstringsInCommands(command, this.missingPackageNameKey, sdkPackage);
         const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
         return commandResult[0];

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
@@ -173,7 +173,7 @@ export abstract class IDistroDotnetSDKProvider {
 
     protected myDistroCommands(commandKey : string) : CommandExecutorCommand[]
     {
-        return JSON.parse(this.distroJson[this.distroVersion.distro][commandKey]) as CommandExecutorCommand[];
+        return this.distroJson[this.distroVersion.distro][commandKey] as CommandExecutorCommand[];
     }
 
     protected myDotnetVersionPackages(fullySpecifiedDotnetVersion : string) : any

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
@@ -40,6 +40,7 @@ export abstract class IDistroDotnetSDKProvider {
     protected installedSDKVersionsCommandKey = 'installedSDKVersionsCommand';
     protected installedRuntimeVersionsCommandKey = 'installedRuntimeVersionsCommand';
     protected currentInstallVersionCommandKey = 'currentInstallationVersionCommand';
+    protected missingPackageNameKey = '{packageName}';
 
     protected distroVersionsKey = 'versions';
     protected versionKey = 'version';

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
@@ -8,7 +8,7 @@ import { DistroVersionPair, DotnetDistroSupportStatus } from './LinuxVersionReso
 import path = require('path');
 import { DotnetAcquisitionDistroUnknownError } from '../EventStream/EventStreamEvents';
 import { VersionResolver } from './VersionResolver';
-import { ICommandExecutor } from '../Utils/ICommandExecutor';
+import { CommandExecutorCommand, ICommandExecutor } from '../Utils/ICommandExecutor';
 import { CommandExecutor } from '../Utils/CommandExecutor';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IUtilityContext } from '../Utils/IUtilityContext';
@@ -99,12 +99,12 @@ export abstract class IDistroDotnetSDKProvider {
      * Return the directory where the dotnet SDK should be installed per the distro preferences.
      * (e.g. where the distro would install it given its supported by default if you ran apt-get install.)
      */
-    public abstract getExpectedDotnetDistroFeedInstallationDirectory() : Promise<string>;
+    public abstract getExpectedDotnetDistroFeedInstallationDirectory() : string;
 
     /**
      * Return the directory where the dotnet SDK should be installed if installed using the microsoft feeds.
      */
-    public abstract getExpectedDotnetMicrosoftFeedInstallationDirectory() : Promise<string>;
+    public abstract getExpectedDotnetMicrosoftFeedInstallationDirectory() : string;
 
     /**
      * Return true if theres a package for the dotnet version on the system with the same major as the requested fullySpecifiedVersion, false else.
@@ -164,9 +164,15 @@ export abstract class IDistroDotnetSDKProvider {
         return distroVersions.filter((x: { [x: string]: string; }) => x[this.versionKey] === this.distroVersion.version)[0];
     }
 
-    protected myDistroCommands() : any
+
+    protected myDistroStrings(stringKey : string) : string
     {
-        return this.distroJson[this.distroVersion.distro];
+        return this.distroJson[this.distroVersion.distro][stringKey];
+    }
+
+    protected myDistroCommands(commandKey : string) : CommandExecutorCommand[]
+    {
+        return JSON.parse(this.distroJson[this.distroVersion.distro][commandKey]) as CommandExecutorCommand[];
     }
 
     protected myDotnetVersionPackages(fullySpecifiedDotnetVersion : string) : any

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxGlobalInstaller.ts
@@ -8,6 +8,7 @@ import { IGlobalInstaller } from './IGlobalInstaller';
 import { DotnetDistroSupportStatus, LinuxVersionResolver } from './LinuxVersionResolver';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IUtilityContext } from '../Utils/IUtilityContext';
+import { IDotnetAcquireContext } from '..';
 
 export class LinuxGlobalInstaller extends IGlobalInstaller {
 
@@ -15,10 +16,10 @@ export class LinuxGlobalInstaller extends IGlobalInstaller {
     private version : string;
     private linuxSDKResolver : LinuxVersionResolver;
 
-    constructor(acqusitionContext : IAcquisitionWorkerContext, utilContext : IUtilityContext, fullySpecifiedDotnetVersion : string)
+    constructor(acqusitionContext : IAcquisitionWorkerContext, utilContext : IUtilityContext, acquireContext : IDotnetAcquireContext, fullySpecifiedDotnetVersion : string)
     {
         super(acqusitionContext, utilContext);
-        this.linuxSDKResolver = new LinuxVersionResolver(acqusitionContext, utilContext);
+        this.linuxSDKResolver = new LinuxVersionResolver(acqusitionContext, utilContext, acquireContext);
         this.version = fullySpecifiedDotnetVersion;
     }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -13,6 +13,7 @@ import { VersionResolver } from './VersionResolver';
 import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { CommandExecutor } from '../Utils/CommandExecutor';
 import { IUtilityContext } from '../Utils/IUtilityContext';
+import { IDotnetAcquireContext } from '..';
 
 /**
  * An enumeration type representing all distros with their versions that we recognize.
@@ -69,10 +70,10 @@ export class LinuxVersionResolver
     Your custom install is located at: `;
     public baseUnsupportedDistroErrorMessage = 'We are unable to detect the distro or version of your machine';
 
-    constructor(acquisitionContext : IAcquisitionWorkerContext, utilContext : IUtilityContext,
+    constructor(acquisitionContext : IAcquisitionWorkerContext, utilContext : IUtilityContext, acquireContext : IDotnetAcquireContext,
         executor : ICommandExecutor | null = null, distroProvider : IDistroDotnetSDKProvider | null = null)
     {
-        this.commandRunner = executor ?? new CommandExecutor(acquisitionContext.eventStream, utilContext);
+        this.commandRunner = executor ?? new CommandExecutor(acquisitionContext.eventStream, utilContext, acquireContext);
         this.acquisitionContext = acquisitionContext;
         this.utilityContext = utilContext;
         this.versionResolver = new VersionResolver(acquisitionContext.extensionState, acquisitionContext.eventStream,
@@ -94,7 +95,7 @@ export class LinuxVersionResolver
             return this.distro;
         }
 
-        const commandResult = (await this.commandRunner.execute('cat /etc/os-release'))[0];
+        const commandResult = await this.commandRunner.execute(CommandExecutor.makeCommand(`cat`, [`/etc/os-release`]));
         const distroNameKey = 'NAME';
         const distroVersionKey = 'VERSION_ID';
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -200,7 +200,7 @@ We cannot verify .NET is safe to download at this time. Please try again later.`
                 CommandExecutor.makeCommand(`/usr/bin/open`, [])
             ];
 
-            const workingCommand = await this.commandRunner.tryFindWorkingCommand(possibleCommands);
+            let workingCommand = await this.commandRunner.tryFindWorkingCommand(possibleCommands);
             if(!workingCommand)
             {
                 const error = new Error(`The 'open' command on OSX was not detected. This is likely due to the PATH environment variable on your system being clobbered by another program.
@@ -208,10 +208,13 @@ Please correct your PATH variable or make sure the 'open' utility is installed s
                 this.acquisitionContext.eventStream.post(new OSXOpenNotAvailableError(error));
                 throw error;
             }
+            else if(workingCommand.commandRoot === 'command')
+            {
+                workingCommand = CommandExecutor.makeCommand(`open`, [`-W`, `${path.resolve(installerPath)}`]);
+            }
 
             const commandResult = await this.commandRunner.execute(
-                CommandExecutor.makeCommand(`${workingCommand.commandRoot}`,
-                workingCommand.commandFollowUps.concat([`-W`, `${path.resolve(installerPath)}`]))
+                workingCommand
             );
 
             this.commandRunner.returnStatus = false;

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -200,8 +200,8 @@ We cannot verify .NET is safe to download at this time. Please try again later.`
                 CommandExecutor.makeCommand(`/usr/bin/open`, [])
             ];
 
-            const workingCommandIndex = await this.commandRunner.tryFindWorkingCommand(possibleCommands);
-            if(workingCommandIndex === -1)
+            const workingCommand = await this.commandRunner.tryFindWorkingCommand(possibleCommands);
+            if(!workingCommand)
             {
                 const error = new Error(`The 'open' command on OSX was not detected. This is likely due to the PATH environment variable on your system being clobbered by another program.
 Please correct your PATH variable or make sure the 'open' utility is installed so .NET can properly execute.`);
@@ -210,9 +210,10 @@ Please correct your PATH variable or make sure the 'open' utility is installed s
             }
 
             const commandResult = await this.commandRunner.execute(
-                CommandExecutor.makeCommand(`${possibleCommands[workingCommandIndex].commandRoot}`,
-                possibleCommands[workingCommandIndex].commandFollowUps.concat([`-W`, `${path.resolve(installerPath)}`]))
+                CommandExecutor.makeCommand(`${workingCommand.commandRoot}`,
+                workingCommand.commandFollowUps.concat([`-W`, `${path.resolve(installerPath)}`]))
             );
+
             this.commandRunner.returnStatus = false;
             return commandResult[0];
         }

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -21,19 +21,17 @@ import { ICommandExecutor } from './ICommandExecutor';
 import path = require('path');
 import { IEventStream } from '../EventStream/EventStream';
 import * as os from 'os';
-import { WindowDisplayWorker } from '../EventStream/WindowDisplayWorker';
 import { IVSCodeExtensionContext } from '../IVSCodeExtensionContext';
-import { IAcquisitionWorkerContext } from '../Acquisition/IAcquisitionWorkerContext';
 import { IUtilityContext } from './IUtilityContext';
+import { CommandExecutorCommand, IDotnetAcquireContext } from '..';
 
 /* tslint:disable:no-any */
 
 export class CommandExecutor extends ICommandExecutor
 {
-
-    constructor(eventStream : IEventStream, utilContext : IUtilityContext)
+    constructor(eventStream : IEventStream, utilContext : IUtilityContext, acquireContext? : IDotnetAcquireContext)
     {
-        super(eventStream, utilContext);
+        super(eventStream, utilContext, acquireContext);
     }
 
     /**
@@ -52,12 +50,11 @@ export class CommandExecutor extends ICommandExecutor
 
     /**
      *
-     * @param commandFollowUps The strings/args/options after the first word in the command.
      * @returns The output of the command.
      */
-    private async ExecSudoAsync(commandFollowUps : string[]) : Promise<string>
+    private async ExecSudoAsync(command : CommandExecutorCommand) : Promise<string>
     {
-        this.eventStream.post(new CommandExecutionUnderSudoEvent(`The command ${commandFollowUps} is being ran under sudo.`));
+        this.eventStream.post(new CommandExecutionUnderSudoEvent(`The command ${command} is being ran under sudo.`));
 
         if(this.isRunningUnderWSL())
         {
@@ -75,9 +72,10 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
         // We wrap the exec in a promise because there is no synchronous version of the sudo exec command for vscode/sudo
         return new Promise<string>((resolve, reject) =>
         {
-            // The '.' character is not allowed for sudo-prompt so we use 'DotNET'
-            const options = { name: 'VS Code DotNET Acquisition' };
-            exec(commandFollowUps.join(' '), options, (error?: any, stdout?: any, stderr?: any) =>
+            // The '.' character is not allowed for sudo-prompt so we use 'NET'
+            const options = { name: `${this.acquisitionContext?.requestingExtensionId} On behalf of NET Install Tool` };
+            const fullCommandString = CommandExecutor.prettifyCommandExecutorCommand(command, false);
+            exec((fullCommandString), options, (error?: any, stdout?: any, stderr?: any) =>
             {
                 let commandResultString = '';
 
@@ -87,114 +85,120 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
                 }
                 if (stderr)
                 {
-                    this.eventStream.post(new CommandExecutionStdError(`The command ${commandFollowUps} encountered stderr, continuing. ${stderr}.`));
+                    this.eventStream.post(new CommandExecutionStdError(`The command ${fullCommandString} encountered stderr, continuing. ${stderr}.`));
                     commandResultString += stderr;
                 }
 
                 if (error)
                 {
-                    this.eventStream.post(new CommandExecutionUserCompletedDialogueEvent(`The command ${commandFollowUps} failed to run under sudo.`));
+                    this.eventStream.post(new CommandExecutionUserCompletedDialogueEvent(`The command ${fullCommandString} failed to run under sudo.`));
                     reject(error);
                 }
                 else
                 {
-                    this.eventStream.post(new CommandExecutionUserCompletedDialogueEvent(`The command ${commandFollowUps} successfully ran under sudo.`));
+                    this.eventStream.post(new CommandExecutionUserCompletedDialogueEvent(`The command ${fullCommandString} successfully ran under sudo.`));
                     resolve(commandResultString);
                 }
             });
         });
     }
 
+    public async executeMultipleCommands(commands: CommandExecutorCommand[], options?: any): Promise<string[]> {
+        const results = [];
+        for(const command of commands)
+        {
+            results.push(await this.execute(command, options));
+        }
+
+        return results;
+    }
+
     /**
      *
-     * @param command The command to run as a whole string. Commands with && will be run individually. Sudo commands will request sudo from the user.
-     * @param workingDirectory - the directory to execute in. Only works for non sudo commands.
+     * @param workingDirectory The directory to execute in. Only works for non sudo commands.
      *
      * @returns the result(s) of each command. Can throw generically if the command fails.
      */
-    public async execute(command : string, options : any | null = null) : Promise<string[]>
+    public async execute(command : CommandExecutorCommand, options : any | null = null) : Promise<string>
     {
+        const fullCommandStringForTelemetryOnly = `${command.commandRoot} ${command.commandFollowUps.join(' ')}`;
         if(!options)
         {
             options = {cwd : path.resolve(__dirname), shell: true};
         }
 
-        const splitCommands : string[] = command.split('&&');
-        const commandResults : string[] = [];
-
-        for (let isolatedCommand of splitCommands)
+        if(command.runUnderSudo)
         {
-            isolatedCommand = isolatedCommand.trim();
-            const rootCommand = isolatedCommand.split(' ')[0];
-            const commandFollowUps : string[] = isolatedCommand.split(' ').slice(1);
-
-            if(rootCommand === 'sudo')
+            return this.ExecSudoAsync(command) ?? '';
+        }
+        else
+        {
+            this.eventStream.post(new CommandExecutionEvent(`Executing command ${command.toString()} or ${fullCommandStringForTelemetryOnly}
+with options ${options.toString()}.`));
+            const commandResult = proc.spawnSync(command.commandRoot, command.commandFollowUps, options);
+            if(this.returnStatus)
             {
-                const commandResult = await this.ExecSudoAsync(commandFollowUps);
-                commandResults.push(commandResult);
-            }
-            else
-            {
-                this.eventStream.post(new CommandExecutionEvent(`The command ${command} is being executed with options ${splitCommands} and ${options}.`));
-                const commandResult = proc.spawnSync(rootCommand, commandFollowUps, options);
-                if(this.returnStatus)
+                if(commandResult.status !== null)
                 {
-                    if(commandResult.status !== null)
-                    {
-                        this.eventStream.post(new CommandExecutionStatusEvent(`The command ${command} exited with status: ${commandResult.status.toString()}.`));
-                        commandResults.push(commandResult.status.toString());
-                    }
-                    else
-                    {
-                        // A signal is generally given if a status is not given, and they are equivalent
-                        if(commandResult.signal !== null)
-                        {
-                            this.eventStream.post(new CommandExecutionSignalSentEvent(`The command ${command} exited with signal: ${commandResult.signal.toString()}.`));
-                            commandResults.push(commandResult.signal.toString());
-                        }
-                        else
-                        {
-                            this.eventStream.post(new CommandExecutionNoStatusCodeWarning(`The command ${command} with ${commandResult} had no status or signal.`));
-                            commandResults.push('000751'); // Error code 000751 : The command did not report an exit code upon completion. This is never expected
-                        }
-                    }
+                    this.eventStream.post(new CommandExecutionStatusEvent(`The command ${command.toString()} or ${fullCommandStringForTelemetryOnly} exited
+with status: ${commandResult.status.toString()}.`));
+                    return commandResult.status.toString() ?? '';
                 }
                 else
                 {
-                    if(commandResult.stdout === null && commandResult.stderr === null)
+                    // A signal is generally given if a status is not given, and they are 'equivalent' enough
+                    if(commandResult.signal !== null)
                     {
-                        commandResults.push('');
+                        this.eventStream.post(new CommandExecutionSignalSentEvent(`The command ${command.toString()} or ${fullCommandStringForTelemetryOnly} exited
+with signal: ${commandResult.signal.toString()}.`));
+                        return commandResult.signal.toString() ?? '';
                     }
                     else
                     {
-                        this.eventStream.post(new CommandExecutionStdError(`The command ${command} with follow ups ${commandFollowUps} encountered stdout and or stderr, continuing.
-out: ${commandResult.stdout} err: ${commandResult.stderr}.`));
-                        commandResults.push(commandResult.stdout?.toString() + commandResult.stderr?.toString());
+                        this.eventStream.post(new CommandExecutionNoStatusCodeWarning(`The command ${command.toString()} or ${fullCommandStringForTelemetryOnly} with
+result: ${commandResult.toString()} had no status or signal.`));
+                        return '000751'; // Error code 000751 : The command did not report an exit code upon completion. This is never expected
                     }
                 }
             }
+            else
+            {
+                if(commandResult.stdout === null && commandResult.stderr === null)
+                {
+                    return '';
+                }
+                else
+                {
+                    this.eventStream.post(new CommandExecutionStdError(`The command ${command.toString()} or ${fullCommandStringForTelemetryOnly} encountered stdout and or stderr, continuing.
+out: ${commandResult.stdout} err: ${commandResult.stderr}.`));
+                    return commandResult.stdout?.toString() + commandResult.stderr?.toString() ?? '';
+                }
+            }
         }
-
-        return commandResults;
     }
 
-    public async TryFindWorkingCommand(commands : string[]) : Promise<[string, boolean]>
+    /**
+     *
+     * @param commandRoots The first word of each command to try
+     * @param matchingCommandParts Any follow up words in that command to execute, matching in the same order as commandRoots
+     * @returns the index of the working command you provided, if no command works, -1.
+     */
+    public async tryFindWorkingCommand(commands : CommandExecutorCommand[]) : Promise<number>
     {
-        let workingCommand = '';
-        let working = false;
-
         const oldReturnStatusSetting = this.returnStatus;
         this.returnStatus = true;
+
+        let index = 0;
+        let workingCommandIndex = -1;
 
         for(const command of commands)
         {
             try
             {
-                const cmdFoundOutput = (await this.execute(command))[0];
+                const cmdFoundOutput = await this.execute(command);
                 if(cmdFoundOutput === '0')
                 {
-                    working = true;
-                    workingCommand = command;
+                    workingCommandIndex = index;
                     this.eventStream.post(new DotnetAlternativeCommandFoundEvent(`The command ${command} was found.`));
                     break;
                 }
@@ -208,10 +212,12 @@ out: ${commandResult.stdout} err: ${commandResult.stderr}.`));
                 // Do nothing. The error should be raised higher up.
                 this.eventStream.post(new DotnetCommandNotFoundEvent(`The command ${command} was NOT found, and we caught any errors.`));
             }
-        }
+
+            ++index;
+        };
 
         this.returnStatus = oldReturnStatusSetting;
-        return [workingCommand, working];
+        return workingCommandIndex;
     }
 
     public async setEnvironmentVariable(variable : string, value : string, vscodeContext : IVSCodeExtensionContext, failureWarningMessage? : string, nonWinFailureMessage? : string)
@@ -225,8 +231,8 @@ out: ${commandResult.stdout} err: ${commandResult.stderr}.`));
 
         if(os.platform() === 'win32')
         {
-            const setShellVariable = `set ${variable}=${value}`;
-            const setSystemVariable = `setx ${variable} "${value}"`;
+            const setShellVariable = CommandExecutor.makeCommand(`set`, [`${variable}=${value}`]);
+            const setSystemVariable = CommandExecutor.makeCommand(`setx`, [`${variable}`, `"${value}"`]);
             try
             {
                 const shellEditResponse = await this.execute(setShellVariable);

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -183,13 +183,12 @@ out: ${commandResult.stdout} err: ${commandResult.stderr}.`));
      * @param matchingCommandParts Any follow up words in that command to execute, matching in the same order as commandRoots
      * @returns the index of the working command you provided, if no command works, -1.
      */
-    public async tryFindWorkingCommand(commands : CommandExecutorCommand[]) : Promise<number>
+    public async tryFindWorkingCommand(commands : CommandExecutorCommand[]) : Promise<CommandExecutorCommand | null>
     {
         const oldReturnStatusSetting = this.returnStatus;
         this.returnStatus = true;
 
-        let index = 0;
-        let workingCommandIndex = -1;
+        let workingCommand : CommandExecutorCommand | null = null;
 
         for(const command of commands)
         {
@@ -198,7 +197,7 @@ out: ${commandResult.stdout} err: ${commandResult.stderr}.`));
                 const cmdFoundOutput = await this.execute(command);
                 if(cmdFoundOutput === '0')
                 {
-                    workingCommandIndex = index;
+                    workingCommand = command;
                     this.eventStream.post(new DotnetAlternativeCommandFoundEvent(`The command ${command} was found.`));
                     break;
                 }
@@ -212,12 +211,10 @@ out: ${commandResult.stdout} err: ${commandResult.stderr}.`));
                 // Do nothing. The error should be raised higher up.
                 this.eventStream.post(new DotnetCommandNotFoundEvent(`The command ${command} was NOT found, and we caught any errors.`));
             }
-
-            ++index;
         };
 
         this.returnStatus = oldReturnStatusSetting;
-        return workingCommandIndex;
+        return workingCommand;
     }
 
     public async setEnvironmentVariable(variable : string, value : string, vscodeContext : IVSCodeExtensionContext, failureWarningMessage? : string, nonWinFailureMessage? : string)

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -121,7 +121,7 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
      */
     public async execute(command : CommandExecutorCommand, options : any | null = null) : Promise<string>
     {
-        const fullCommandStringForTelemetryOnly = `${command.commandRoot} ${command.commandFollowUps.join(' ')}`;
+        const fullCommandStringForTelemetryOnly = `${command.commandRoot} ${command.commandParts.join(' ')}`;
         if(!options)
         {
             options = {cwd : path.resolve(__dirname), shell: true};
@@ -135,7 +135,7 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
         {
             this.eventStream.post(new CommandExecutionEvent(`Executing command ${command.toString()} or ${fullCommandStringForTelemetryOnly}
 with options ${options.toString()}.`));
-            const commandResult = proc.spawnSync(command.commandRoot, command.commandFollowUps, options);
+            const commandResult = proc.spawnSync(command.commandRoot, command.commandParts, options);
             if(this.returnStatus)
             {
                 if(commandResult.status !== null)

--- a/vscode-dotnet-runtime-library/src/Utils/ICommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ICommandExecutor.ts
@@ -14,13 +14,13 @@ export type CommandExecutorCommand =
     /**
      * @property commandRoot
      * The command first 'word' to run, example: 'dotnet --info' has a first word of 'dotnet'
-     * @property commandFollowUps
+     * @property commandParts
      * The remaining strings in the command to execute, example: 'dotnet build foo.csproj' will be ['build', 'foo.csproj']
      * @property runUnderSudo
      * Use this if the command should be executed under sudo on linux.
      */
     commandRoot : string,
-    commandFollowUps : string[],
+    commandParts : string[],
     runUnderSudo : boolean
 }
 
@@ -70,27 +70,27 @@ export abstract class ICommandExecutor
     {
         return {
             commandRoot: command,
-            commandFollowUps: args,
+            commandParts: args,
             runUnderSudo: isSudo
         };
     }
 
     public static prettifyCommandExecutorCommand(command : CommandExecutorCommand, includeSudo = true) : string
     {
-        return `${command.runUnderSudo && includeSudo ? `sudo ` : ``}${command.commandRoot} ${command.commandFollowUps.join(' ')}`
+        return `${command.runUnderSudo && includeSudo ? `sudo ` : ``}${command.commandRoot} ${command.commandParts.join(' ')}`
     }
 
     public static replaceSubstringsInCommand(command : CommandExecutorCommand, substring : string, replacement : string) : CommandExecutorCommand
     {
         const newCommandRoot = command.commandRoot.replace(substring, replacement);
         const newCommandParts: string[] = [];
-        for(const commandPart of command.commandFollowUps)
+        for(const commandPart of command.commandParts)
         {
             newCommandParts.push(commandPart.replace(substring, replacement));
         }
         return {
             commandRoot: newCommandRoot,
-            commandFollowUps: newCommandParts,
+            commandParts: newCommandParts,
             runUnderSudo: command.runUnderSudo
         } as CommandExecutorCommand
     }

--- a/vscode-dotnet-runtime-library/src/Utils/ICommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ICommandExecutor.ts
@@ -64,7 +64,7 @@ export abstract class ICommandExecutor
      * @param commands The set of commands to see if one of them is available/works.
      * @returns the working command index if one is available, else -1.
      */
-    public abstract tryFindWorkingCommand(commands : CommandExecutorCommand[]) : Promise<number>;
+    public abstract tryFindWorkingCommand(commands : CommandExecutorCommand[]) : Promise<CommandExecutorCommand | null>;
 
     public static makeCommand(command : string, args : string[], runUnderSudo = false) : CommandExecutorCommand
     {

--- a/vscode-dotnet-runtime-library/src/Utils/ICommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ICommandExecutor.ts
@@ -5,19 +5,37 @@
  * ------------------------------------------------------------------------------------------ */
 /* tslint:disable:no-any */
 
+import { IDotnetAcquireContext } from '..';
 import { IEventStream } from '../EventStream/EventStream';
 import { IUtilityContext } from './IUtilityContext';
 
+export type CommandExecutorCommand =
+{
+    /**
+     * @property commandRoot
+     * The command first 'word' to run, example: 'dotnet --info' has a first word of 'dotnet'
+     * @property commandFollowUps
+     * The remaining strings in the command to execute, example: 'dotnet build foo.csproj' will be ['build', 'foo.csproj']
+     * @property runUnderSudo
+     * Use this if the command should be executed under sudo on linux.
+    */
+    commandRoot : string,
+    commandFollowUps : string[],
+    runUnderSudo : boolean
+}
+
 export abstract class ICommandExecutor
 {
-    constructor(eventStream : IEventStream, utilContext : IUtilityContext)
+    constructor(eventStream : IEventStream, utilContext : IUtilityContext, acquireContext? : IDotnetAcquireContext)
     {
         this.eventStream = eventStream;
         this.utilityContext = utilContext;
+        this.acquisitionContext = acquireContext;
     }
 
     protected eventStream : IEventStream;
-    protected utilityContext : IUtilityContext
+    protected utilityContext : IUtilityContext;
+    protected acquisitionContext? : IDotnetAcquireContext;
 
     /**
      * @remarks Set this to true if you don't want to capture stdout and stderr, and just want to return the status / exit code.
@@ -27,15 +45,63 @@ export abstract class ICommandExecutor
 
     /**
      *
-     * @param command The command to execute, with arguments separated by spaces in the string.
-     * @param options Options to forward to the execSync command.
+     * @param workingDirectory The directory to execute in. Only works for non sudo commands.
+     *
+     * @returns the parsed result of the command.
      */
-    public abstract execute(command : string, options? : any | null) : Promise<string[]>;
+    public abstract execute(command : CommandExecutorCommand, options? : any) : Promise<string>;
+
+    /**
+     *
+     * @param workingDirectory The directory to execute in. Only works for non sudo commands.
+     *
+     * @returns the result(s) of each command in the same order they were requested. Can throw generically if the command fails.
+     */
+    public abstract executeMultipleCommands(commands : CommandExecutorCommand[], options? : any) : Promise<string[]>;
 
     /**
      *
      * @param commands The set of commands to see if one of them is available/works.
-     * @returns the working command (if any) and a boolean for true or false if a command was available.
+     * @returns the working command index if one is available, else -1.
      */
-    public abstract TryFindWorkingCommand(commands : string[]) : Promise<[string, boolean]>;
+    public abstract tryFindWorkingCommand(commands : CommandExecutorCommand[]) : Promise<number>;
+
+    public static makeCommand(command : string, args : string[], runUnderSudo = false) : CommandExecutorCommand
+    {
+        return {
+            commandRoot: command,
+            commandFollowUps: args,
+            runUnderSudo: runUnderSudo
+        };
+    }
+
+    public static prettifyCommandExecutorCommand(command : CommandExecutorCommand, includeSudo = true) : string
+    {
+        return `${command.runUnderSudo && includeSudo ? `sudo ` : ``}${command.commandRoot} ${command.commandFollowUps.join(' ')}`
+    }
+
+    public static replaceSubstringsInCommand(command : CommandExecutorCommand, substring : string, replacement : string) : CommandExecutorCommand
+    {
+        let newCommandRoot = command.commandRoot.replace(substring, replacement);
+        let newCommandParts: string[] = [];
+        for(const commandPart of command.commandFollowUps)
+        {
+            newCommandParts.push(commandPart.replace(substring, replacement));
+        }
+        return {
+            commandRoot: newCommandRoot,
+            commandFollowUps: newCommandParts,
+            runUnderSudo: command.runUnderSudo
+        } as CommandExecutorCommand
+    }
+
+    public static replaceSubstringsInCommands(commands : CommandExecutorCommand[], substring : string, replacement : string) : CommandExecutorCommand[]
+    {
+        let newCommands : CommandExecutorCommand[] = [];
+        for(const command of commands)
+        {
+            newCommands.push(this.replaceSubstringsInCommand(command, substring, replacement));
+        }
+        return newCommands;
+    }
 };

--- a/vscode-dotnet-runtime-library/src/Utils/ICommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ICommandExecutor.ts
@@ -18,7 +18,7 @@ export type CommandExecutorCommand =
      * The remaining strings in the command to execute, example: 'dotnet build foo.csproj' will be ['build', 'foo.csproj']
      * @property runUnderSudo
      * Use this if the command should be executed under sudo on linux.
-    */
+     */
     commandRoot : string,
     commandFollowUps : string[],
     runUnderSudo : boolean
@@ -66,12 +66,12 @@ export abstract class ICommandExecutor
      */
     public abstract tryFindWorkingCommand(commands : CommandExecutorCommand[]) : Promise<CommandExecutorCommand | null>;
 
-    public static makeCommand(command : string, args : string[], runUnderSudo = false) : CommandExecutorCommand
+    public static makeCommand(command : string, args : string[], isSudo = false) : CommandExecutorCommand
     {
         return {
             commandRoot: command,
             commandFollowUps: args,
-            runUnderSudo: runUnderSudo
+            runUnderSudo: isSudo
         };
     }
 
@@ -82,8 +82,8 @@ export abstract class ICommandExecutor
 
     public static replaceSubstringsInCommand(command : CommandExecutorCommand, substring : string, replacement : string) : CommandExecutorCommand
     {
-        let newCommandRoot = command.commandRoot.replace(substring, replacement);
-        let newCommandParts: string[] = [];
+        const newCommandRoot = command.commandRoot.replace(substring, replacement);
+        const newCommandParts: string[] = [];
         for(const commandPart of command.commandFollowUps)
         {
             newCommandParts.push(commandPart.replace(substring, replacement));
@@ -97,7 +97,7 @@ export abstract class ICommandExecutor
 
     public static replaceSubstringsInCommands(commands : CommandExecutorCommand[], substring : string, replacement : string) : CommandExecutorCommand[]
     {
-        let newCommands : CommandExecutorCommand[] = [];
+        const newCommands : CommandExecutorCommand[] = [];
         for(const command of commands)
         {
             newCommands.push(this.replaceSubstringsInCommand(command, substring, replacement));

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -313,8 +313,8 @@ export class MockCommandExecutor extends ICommandExecutor
         return result;
     }
 
-    public async tryFindWorkingCommand(commands: CommandExecutorCommand[]): Promise<number> {
-        return 0;
+    public async tryFindWorkingCommand(commands: CommandExecutorCommand[]): Promise<CommandExecutorCommand> {
+        return commands[0];
     }
 }
 

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -18,7 +18,7 @@ import { ITelemetryReporter } from '../../EventStream/TelemetryObserver';
 import { IExistingPath, IExtensionConfiguration } from '../../IExtensionContext';
 import { IExtensionState } from '../../IExtensionState';
 import { WebRequestWorker } from '../../Utils/WebRequestWorker';
-import { ICommandExecutor } from '../../Utils/ICommandExecutor';
+import { CommandExecutorCommand, ICommandExecutor } from '../../Utils/ICommandExecutor';
 import { CommandExecutor } from '../../Utils/CommandExecutor';
 import { IDistroDotnetSDKProvider } from '../../Acquisition/IDistroDotnetSDKProvider';
 import { DistroVersionPair, DotnetDistroSupportStatus } from '../../Acquisition/LinuxVersionResolver';
@@ -283,30 +283,38 @@ export class MockCommandExecutor extends ICommandExecutor
         this.trueExecutor = new CommandExecutor(eventStream, utilContext);
     }
 
-    public async execute(command: string, options : object | null = null): Promise<string[]>
+    public async execute(command: CommandExecutorCommand, options : object | null = null): Promise<string>
     {
-        this.attemptedCommand = command;
-        let commandResults : string[] = [];
+        this.attemptedCommand = CommandExecutor.prettifyCommandExecutorCommand(command);
 
-        if(!command.includes('sudo') && this.fakeReturnValue === '')
+        if(!command.runUnderSudo && this.fakeReturnValue === '')
         {
-            commandResults = await this.trueExecutor.execute(command, options);
+            return this.trueExecutor.execute(command, options);
         }
-        else if(this.otherCommandsToMock.some(x => x.includes(command)))
+        else if(this.otherCommandsToMock.some(x => x.includes(command.commandRoot)))
         {
-            const fakeResultIndex = this.otherCommandsToMock.findIndex(x => x.includes(command));
+            const fakeResultIndex = this.otherCommandsToMock.findIndex(x => x.includes(command.commandRoot));
             // We don't need to verify the index since this is test code!
-            commandResults.push(this.otherCommandsReturnValues[fakeResultIndex]);
+            return this.otherCommandsReturnValues[fakeResultIndex];
         }
         else
         {
-            commandResults.push(this.fakeReturnValue);
+            return this.fakeReturnValue;
         }
-        return commandResults;
     }
 
-    public async TryFindWorkingCommand(commands: string[]): Promise<[string, boolean]> {
-        return [commands[0], true];
+    public async executeMultipleCommands(commands: CommandExecutorCommand[], options?: any): Promise<string[]>
+    {
+        const result = [];
+        for(const command of commands)
+        {
+            result.push(await this.execute(command));
+        }
+        return result;
+    }
+
+    public async tryFindWorkingCommand(commands: CommandExecutorCommand[]): Promise<number> {
+        return 0;
     }
 }
 
@@ -362,62 +370,62 @@ export class MockDistroProvider extends IDistroDotnetSDKProvider
     }
 
     public installDotnet(fullySpecifiedVersion: string): Promise<string> {
-        this.commandRunner.execute('install dotnet');
+        this.commandRunner.execute(CommandExecutor.makeCommand('install', [`dotnet`]));
         return Promise.resolve(this.installReturnValue);
     }
 
     public getInstalledDotnetSDKVersions(): Promise<string[]> {
-        this.commandRunner.execute('get sdk versions');
+        this.commandRunner.execute(CommandExecutor.makeCommand(`get`, [`sdk`, `versions`]));
         return Promise.resolve(this.installedSDKsReturnValue);
     }
 
     public getInstalledDotnetRuntimeVersions(): Promise<string[]> {
-        this.commandRunner.execute('get runtime versions');
+        this.commandRunner.execute(CommandExecutor.makeCommand(`get`, [`runtime`, `versions`]));
         return Promise.resolve(this.installedRuntimesReturnValue);
     }
 
     public getInstalledGlobalDotnetPathIfExists(): Promise<string | null> {
-        this.commandRunner.execute('global path');
+        this.commandRunner.execute(CommandExecutor.makeCommand(`global`, [`path`]));
         return Promise.resolve(this.globalPathReturnValue);
     }
 
     public getInstalledGlobalDotnetVersionIfExists(): Promise<string | null> {
-        this.commandRunner.execute('global version');
+        this.commandRunner.execute(CommandExecutor.makeCommand(`global`, [`version`]));
         return Promise.resolve(this.globalVersionReturnValue);
     }
 
-    public getExpectedDotnetDistroFeedInstallationDirectory(): Promise<string> {
-        this.commandRunner.execute('distro feed dir');
-        return Promise.resolve(this.distroFeedReturnValue);
+    public getExpectedDotnetDistroFeedInstallationDirectory(): string {
+        this.commandRunner.execute(CommandExecutor.makeCommand(`distro`, [`feed`, `dir`]));
+        return this.distroFeedReturnValue;
     }
 
-    public getExpectedDotnetMicrosoftFeedInstallationDirectory(): Promise<string> {
-        this.commandRunner.execute('microsoft feed dir');
-        return Promise.resolve(this.microsoftFeedReturnValue);
+    public getExpectedDotnetMicrosoftFeedInstallationDirectory(): string {
+        this.commandRunner.execute(CommandExecutor.makeCommand(`microsoft`, [`feed`, `dir`]));
+        return this.microsoftFeedReturnValue;
     }
 
     public dotnetPackageExistsOnSystem(fullySpecifiedVersion: string): Promise<boolean> {
-        this.commandRunner.execute('package check');
+        this.commandRunner.execute(CommandExecutor.makeCommand(`package`, [`check`]));
         return Promise.resolve(this.packageExistsReturnValue);
     }
 
     public getDotnetVersionSupportStatus(fullySpecifiedVersion: string): Promise<DotnetDistroSupportStatus> {
-        this.commandRunner.execute('support status');
+        this.commandRunner.execute(CommandExecutor.makeCommand(`support`, [`status`]));
         return Promise.resolve(this.supportStatusReturnValue);
     }
 
     public getRecommendedDotnetVersion(): string {
-        this.commandRunner.execute('recommended version');
+        this.commandRunner.execute(CommandExecutor.makeCommand(`recommended`, [`version`]));
         return this.recommendedVersionReturnValue;
     }
 
     public upgradeDotnet(versionToUpgrade: string): Promise<string> {
-        this.commandRunner.execute('upgrade update dotnet');
+        this.commandRunner.execute(CommandExecutor.makeCommand(`upgrade`, [`update`, `dotnet`]));
         return Promise.resolve(this.upgradeReturnValue);
     }
 
     public uninstallDotnet(versionToUninstall: string): Promise<string> {
-        this.commandRunner.execute('uninstall dotnet');
+        this.commandRunner.execute(CommandExecutor.makeCommand(`uninstall`, [`dotnet`]));
         return Promise.resolve(this.uninstallReturnValue);
     }
 

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -147,7 +147,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             await provider.installDotnet(mockVersion);
-            assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get update && sudo apt-get install -y dotnet-sdk-7.0');
+            assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get install -y dotnet-sdk-7.0');
         }
     });
 
@@ -163,7 +163,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             await provider.upgradeDotnet(mockVersion);
-            assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get update && apt-get upgrade -y dotnet-sdk-7.0');
+            assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get upgrade -y dotnet-sdk-7.0');
         }
     }).timeout(standardTimeoutTime*1000);
 });

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -8,14 +8,14 @@ import * as os from 'os';
 import { GenericDistroSDKProvider } from '../../Acquisition/GenericDistroSDKProvider';
 import { MockCommandExecutor, MockEventStream } from '../mocks/MockObjects';
 import { DistroVersionPair, DotnetDistroSupportStatus } from '../../Acquisition/LinuxVersionResolver';
-import { getMockAcquiringContext, getMockUtilityContext } from './TestUtility';
+import { getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
 const assert = chai.assert;
 const standardTimeoutTime = 100000;
 
 const mockVersion = '7.0.103';
 const mockExecutor = new MockCommandExecutor(new MockEventStream(), getMockUtilityContext());
 const pair : DistroVersionPair = { distro : 'Ubuntu', version : '22.04' };
-const provider : GenericDistroSDKProvider = new GenericDistroSDKProvider(pair, getMockAcquiringContext(false), getMockUtilityContext(), mockExecutor);
+const provider : GenericDistroSDKProvider = new GenericDistroSDKProvider(pair, getMockAcquisitionContext(false), getMockUtilityContext(), mockExecutor);
 const shouldRun = os.platform() === 'linux';
 
 const noDotnetString = `

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxVersionResolver.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxVersionResolver.test.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 import * as util from './TestUtility'
 import { MockCommandExecutor, MockDistroProvider, MockEventStream } from '../mocks/MockObjects';
 import { DistroVersionPair, LinuxVersionResolver } from '../../Acquisition/LinuxVersionResolver';
-import { getMockAcquiringContext, getMockUtilityContext } from './TestUtility';
+import { getMockAcquireContext, getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
 const assert = chai.assert;
 
 
@@ -20,9 +20,9 @@ suite('Linux Version Resolver Tests', () =>
     const mockExecutor = new MockCommandExecutor(new MockEventStream(), getMockUtilityContext());
     const pair : DistroVersionPair = { distro : 'Ubuntu', version : '22.04' };
     const shouldRun = os.platform() === 'linux';
-    const context = util.getMockAcquiringContext(false);
+    const context = util.getMockAcquisitionContext(false);
     const mockDistroProvider = new MockDistroProvider(pair, context, getMockUtilityContext(), mockExecutor);
-    const resolver : LinuxVersionResolver = new LinuxVersionResolver(context, getMockUtilityContext(), mockExecutor, mockDistroProvider);
+    const resolver : LinuxVersionResolver = new LinuxVersionResolver(context, getMockUtilityContext(), getMockAcquireContext(), mockExecutor, mockDistroProvider);
 
         test('It can determine the running distro', async () => {
             if(shouldRun)

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -4,6 +4,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+import { IDotnetAcquireContext } from '../..';
 import { IAcquisitionWorkerContext } from '../../Acquisition/IAcquisitionWorkerContext';
 import { RuntimeInstallationDirectoryProvider } from '../../Acquisition/RuntimeInstallationDirectoryProvider';
 import { SdkInstallationDirectoryProvider } from '../../Acquisition/SdkInstallationDirectoryProvider';
@@ -12,7 +13,7 @@ import { MockEventStream, MockExtensionContext, MockInstallationValidator, MockV
 import { MockWindowDisplayWorker } from '../mocks/MockWindowDisplayWorker';
 const standardTimeoutTime = 100000;
 
-export function getMockAcquiringContext(runtimeInstall: boolean, timeoutTime : number = standardTimeoutTime): IAcquisitionWorkerContext{
+export function getMockAcquisitionContext(runtimeInstall: boolean, timeoutTime : number = standardTimeoutTime): IAcquisitionWorkerContext{
     const extensionContext = new MockExtensionContext();
     const eventStream = new MockEventStream();
     const workerContext : IAcquisitionWorkerContext = {
@@ -28,11 +29,20 @@ export function getMockAcquiringContext(runtimeInstall: boolean, timeoutTime : n
     return workerContext;
 }
 
-export function getMockUtilityContext()
+export function getMockUtilityContext() : IUtilityContext
 {
     const utilityContext : IUtilityContext = {
         ui : new MockWindowDisplayWorker(),
         vsCodeEnv : new MockVSCodeEnvironment()
     }
     return utilityContext;
+}
+
+export function getMockAcquireContext() : IDotnetAcquireContext
+{
+    const acquireContext : IDotnetAcquireContext =
+    {
+        version: ''
+    };
+    return acquireContext;
 }

--- a/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
@@ -14,7 +14,7 @@ import { SdkInstallationDirectoryProvider } from '../../Acquisition/SdkInstallat
 import { IAcquisitionWorkerContext } from '../../Acquisition/IAcquisitionWorkerContext';
 import { FileUtilities } from '../../Utils/FileUtilities';
 import { MockWindowDisplayWorker } from '../mocks/MockWindowDisplayWorker';
-import { getMockAcquiringContext, getMockUtilityContext } from './TestUtility';
+import { getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
 const assert = chai.assert;
 const standardTimeoutTime = 100000;
 

--- a/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
@@ -139,7 +139,8 @@ suite('Windows & Mac Global Installer Tests', () =>
 
         if(os.platform() === 'darwin')
         {
-            assert.isTrue(mockExecutor.attemptedCommand.startsWith('open -W'), 'It ran the right mac command')
+            assert.isTrue(mockExecutor.attemptedCommand.startsWith('open'), `It ran the right mac command, open. Command found: ${mockExecutor.attemptedCommand}`)
+            assert.isTrue(mockExecutor.attemptedCommand.includes('-W'), 'It used the -W flag')
         }
         else if(os.platform() === 'win32')
         {


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1485 to avoid parsing spaces and commands by adding a new command type.
