### PR TITLE
Use Installer Type Conforming Installation Directory for Ubuntu

### DIFF
--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -59,6 +59,14 @@
 				"commandParts": ["-l", "{packageName}"]
 			}
 		],
+		"readSymLinkCommand":
+		[
+			{
+				"runUnderSudo": false,
+				"commandRoot": "readlink",
+				"commandParts": ["-f", "{path}"]
+			}
+		],
 		"expectedDistroFeedInstallDirectory" : "/usr/lib/dotnet",
         "expectedMicrosoftFeedInstallDirectory" : "/usr/share/dotnet",
 		"installedSDKVersionsCommand":
@@ -253,6 +261,14 @@
 					"{packageName}",
 					"-q"
 				]
+			}
+		],
+		"readSymLinkCommand":
+		[
+			{
+				"runUnderSudo": false,
+				"commandRoot": "readlink",
+				"commandParts": ["-f", "{path}"]
 			}
 		],
 		"expectedDistroFeedInstallDirectory": "/usr/lib64/dotnet/dotnet",

--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -60,7 +60,7 @@
 			}
 		],
 		"expectedDistroFeedInstallDirectory" : "/usr/lib/dotnet",
-        "expectedMicrosoftFeedInstallDirectory" : "/usr/bin/dotnet",
+        "expectedMicrosoftFeedInstallDirectory" : "/usr/share/dotnet",
 		"installedSDKVersionsCommand":
 		[
 			{

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -13,6 +13,8 @@ import { IDistroDotnetSDKProvider } from './IDistroDotnetSDKProvider';
 
 export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
 {
+    protected resolvePathAsSymlink = true;
+
     public async installDotnet(fullySpecifiedVersion : string, installType : LinuxInstallType): Promise<string>
     {
         await this.injectPMCFeed(fullySpecifiedVersion, installType);
@@ -37,6 +39,18 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
         {
             commandResult[0] = commandResult[0].trim();
         }
+
+        if(commandResult && this.resolvePathAsSymlink)
+        {
+            let symLinkReadCommand = this.myDistroCommands(this.readSymbolicLinkCommandKey);
+            symLinkReadCommand = CommandExecutor.replaceSubstringsInCommands(symLinkReadCommand, this.missingPathKey, commandResult[0]);
+            const resolvedPath = (await this.commandRunner.executeMultipleCommands(symLinkReadCommand))[0];
+            if(resolvedPath)
+            {
+                return resolvedPath.trim();
+            }
+        }
+
         return commandResult[0];
     }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -47,7 +47,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
             const resolvedPath = (await this.commandRunner.executeMultipleCommands(symLinkReadCommand))[0];
             if(resolvedPath)
             {
-                return resolvedPath.trim();
+                return path.dirname(resolvedPath.trim());
             }
         }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
@@ -43,6 +43,7 @@ export abstract class IDistroDotnetSDKProvider {
     protected searchCommandKey = 'searchCommand';
     protected updateCommandKey = 'updateCommand';
     protected packageLookupCommandKey = 'packageLookupCommand';
+    protected readSymbolicLinkCommandKey = 'readSymLinkCommand';
     protected currentInstallPathCommandKey = 'currentInstallPathCommand';
     protected isInstalledCommandKey = 'isInstalledCommand';
     protected expectedMicrosoftFeedInstallDirKey = 'expectedMicrosoftFeedInstallDirectory';
@@ -51,6 +52,7 @@ export abstract class IDistroDotnetSDKProvider {
     protected installedRuntimeVersionsCommandKey = 'installedRuntimeVersionsCommand';
     protected currentInstallVersionCommandKey = 'currentInstallationVersionCommand';
     protected missingPackageNameKey = '{packageName}';
+    protected missingPathKey = '{path}';
 
     protected distroVersionsKey = 'versions';
     protected versionKey = 'version';

--- a/vscode-dotnet-runtime-library/src/Acquisition/RedHatDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RedHatDistroSDKProvider.ts
@@ -3,12 +3,22 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
+import { ICommandExecutor } from '../Utils/ICommandExecutor';
+import { IUtilityContext } from '../Utils/IUtilityContext';
 import { GenericDistroSDKProvider } from './GenericDistroSDKProvider';
+import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { LinuxInstallType } from './LinuxInstallType';
+import { DistroVersionPair } from './LinuxVersionResolver';
 /* tslint:disable:no-any */
 
 export class RedHatDistroSDKProvider extends GenericDistroSDKProvider
 {
+    constructor(distroVersion : DistroVersionPair, context : IAcquisitionWorkerContext, utilContext : IUtilityContext, executor : ICommandExecutor | null = null)
+    {
+        super(distroVersion, context, utilContext, executor);
+        this.resolvePathAsSymlink = false;
+    }
+
     protected myVersionDetails() : any
     {
         const distroVersions = this.distroJson[this.distroVersion.distro][this.distroVersionsKey];

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -86,7 +86,9 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
         return new Promise<string>((resolve, reject) =>
         {
             // The '.' character is not allowed for sudo-prompt so we use 'NET'
-            const options = { name: `${this.context?.acquisitionContext?.requestingExtensionId} On behalf of NET Install Tool` };
+            let sanitizedCallerName = this.context?.acquisitionContext?.requestingExtensionId?.replace(/[^0-9a-z]/gi, ''); // Remove non-alphanumerics per OS requirements
+            sanitizedCallerName = sanitizedCallerName?.substring(0, 69); // 70 Characters is the maximum limit we can use for the prompt.
+            const options = { name: `${sanitizedCallerName ?? '.NET Install Tool'}` };
             exec((fullCommandString), options, (error?: any, stdout?: any, stderr?: any) =>
             {
                 let commandResultString = '';

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -104,7 +104,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             await provider.getInstalledGlobalDotnetPathIfExists(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'which dotnet');
+            assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/bin/dotnet');
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -60,7 +60,7 @@ suite('Linux Distro Logic Unit Tests', () =>
         if(shouldRun)
         {
             const microsoftFeedDir = await provider.getExpectedDotnetMicrosoftFeedInstallationDirectory();
-            assert.equal(microsoftFeedDir, '/usr/bin/dotnet');
+            assert.equal(microsoftFeedDir, '/usr/share/dotnet');
         }
     }).timeout(standardTimeoutTime);
 


### PR DESCRIPTION
For https://github.com/dotnet/vscode-dotnet-runtime/issues/1520
The /bin/ folder is a symlink that gets used by both distro support types, PMC and Distro Built In.
I got confirmation from Cannonical that lib is where they always put their files and we should expect our PMC debs to place them into share. This is a much simpler change that reading the symlink.

I think I put bin there when testing because thats what I saw the OS doing but it was in reality a symlink.