### PR TITLE
Improve timeout error handling

### DIFF
--- a/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
@@ -38,8 +38,9 @@ export namespace errorConstants {
 }
 
 export namespace timeoutConstants {
-    export const timeoutMessage = `.NET installation timed out. You may need to change the timeout time if you have a slow connection. Please see: https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md#install-script-timeouts.
-Note that our websites may be blocked in China or experience significant timeouts, and you may want to install .NET manually.`;
+    export const timeoutMessage = `.NET install timed out.
+You should change the timeout if you have a slow connection. See: https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md#install-script-timeouts.
+Our CDN may be blocked in China or experience significant slowdown, in which case you should install .NET manually.`;
     export const moreInfoOption = 'Change Timeout Value';
 }
 

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -231,15 +231,15 @@ export class WebRequestWorker
             {
                 if(isAxiosError(error))
                 {
-                    let formattedError = error as AxiosError;
-                    const genericError = new Error(
-`Request to ${this.url} Failed: ${formattedError.message}. Aborting.
-${formattedError.cause? `Error Cause: ${formattedError.cause!.message}` : ``}
+                    const axiosBasedError = error as AxiosError;
+                    const summarizedError = new Error(
+`Request to ${this.url} Failed: ${axiosBasedError.message}. Aborting.
+${axiosBasedError.cause? `Error Cause: ${axiosBasedError.cause!.message}` : ``}
 Please ensure that you are online.
 
 If you're on a proxy and disable registry access, you must set the proxy in our extension settings. See https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md.`);
-                    this.eventStream.post(new WebRequestError(genericError));
-                    throw genericError;
+                    this.eventStream.post(new WebRequestError(summarizedError));
+                    throw summarizedError;
                 }
                 else
                 {


### PR DESCRIPTION
Axios already has its own timeout, so I dont think we need a 2nd timeout handler,  I was able to confirm it works by using https://httpstat.us/524 with a miniscule timeout value, and it does report the time it took to timeout in a similar fashion. We will get more information from errors this way when it is available.