### PR TITLE
Dont fail for unknown versions of Ubuntu by estimating a closest version

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -172,9 +172,33 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
 
     protected myVersionDetails() : any
     {
+
         const distroVersions = this.distroJson[this.distroVersion.distro][this.distroVersionsKey];
         const versionData = distroVersions.filter((x: { [x: string]: string; }) => x[this.versionKey] === this.distroVersion.version)[0];
+        if(!versionData)
+        {
+            const closestVersion = this.findMostSimilarVersion(this.distroVersion.version, distroVersions.map((x: { [x: string]: string; }) => parseFloat(x[this.versionKey])));
+            return distroVersions.filter((x: { [x: string]: string; }) => parseFloat(x[this.versionKey]) === closestVersion)[0];
+        }
         return versionData;
+    }
+
+    private findMostSimilarVersion(myVersion : string, knownVersions : number[]) : number
+    {
+        const sameMajorVersions = knownVersions.filter(x => Math.floor(x) === Math.floor(parseFloat(myVersion)));
+        if(sameMajorVersions && sameMajorVersions.length)
+        {
+            return Math.max(...sameMajorVersions);
+        }
+
+        const lowerMajorVersions = knownVersions.filter(x => x < Math.floor(parseFloat(myVersion)));
+        if(lowerMajorVersions && lowerMajorVersions.length)
+        {
+            return Math.max(...lowerMajorVersions);
+        }
+
+        // Just return the lowest known version, as it will be the closest to our version, as they are all larger than our version.
+        return Math.min(...knownVersions);
     }
 
     public async getRecommendedDotnetVersion(installType : LinuxInstallType) : Promise<string>

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -293,7 +293,7 @@ export class LinuxVersionResolver
         // Verify the version of dotnet is supported
         if (!( await this.distroSDKProvider!.isDotnetVersionSupported(fullySpecifiedDotnetVersion, 'sdk') ))
         {
-            throw new Error(`The distro ${this.distro?.distro, this.distro?.version} does not officially support dotnet version ${fullySpecifiedDotnetVersion}.`);
+            throw new Error(`The distro ${this.distro?.distro} ${this.distro?.version} does not officially support dotnet version ${fullySpecifiedDotnetVersion}.`);
         }
 
         // Verify there are no conflicting installs

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -293,7 +293,7 @@ export class LinuxVersionResolver
         // Verify the version of dotnet is supported
         if (!( await this.distroSDKProvider!.isDotnetVersionSupported(fullySpecifiedDotnetVersion, 'sdk') ))
         {
-            throw new Error(`The distro ${this.distro} does not officially support dotnet version ${fullySpecifiedDotnetVersion}.`);
+            throw new Error(`The distro ${this.distro?.distro, this.distro?.version} does not officially support dotnet version ${fullySpecifiedDotnetVersion}.`);
         }
 
         // Verify there are no conflicting installs


### PR DESCRIPTION
The theory is a version with the same major but with the maximum lower minor will be the closest in behavior, then the maximum version that is lower than the current version is most likely to have the same behavior. If there is no smaller known version, it will just use the minimum version that is higher.

This logic may not always work. But with the given circumstances, we are covered by including the first version where preinstall commands were not needed