### PR TITLE
Fix Axios Storage Handler to Handle Timeout & TLS Handshake Properly

### DIFF
--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -27,10 +27,21 @@ const mementoBasedAxiosCacheInterceptorStorage = (extensionStorage: IExtensionSt
         // tslint:disable-next-line
         set(key: string, value: any, request? : CacheRequestConfig)
          {
-             try
-             {
+            if(value.state === 'loading')
+            {
+                setTimeout(() =>
+                {
+                    if(value.state === 'loading')
+                    {
+                        return; // The web request is a timeout, do NOT cache its result, as the result is junk
+                    }
+                }, websiteTimeoutMs); // Give web requests
+            }
+
+            try
+            {
                 JSON.parse(value);
-             }
+            }
              catch(error : any)
              {
                 if(error.includes('Converting circular structure to JSON'))
@@ -45,17 +56,6 @@ const mementoBasedAxiosCacheInterceptorStorage = (extensionStorage: IExtensionSt
                 {
                     // Web request is to something other than json
                 }
-            }
-
-            if(value.state === 'loading')
-            {
-                setTimeout(() =>
-                {
-                    if(value.state === 'loading')
-                    {
-                        return; // The web request is a timeout, do NOT cache its result, as the result is junk
-                    }
-                }, websiteTimeoutMs); // Give web requests
             }
 
             extensionStorage.update(`${cachePrefix}:${key}`, value);

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -6,7 +6,7 @@ import Axios from 'axios';
 import axiosRetry from 'axios-retry';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { getProxySettings } from 'get-proxy-settings';
-import { AxiosCacheInstance, buildStorage, setupCache, StorageValue } from 'axios-cache-interceptor';
+import { AxiosCacheInstance, buildStorage, CacheRequestConfig, setupCache, StorageValue } from 'axios-cache-interceptor';
 import { IEventStream } from '../EventStream/EventStream';
 import {SuppressedAcquisitionError, WebRequestError, WebRequestSent } from '../EventStream/EventStreamEvents';
 import { IExtensionState } from '../IExtensionState';
@@ -21,12 +21,47 @@ This wraps the VSCode memento state blob into an axios-cache-interceptor-compati
 (The momento state is used to save extensionState/data across runs of the extension.)
 All the calls are synchronous.
 */
-const mementoStorage = (extensionStorage: IExtensionState) => {
+const mementoBasedAxiosCacheInterceptorStorage = (extensionStorage: IExtensionState, websiteTimeoutMs : number) => {
     const cachePrefix = 'axios-cache'; // Used to make it easier to tell what part of the extension state is from the cache
     return buildStorage({
         // tslint:disable-next-line
-        set(key: string, value: any) {
-            extensionStorage.update(`${cachePrefix}:${key}`, value);
+        set(key: string, value: any, request? : CacheRequestConfig)
+         {
+             let isJson = false;
+             let parsedJson = undefined;
+             try
+             {
+                parsedJson = JSON.parse(value);
+                isJson = true;
+             }
+             catch(error : any)
+             {
+                if(error.includes('Converting circular structure to JSON'))
+                {
+                    // For requests that contain the TLSSocket, which are web requests that are still initiating, they will be circular/cyclic
+                    // VS Code will try to unwrap the circular reference as there is a bug in the extension state handler
+                    // This will cause an infinite-loop timeout failure to update the extension state in the future
+                    // So we do not permit such requests to be cached
+                    return;
+                }
+                else
+                {
+                    // Web request is to something other than json
+                }
+            }
+
+            if(value.state === 'loading')
+            {
+                setTimeout(() =>
+                {
+                    if(value.state === 'loading')
+                    {
+                        return; // The web request is a timeout, do NOT cache its result, as the result is junk
+                    }
+                }, websiteTimeoutMs); // Give web requests
+            }
+
+            extensionStorage.update(`${cachePrefix}:${key}`, isJson ? parsedJson : value);
         },
         remove(key: string) {
             extensionStorage.update(`${cachePrefix}:${key}`, undefined);
@@ -73,7 +108,7 @@ export class WebRequestWorker
 
             this.client = setupCache(uncachedAxiosClient,
                 {
-                    storage: mementoStorage(this.extensionState),
+                    storage: mementoBasedAxiosCacheInterceptorStorage(this.extensionState, this.websiteTimeoutMs),
                     ttl: this.cacheTimeToLive
                 }
             );

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -27,12 +27,9 @@ const mementoBasedAxiosCacheInterceptorStorage = (extensionStorage: IExtensionSt
         // tslint:disable-next-line
         set(key: string, value: any, request? : CacheRequestConfig)
          {
-             let isJson = false;
-             let parsedJson = undefined;
              try
              {
-                parsedJson = JSON.parse(value);
-                isJson = true;
+                JSON.parse(value);
              }
              catch(error : any)
              {
@@ -61,7 +58,7 @@ const mementoBasedAxiosCacheInterceptorStorage = (extensionStorage: IExtensionSt
                 }, websiteTimeoutMs); // Give web requests
             }
 
-            extensionStorage.update(`${cachePrefix}:${key}`, isJson ? parsedJson : value);
+            extensionStorage.update(`${cachePrefix}:${key}`, value);
         },
         remove(key: string) {
             extensionStorage.update(`${cachePrefix}:${key}`, undefined);


### PR DESCRIPTION
https://axios-cache-interceptor.js.org/guide/storages The storage handler is supposed to prevent timed out requests from going into the cache per the documentation which it does not do.

Also, VS Code will try to unwrap a circular reference which the request will be circular in the TLS handshake. This is a 'bug' in serializeRequestArguments in extensionHostProcess.js from VS Code. This will prevent us from removing from the extension state in the future as trying to access it will cause an exception and cancel the request. Unfortunately, there is no good way I could find to filter things out of the cache.

I've changed to a memory based cache and @baronfel is OK with this change. This means the cache will not persist over different vscode windows, which is not optimal. However, until vs code does not fail with circular json references or non json objects with this cache, we do not seem to have ways to filter what goes into the cache and what does not. Even for one request, the no cache method still ends up putting things into the storage, see: https://axios-cache-interceptor.js.org/config/request-specifics#cache.

Then, the request object given to set does allow us to filter some of the content per request, but even then, one request seems to cause multiple potential cache entries. In addition, I looked at the code of the axios-cache-interceptor- and the loading state never gets updated until something is in the cache, so my previous code was based on incorrect assumptions, even if the logic would have worked if we had that kind of graunlar control. 

Perhaps I will raise an issue on the vscode repo, once that is complete, we could go back to the older more performant caching method.