### PR TITLE
Add PMC Feed Earlier & Fix PMC Feed Addition with Apt-Cache

### DIFF
--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -133,11 +133,6 @@
 					{
 						"runUnderSudo": true,
 						"commandRoot": "apt-get",
-						"commandParts": ["update"]
-					},
-					{
-						"runUnderSudo": true,
-						"commandRoot": "apt-get",
 						"commandParts": ["install", "-y", "wget"]
 					},
 					{
@@ -149,7 +144,12 @@
 						"runUnderSudo": true,
 						"commandRoot": "dpkg",
 						"commandParts": ["-i", "packages-microsoft-prod.deb"]
-					}
+					},
+					{
+						"runUnderSudo": true,
+						"commandRoot": "apt-get",
+						"commandParts": ["update"]
+					},
 				]
 			},
 			{

--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -149,7 +149,7 @@
 						"runUnderSudo": true,
 						"commandRoot": "apt-get",
 						"commandParts": ["update"]
-					},
+					}
 				]
 			},
 			{

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
@@ -166,7 +166,7 @@ export abstract class IDistroDotnetSDKProvider {
         return supportedType && this.versionResolver.getFeatureBandFromVersion(fullySpecifiedVersion) === '1';
     }
 
-    protected async myVersionPackages(installType : LinuxInstallType) : Promise<LinuxPackageCollection[]>
+    protected async myVersionPackages(installType : LinuxInstallType, haveTriedFeedInjectionAlready = false) : Promise<LinuxPackageCollection[]>
     {
         const availableVersions : LinuxPackageCollection[] = [];
 
@@ -197,7 +197,58 @@ export abstract class IDistroDotnetSDKProvider {
             }
         }
 
+        if(availableVersions.length === 0 && !haveTriedFeedInjectionAlready)
+        {
+            // PMC is only injected and should only be injected for MSFT feed distros.
+            // Our check runs by checking the feature band first, so that needs to be supported for it to fallback to the preinstall command check.
+            const fakeVersionToCheckMicrosoftSupportStatus = '6.0.1xx';
+
+            await this.injectPMCFeed(fakeVersionToCheckMicrosoftSupportStatus, installType);
+            return this.myVersionPackages(installType, true);
+        }
         return availableVersions;
+    }
+
+    protected async injectPMCFeed(fullySpecifiedVersion : string, installType : LinuxInstallType)
+    {
+        const supportStatus = await this.getDotnetVersionSupportStatus(fullySpecifiedVersion, installType);
+        if(supportStatus === DotnetDistroSupportStatus.Microsoft)
+        {
+            const myVersionDetails = this.myVersionDetails();
+            const preInstallCommands = myVersionDetails[this.preinstallCommandKey] as CommandExecutorCommand[];
+            await this.commandRunner.executeMultipleCommands(preInstallCommands);
+        }
+    }
+
+    protected myVersionDetails() : any
+    {
+
+        const distroVersions = this.distroJson[this.distroVersion.distro][this.distroVersionsKey];
+        const versionData = distroVersions.filter((x: { [x: string]: string; }) => x[this.versionKey] === this.distroVersion.version)[0];
+        if(!versionData)
+        {
+            const closestVersion = this.findMostSimilarVersion(this.distroVersion.version, distroVersions.map((x: { [x: string]: string; }) => parseFloat(x[this.versionKey])));
+            return distroVersions.filter((x: { [x: string]: string; }) => parseFloat(x[this.versionKey]) === closestVersion)[0];
+        }
+        return versionData;
+    }
+
+    protected findMostSimilarVersion(myVersion : string, knownVersions : number[]) : number
+    {
+        const sameMajorVersions = knownVersions.filter(x => Math.floor(x) === Math.floor(parseFloat(myVersion)));
+        if(sameMajorVersions && sameMajorVersions.length)
+        {
+            return Math.max(...sameMajorVersions);
+        }
+
+        const lowerMajorVersions = knownVersions.filter(x => x < Math.floor(parseFloat(myVersion)));
+        if(lowerMajorVersions && lowerMajorVersions.length)
+        {
+            return Math.max(...lowerMajorVersions);
+        }
+
+        // Just return the lowest known version, as it will be the closest to our version, as they are all larger than our version.
+        return Math.min(...knownVersions);
     }
 
     protected myDistroStrings(stringKey : string) : string


### PR DESCRIPTION
If we dont run sudo apt-get update first then the search command will have no idea PMC packages exist.

In addition, regarding when we add the PMC and how we check for what packages of dotnet are available, the old code is incorrect and Im surprised it worked correctly but see how it happened. 

The following code relies on the function myVersionPackages

-  uninstall, update, install, should update (dotnetpackageexistsonsystem), getglobalsdkpath, getrecommendeddotnetversion

Some of those may have incorrect information based on whether or not the PMC was added before by the install command first before they were called...

This fixes said issue.