### PR TITLE
Dont fail install if we dont have permission to clean up installer file

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -92,7 +92,7 @@ We cannot verify .NET is safe to download at this time. Please try again later.`
 
         if(this.cleanupInstallFiles)
         {
-            this.file.wipeDirectory(path.dirname(installerFile));
+            this.file.wipeDirectory(path.dirname(installerFile), this.acquisitionContext.eventStream);
         }
 
         const validInstallerStatusCodes = ['0', '1641', '3010']; // Ok, Pending Reboot, + Reboot Starting Now
@@ -114,7 +114,7 @@ We cannot verify .NET is safe to download at this time. Please try again later.`
     private async downloadInstaller(installerUrl : string) : Promise<string>
     {
         const ourInstallerDownloadFolder = IGlobalInstaller.getDownloadedInstallFilesFolder();
-        this.file.wipeDirectory(ourInstallerDownloadFolder);
+        this.file.wipeDirectory(ourInstallerDownloadFolder, this.acquisitionContext.eventStream);
         const installerPath = path.join(ourInstallerDownloadFolder, `${installerUrl.split('/').slice(-1)}`);
 
         const installerDir = path.dirname(installerPath);

--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -88,7 +88,7 @@ export class FileUtilities extends IFileUtilities
     /**
      * @param directoryToWipe the directory to delete all of the files in if privilege to do so exists.
      */
-    public wipeDirectory(directoryToWipe : string)
+    public wipeDirectory(directoryToWipe : string, eventStream : IEventStream)
     {
         if(!fs.existsSync(directoryToWipe))
         {
@@ -96,7 +96,17 @@ export class FileUtilities extends IFileUtilities
         }
 
         // Use rimraf to delete all of the items in a directory without the directory itself.
-        fs.readdirSync(directoryToWipe).forEach(f => fs.rmSync(`${directoryToWipe}/${f}`));
+        fs.readdirSync(directoryToWipe).forEach(f =>
+        {
+            try
+            {
+                fs.rmSync(`${directoryToWipe}/${f}`);
+            }
+            catch(error : any)
+            {
+                eventStream.post(new SuppressedAcquisitionError(error, `Failed to delete ${f} when marked for deletion.`));
+            }
+        });
     }
 
     /**

--- a/vscode-dotnet-runtime-library/src/Utils/IFileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/IFileUtilities.ts
@@ -11,13 +11,13 @@ export abstract class IFileUtilities
     public abstract writeFileOntoDisk(scriptContent: string, filePath: string, eventStream : IEventStream) : void;
 
     /**
-     * @param directoryToWipe the directory to delete all of the files in if privellege to do so exists.
+     * @param directoryToWipe the directory to delete all of the files in if privilege to do so exists.
      */
-    public abstract wipeDirectory(directoryToWipe : string) : void;
+    public abstract wipeDirectory(directoryToWipe : string, eventStream : IEventStream) : void;
 
     /**
      *
-     * @returns true if the process is running with admin privelleges on windows.
+     * @returns true if the process is running with admin privileges on windows.
      */
     public abstract isElevated(eventStream? : IEventStream) : boolean;
 

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -332,9 +332,9 @@ export class MockFileUtilities extends IFileUtilities
         return this.trueUtilities.writeFileOntoDisk(content, filePath, new MockEventStream());
     }
 
-    public wipeDirectory(directoryToWipe : string)
+    public wipeDirectory(directoryToWipe : string, eventSteam : IEventStream)
     {
-        return this.trueUtilities.wipeDirectory(directoryToWipe);
+        return this.trueUtilities.wipeDirectory(directoryToWipe, eventSteam);
     }
 
     public isElevated()


### PR DESCRIPTION
This is in the dist folder, it should* be cleaned up worst case by upgrade/uninstall of the extension, we dont want to fail everything if we dont have perm to delete, this is a win arm64 problem for whichever reason

- Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1515 by not failing the install if we dont have permission to delete the installer file we download, which happens on arm64
