### PR TITLE
Migrate to x64 VS Code instances for testing as 32-bit is unsupported

### DIFF
--- a/vscode-dotnet-runtime-extension/src/test/functional/runTest.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/runTest.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
+import * as os from 'os';
 
 import { runTests } from 'vscode-test';
 
@@ -17,8 +18,23 @@ async function main() {
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, './index');
 
+    let platformValue = '';
+    switch(os.platform())
+    {
+      case 'win32':
+        platformValue = 'win32-x64-archive';
+        break;
+      case 'darwin':
+        platformValue = 'darwin';
+        break;
+      case 'linux':
+        platformValue = 'linux-x64';
+        break;
+    }
+
     // Download VS Code, unzip it and run the integration test
     await runTests({
+      ...(platformValue !== '' && {platform: platformValue}),
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs: [

--- a/vscode-dotnet-sdk-extension/src/test/functional/runTest.ts
+++ b/vscode-dotnet-sdk-extension/src/test/functional/runTest.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
+import * as os from 'os';
 
 import { runTests } from 'vscode-test';
 
@@ -16,9 +17,23 @@ async function main() {
     // The path to the extension test runner script
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, './index');
+    let platformValue = '';
+    switch(os.platform())
+    {
+      case 'win32':
+        platformValue = 'win32-x64-archive';
+        break;
+      case 'darwin':
+        platformValue = 'darwin';
+        break;
+      case 'linux':
+        platformValue = 'linux-x64';
+        break;
+    }
 
     // Download VS Code, unzip it and run the integration test
     await runTests({
+      ...(platformValue !== '' && {platform: platformValue}),
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs: [


### PR DESCRIPTION

- Migrate to 64 bit vscode testing platform as 32-bit support is dropped and was the old default, which now causes failure on all tests: https://github.com/microsoft/vscode/issues/197554 and not committed to updating to a newer version of vscode yet where it's fixed.