### PR TITLE
Fix SDK Linux Updates, & Add Cancellation Messages - 2.0.1 Release

### DIFF
--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -35,7 +35,7 @@
 		},
 		"../vscode-dotnet-runtime-extension": {
 			"name": "vscode-dotnet-runtime",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^1.3.4",
@@ -128,7 +128,7 @@
 			}
 		},
 		"../vscode-dotnet-sdk-extension": {
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/chai": "4.2.22",

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -1832,7 +1832,7 @@
 
 "vscode-dotnet-runtime@file:../vscode-dotnet-runtime-extension":
   "resolved" "file:../vscode-dotnet-runtime-extension"
-  "version" "2.0.0"
+  "version" "2.0.1"
   dependencies:
     "axios" "^1.3.4"
     "axios-cache-interceptor" "^1.0.1"
@@ -1860,7 +1860,7 @@
 
 "vscode-dotnet-sdk@file:../vscode-dotnet-sdk-extension":
   "resolved" "file:../vscode-dotnet-sdk-extension"
-  "version" "2.0.0"
+  "version" "2.0.1"
   dependencies:
     "@types/chai" "4.2.22"
     "@types/chai-as-promised" "^7.1.4"

--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
+## [2.0.1] - 2023-09-18
+
+Fixes several key bugs with installing .NET:
+
+- Ubuntu Installs would fail for the first time on 18.04.
+- The extension would print ... forever after installation failure.
+- The extension would fail to read Ubuntu directories properly if PMC was installed in certain scenarios.
+- GitHub Forms is now added.
+- Corrects behavior on our unknown Ubuntu Versions by estimating the correct behavior for known versions.
+- Improve timeout error handling
+- Catch bug in the caching library we use to prevent it from failing to cache
+- Several other key issues.
+
 ## [2.0.0] - 2023-09-18
 
 The '.NET Runtime Install Tool' has been renamed to the '.NET Install Tool.'

--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -6,20 +6,27 @@ The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
-## [2.0.1] - 2023-09-18
+## [2.0.1] - 2024-01-03
 
 Fixes several key bugs with installing .NET:
 
-- Ubuntu Installs would fail for the first time on 18.04.
-- The extension would print ... forever after installation failure.
-- The extension would fail to read Ubuntu directories properly if PMC was installed in certain scenarios.
+- Ubuntu Global SDK Installs would fail for the first time on 18.04.
+- The extension would print ... forever after installation failure for certain errors.
+- The extension would fail to read Ubuntu directories properly for the first time if PMC was installed in certain scenarios.
 - GitHub Forms is now added.
 - Corrects behavior on our unknown Ubuntu Versions by estimating the correct behavior for known versions.
 - Improve timeout error handling
 - Catch bug in the caching library we use to prevent it from failing to cache
+- Remove bug where status bar would stay red when cancelling install
+- Fix bug where Linux would not update .NET SDKs properly when it could update instead of install
+- Detect when a user cancels the installation in the password prompt or windows installer so we can remove the error failure message
+- Adds more logging to the extension to improve diagnostics and speed to resolve github issues
+- Improve installation management, so that the extension is aware that installs it manages can be deleted by external sources, to prevent it from thinking something is installed when it is no longer installed.
+- Fix an issue where the uninstall command would think it could uninstall a global SDK. This is not the case.
+- Improve detection logic for existing Ubuntu and RHEL installations of linux to prevent installing when it is not needed
 - Several other key issues.
 
-## [2.0.0] - 2023-09-18
+## [2.0.0] - 2023-11-23
 
 The '.NET Runtime Install Tool' has been renamed to the '.NET Install Tool.'
 

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-dotnet-runtime",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-dotnet-runtime",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^1.3.4",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -13,7 +13,7 @@
 	"description": "This extension installs and manages different versions of the .NET SDK and Runtime.",
 	"appInsightsKey": "02dc18e0-7494-43b2-b2a3-18ada5fcb522",
 	"icon": "images/dotnetIcon.png",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"publisher": "ms-dotnettools",
 	"engines": {
 		"vscode": "^1.74.0"

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -106,7 +106,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         showLogCommand: `${commandPrefix}.${commandKeys.showAcquisitionLog}`,
         packageJson
     } as IEventStreamContext;
-    const [eventStream, outputChannel, loggingObserver, eventStreamObservers, telemetryObserver] = registerEventStream(eventStreamContext, vsCodeExtensionContext, utilContext);
+    const [globalEventStream, outputChannel, loggingObserver, eventStreamObservers, telemetryObserver] = registerEventStream(eventStreamContext, vsCodeExtensionContext, utilContext);
 
 
     // Setting up command-shared classes for Runtime & SDK Acquisition
@@ -125,8 +125,8 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
     const dotnetAcquireRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquire}`, async (commandContext: IDotnetAcquireContext) => {
         let fullyResolvedVersion = '';
         const dotnetPath = await callWithErrorHandling<Promise<IDotnetAcquireResult>>(async () => {
-            eventStream.post(new DotnetRuntimeAcquisitionStarted(commandContext.requestingExtensionId));
-            eventStream.post(new DotnetAcquisitionRequested(commandContext.version, commandContext.requestingExtensionId));
+            globalEventStream.post(new DotnetRuntimeAcquisitionStarted(commandContext.requestingExtensionId));
+            globalEventStream.post(new DotnetAcquisitionRequested(commandContext.version, commandContext.requestingExtensionId));
 
             runtimeAcquisitionWorker.setAcquisitionContext(commandContext);
             telemetryObserver?.setAcquisitionContext(runtimeContext, commandContext);
@@ -154,7 +154,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         }, runtimeIssueContextFunctor(commandContext.errorConfiguration, 'acquire', commandContext.version), commandContext.requestingExtensionId, runtimeContext);
 
         const installKey = runtimeAcquisitionWorker.getInstallKey(fullyResolvedVersion);
-        eventStream.post(new DotnetRuntimeAcquisitionTotalSuccessEvent(commandContext.version, installKey, commandContext.requestingExtensionId ?? '', dotnetPath?.dotnetPath ?? ''));
+        globalEventStream.post(new DotnetRuntimeAcquisitionTotalSuccessEvent(commandContext.version, installKey, commandContext.requestingExtensionId ?? '', dotnetPath?.dotnetPath ?? ''));
         return dotnetPath;
     });
 
@@ -167,8 +167,8 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
 
         const pathResult = callWithErrorHandling(async () =>
         {
-            eventStream.post(new DotnetSDKAcquisitionStarted(commandContext.requestingExtensionId));
-            eventStream.post(new DotnetAcquisitionRequested(commandContext.version, commandContext.requestingExtensionId));
+            globalEventStream.post(new DotnetSDKAcquisitionStarted(commandContext.requestingExtensionId));
+            globalEventStream.post(new DotnetAcquisitionRequested(commandContext.version, commandContext.requestingExtensionId));
 
             const existingPath = await resolveExistingPathIfExists(existingPathConfigWorker, commandContext);
             if(existingPath)
@@ -196,7 +196,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
 
     const dotnetAcquireStatusRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquireStatus}`, async (commandContext: IDotnetAcquireContext) => {
         const pathResult = callWithErrorHandling(async () => {
-            eventStream.post(new DotnetAcquisitionStatusRequested(commandContext.version, commandContext.requestingExtensionId));
+            globalEventStream.post(new DotnetAcquisitionStatusRequested(commandContext.version, commandContext.requestingExtensionId));
             const resolvedVersion = await runtimeVersionResolver.getFullRuntimeVersion(commandContext.version);
             const dotnetPath = await runtimeAcquisitionWorker.acquireStatus(resolvedVersion, true);
             return dotnetPath;
@@ -220,7 +220,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
             const result = cp.spawnSync(commandContext.command, commandContext.arguments);
             const installer = new DotnetCoreDependencyInstaller();
             if (installer.signalIndicatesMissingLinuxDependencies(result.signal!)) {
-                eventStream.post(new DotnetAcquisitionMissingLinuxDependencies());
+                globalEventStream.post(new DotnetAcquisitionMissingLinuxDependencies());
                 await installer.promptLinuxDependencyInstall('Failed to run .NET runtime.');
             }
         }, runtimeIssueContextFunctor(commandContext.errorConfiguration, 'ensureDependencies'));
@@ -239,7 +239,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
 
         const existingPath = existingPathResolver.resolveExistingPath(configResolver.getPathConfigurationValue(), commandContext.requestingExtensionId, displayWorker);
         if (existingPath) {
-            eventStream.post(new DotnetExistingPathResolutionCompleted(existingPath.dotnetPath));
+            globalEventStream.post(new DotnetExistingPathResolutionCompleted(existingPath.dotnetPath));
             return new Promise((resolve) => {
                 resolve(existingPath);
             });
@@ -254,8 +254,8 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         return {
             storagePath: context.globalStoragePath,
             extensionState: context.globalState,
-            eventStream: eventStream,
-            installationValidator: new InstallationValidator(eventStream),
+            eventStream: globalEventStream,
+            installationValidator: new InstallationValidator(globalEventStream),
             timeoutSeconds: resolvedTimeoutSeconds,
             installDirectoryProvider: isRuntimeInstall ? new RuntimeInstallationDirectoryProvider(context.globalStoragePath): new SdkInstallationDirectoryProvider(context.globalStoragePath),
             proxyUrl: proxyLink,
@@ -276,7 +276,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
                 errorConfiguration: errorConfiguration || AcquireErrorConfiguration.DisplayAllErrorPopups,
                 displayWorker,
                 extensionConfigWorker: configResolver,
-                eventStream,
+                eventStream: globalEventStream,
                 commandName,
                 version,
                 moreInfoUrl,

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -254,7 +254,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         return {
             storagePath: context.globalStoragePath,
             extensionState: context.globalState,
-            eventStream,
+            eventStream: eventStream,
             installationValidator: new InstallationValidator(eventStream),
             timeoutSeconds: resolvedTimeoutSeconds,
             installDirectoryProvider: isRuntimeInstall ? new RuntimeInstallationDirectoryProvider(context.globalStoragePath): new SdkInstallationDirectoryProvider(context.globalStoragePath),

--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -271,7 +271,7 @@
 				"commandParts": ["-f", "{path}"]
 			}
 		],
-		"expectedDistroFeedInstallDirectory": "/usr/lib64/dotnet/dotnet",
+		"expectedDistroFeedInstallDirectory": "/usr/lib64/dotnet",
 		"expectedMicrosoftFeedInstallDirectory": "",
 		"installedSDKVersionsCommand": [
 			{

--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -59,6 +59,14 @@
 				"commandParts": ["-l", "{packageName}"]
 			}
 		],
+		"readSymLinkCommand":
+		[
+			{
+				"runUnderSudo": false,
+				"commandRoot": "readlink",
+				"commandParts": ["-f", "{path}"]
+			}
+		],
 		"expectedDistroFeedInstallDirectory" : "/usr/lib/dotnet",
         "expectedMicrosoftFeedInstallDirectory" : "/usr/share/dotnet",
 		"installedSDKVersionsCommand":
@@ -253,6 +261,14 @@
 					"{packageName}",
 					"-q"
 				]
+			}
+		],
+		"readSymLinkCommand":
+		[
+			{
+				"runUnderSudo": false,
+				"commandRoot": "readlink",
+				"commandParts": ["-f", "{path}"]
 			}
 		],
 		"expectedDistroFeedInstallDirectory": "/usr/lib64/dotnet/dotnet",

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -308,7 +308,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
 
         this.context.eventStream.post(new DotnetBeginGlobalInstallerExecution(`Beginning to run installer for ${installKey} in ${os.platform()}.`))
         const installerResult = await installer.installSDK();
-        this.context.eventStream.post(new DotnetCompletedGlobalInstallerExecution(`Beginning to run installer for ${installKey} in ${os.platform()}.`))
+        this.context.eventStream.post(new DotnetCompletedGlobalInstallerExecution(`Completed installer for ${installKey} in ${os.platform()}.`))
 
         if(installerResult !== '0')
         {

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -35,6 +35,17 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
     public async getInstalledGlobalDotnetPathIfExists(installType : LinuxInstallType) : Promise<string | null>
     {
         const commandResult = await this.commandRunner.executeMultipleCommands(this.myDistroCommands(this.currentInstallPathCommandKey));
+
+        const oldReturnStatusSetting = this.commandRunner.returnStatus;
+        this.commandRunner.returnStatus = true;
+        const commandSignal = await this.commandRunner.executeMultipleCommands(this.myDistroCommands(this.currentInstallPathCommandKey));
+        this.commandRunner.returnStatus = oldReturnStatusSetting;
+
+        if(commandSignal[0] !== '0') // no dotnet error can be returned, dont want to try to parse this as a path
+        {
+            return null;
+        }
+
         if(commandResult[0])
         {
             commandResult[0] = commandResult[0].trim();

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -13,6 +13,8 @@ import { IDistroDotnetSDKProvider } from './IDistroDotnetSDKProvider';
 
 export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
 {
+    protected resolvePathAsSymlink = true;
+
     public async installDotnet(fullySpecifiedVersion : string, installType : LinuxInstallType): Promise<string>
     {
         await this.injectPMCFeed(fullySpecifiedVersion, installType);
@@ -37,6 +39,18 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
         {
             commandResult[0] = commandResult[0].trim();
         }
+
+        if(commandResult && this.resolvePathAsSymlink)
+        {
+            let symLinkReadCommand = this.myDistroCommands(this.readSymbolicLinkCommandKey);
+            symLinkReadCommand = CommandExecutor.replaceSubstringsInCommands(symLinkReadCommand, this.missingPathKey, commandResult[0]);
+            const resolvedPath = (await this.commandRunner.executeMultipleCommands(symLinkReadCommand))[0];
+            if(resolvedPath)
+            {
+                return resolvedPath.trim();
+            }
+        }
+
         return commandResult[0];
     }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -51,7 +51,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
             }
         }
 
-        return commandResult[0];
+        return commandResult[0] ?? null;
     }
 
     public async dotnetPackageExistsOnSystem(fullySpecifiedDotnetVersion : string, installType : LinuxInstallType) : Promise<boolean>

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -77,11 +77,15 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
 
     public async upgradeDotnet(versionToUpgrade : string, installType : LinuxInstallType): Promise<string>
     {
+        const oldReturnStatusSetting = this.commandRunner.returnStatus;
+        this.commandRunner.returnStatus = true;
+
         let command = this.myDistroCommands(this.updateCommandKey);
         const sdkPackage = await this.myDotnetVersionPackageName(versionToUpgrade, installType);
         command = CommandExecutor.replaceSubstringsInCommands(command, this.missingPackageNameKey, sdkPackage);
         const commandResult = (await this.commandRunner.executeMultipleCommands(command))[0];
 
+        this.commandRunner.returnStatus = oldReturnStatusSetting;
         return commandResult[0];
     }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -40,7 +40,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
             commandResult[0] = commandResult[0].trim();
         }
 
-        if(commandResult && this.resolvePathAsSymlink)
+        if(!commandResult[0] && this.resolvePathAsSymlink)
         {
             let symLinkReadCommand = this.myDistroCommands(this.readSymbolicLinkCommandKey);
             symLinkReadCommand = CommandExecutor.replaceSubstringsInCommands(symLinkReadCommand, this.missingPathKey, commandResult[0]);

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -47,7 +47,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
             const resolvedPath = (await this.commandRunner.executeMultipleCommands(symLinkReadCommand))[0];
             if(resolvedPath)
             {
-                return resolvedPath.trim();
+                return path.dirname(resolvedPath.trim());
             }
         }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -40,7 +40,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
             commandResult[0] = commandResult[0].trim();
         }
 
-        if(!commandResult[0] && this.resolvePathAsSymlink)
+        if(commandResult[0] && this.resolvePathAsSymlink)
         {
             let symLinkReadCommand = this.myDistroCommands(this.readSymbolicLinkCommandKey);
             symLinkReadCommand = CommandExecutor.replaceSubstringsInCommands(symLinkReadCommand, this.missingPathKey, commandResult[0]);

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
@@ -43,6 +43,7 @@ export abstract class IDistroDotnetSDKProvider {
     protected searchCommandKey = 'searchCommand';
     protected updateCommandKey = 'updateCommand';
     protected packageLookupCommandKey = 'packageLookupCommand';
+    protected readSymbolicLinkCommandKey = 'readSymLinkCommand';
     protected currentInstallPathCommandKey = 'currentInstallPathCommand';
     protected isInstalledCommandKey = 'isInstalledCommand';
     protected expectedMicrosoftFeedInstallDirKey = 'expectedMicrosoftFeedInstallDirectory';
@@ -51,6 +52,7 @@ export abstract class IDistroDotnetSDKProvider {
     protected installedRuntimeVersionsCommandKey = 'installedRuntimeVersionsCommand';
     protected currentInstallVersionCommandKey = 'currentInstallationVersionCommand';
     protected missingPackageNameKey = '{packageName}';
+    protected missingPathKey = '{path}';
 
     protected distroVersionsKey = 'versions';
     protected versionKey = 'version';

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -318,7 +318,7 @@ export class LinuxVersionResolver
         {
             return '0';
         }
-        return updateOrRejectState;
+        return String(updateOrRejectState);
     }
 
     /**

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -10,6 +10,7 @@ import
     DotnetAcquisitionDistroUnknownError,
     DotnetConflictingLinuxInstallTypesError,
     DotnetCustomLinuxInstallExistsError,
+    DotnetInstallLinuxChecks,
     DotnetUpgradedEvent
 } from '../EventStream/EventStreamEvents';
 import { GenericDistroSDKProvider } from './GenericDistroSDKProvider'

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -256,6 +256,7 @@ export class LinuxVersionResolver
     {
         await this.Initialize();
 
+        this.acquisitionContext.eventStream.post(new DotnetInstallLinuxChecks(`Checking to see if we should install, update, or cancel...`));
         if(existingInstall)
         {
             const existingGlobalInstallSDKVersion = await this.distroSDKProvider!.getInstalledGlobalDotnetVersionIfExists();

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -184,9 +184,9 @@ export class LinuxVersionResolver
             case 'Red Hat Enterprise Linux':
                 if(this.isRedHatVersion7(distroAndVersion.version))
                 {
-                    const error = new DotnetAcquisitionDistroUnknownError(new Error(this.redhatUnsupportedDistroErrorMessage), getInstallKeyFromContext(this.acquireContext));
-                    this.acquisitionContext.eventStream.post(error);
-                    throw error.error;
+                    const unsupportedRhelErr = new DotnetAcquisitionDistroUnknownError(new Error(this.redhatUnsupportedDistroErrorMessage), getInstallKeyFromContext(this.acquireContext));
+                    this.acquisitionContext.eventStream.post(unsupportedRhelErr);
+                    throw unsupportedRhelErr.error;
                 }
                 return new RedHatDistroSDKProvider(distroAndVersion, this.acquisitionContext, this.utilityContext);
             default:
@@ -264,7 +264,8 @@ export class LinuxVersionResolver
             if(existingGlobalInstallSDKVersion && Number(this.versionResolver.getMajorMinor(existingGlobalInstallSDKVersion)) ===
                 Number(this.versionResolver.getMajorMinor(fullySpecifiedDotnetVersion)))
             {
-                const isPatchUpgrade = Number(this.versionResolver.getFeatureBandPatchVersion(existingGlobalInstallSDKVersion)) < Number(this.versionResolver.getFeatureBandPatchVersion(fullySpecifiedDotnetVersion));
+                const isPatchUpgrade = Number(this.versionResolver.getFeatureBandPatchVersion(existingGlobalInstallSDKVersion)) <
+                    Number(this.versionResolver.getFeatureBandPatchVersion(fullySpecifiedDotnetVersion));
 
                 if(Number(this.versionResolver.getMajorMinor(existingGlobalInstallSDKVersion)) > Number(this.versionResolver.getMajorMinor(fullySpecifiedDotnetVersion))
                 || Number(this.versionResolver.getFeatureBandFromVersion(existingGlobalInstallSDKVersion)) > Number(this.versionResolver.getFeatureBandFromVersion(fullySpecifiedDotnetVersion)))

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -70,6 +70,7 @@ export class LinuxVersionResolver
     protected commandRunner : ICommandExecutor;
     protected versionResolver : VersionResolver;
     public okUpdateExitCode = 11188; // Arbitrary number that is not shared or used by other things we rely on as an exit code
+    public okAlreadyExistsExitCode = 11166;
 
     public conflictingInstallErrorMessage = `A dotnet installation was found which indicates dotnet that was installed via Microsoft package feeds. But for this distro and version, we only acquire .NET via the distro feeds.
     You should not mix distro feed and microsoft feed installations. To continue, please completely remove this version of dotnet to continue by following https://learn.microsoft.com/dotnet/core/install/remove-runtime-sdk-versions?pivots=os-linux.
@@ -289,7 +290,7 @@ export class LinuxVersionResolver
                 else
                 {
                     // An existing install exists.
-                    return '1';
+                    return String(this.okAlreadyExistsExitCode);
                 }
             }
             // Additional logic to check the major.minor could be added here if we wanted to prevent installing lower major.minors if an existing install existed.
@@ -322,7 +323,7 @@ export class LinuxVersionResolver
         {
             return await this.distroSDKProvider!.installDotnet(fullySpecifiedDotnetVersion, 'sdk') ? '0' : '1';
         }
-        else if(updateOrRejectState === String(this.okUpdateExitCode))
+        else if(updateOrRejectState === String(this.okUpdateExitCode) || updateOrRejectState === String(this.okAlreadyExistsExitCode))
         {
             return '0';
         }

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -266,7 +266,8 @@ export class LinuxVersionResolver
             {
                 const isPatchUpgrade = Number(this.versionResolver.getFeatureBandPatchVersion(existingGlobalInstallSDKVersion)) < Number(this.versionResolver.getFeatureBandPatchVersion(fullySpecifiedDotnetVersion));
 
-                if(Number(this.versionResolver.getMajorMinor(existingGlobalInstallSDKVersion)) > Number(this.versionResolver.getMajorMinor(fullySpecifiedDotnetVersion)))
+                if(Number(this.versionResolver.getMajorMinor(existingGlobalInstallSDKVersion)) > Number(this.versionResolver.getMajorMinor(fullySpecifiedDotnetVersion))
+                || Number(this.versionResolver.getFeatureBandFromVersion(existingGlobalInstallSDKVersion)) > Number(this.versionResolver.getFeatureBandFromVersion(fullySpecifiedDotnetVersion)))
                 {
                     // We shouldn't downgrade to a lower patch
                     const err = new DotnetCustomLinuxInstallExistsError(new Error(`An installation of ${fullySpecifiedDotnetVersion} was requested but ${existingGlobalInstallSDKVersion} is already available.`),

--- a/vscode-dotnet-runtime-library/src/Acquisition/RedHatDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RedHatDistroSDKProvider.ts
@@ -3,12 +3,22 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
+import { ICommandExecutor } from '../Utils/ICommandExecutor';
+import { IUtilityContext } from '../Utils/IUtilityContext';
 import { GenericDistroSDKProvider } from './GenericDistroSDKProvider';
+import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { LinuxInstallType } from './LinuxInstallType';
+import { DistroVersionPair } from './LinuxVersionResolver';
 /* tslint:disable:no-any */
 
 export class RedHatDistroSDKProvider extends GenericDistroSDKProvider
 {
+    constructor(distroVersion : DistroVersionPair, context : IAcquisitionWorkerContext, utilContext : IUtilityContext, executor : ICommandExecutor | null = null)
+    {
+        super(distroVersion, context, utilContext, executor);
+        this.resolvePathAsSymlink = false;
+    }
+
     protected myVersionDetails() : any
     {
         const distroVersions = this.distroJson[this.distroVersion.distro][this.distroVersionsKey];

--- a/vscode-dotnet-runtime-library/src/Acquisition/RedHatDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RedHatDistroSDKProvider.ts
@@ -16,7 +16,6 @@ export class RedHatDistroSDKProvider extends GenericDistroSDKProvider
     constructor(distroVersion : DistroVersionPair, context : IAcquisitionWorkerContext, utilContext : IUtilityContext, executor : ICommandExecutor | null = null)
     {
         super(distroVersion, context, utilContext, executor);
-        this.resolvePathAsSymlink = false;
     }
 
     protected myVersionDetails() : any
@@ -25,18 +24,5 @@ export class RedHatDistroSDKProvider extends GenericDistroSDKProvider
         const targetVersion = Math.floor(parseFloat(this.distroVersion.version[0])).toFixed(1);
         const versionData = distroVersions.filter((x: { [x: string]: string; }) => x[this.versionKey] === String(targetVersion));
         return versionData;
-    }
-
-    public async getInstalledGlobalDotnetPathIfExists(installType : LinuxInstallType) : Promise<string | null>
-    {
-        this.commandRunner.returnStatus = true;
-        const commandResult = await this.commandRunner.executeMultipleCommands(this.myDistroCommands(this.currentInstallPathCommandKey));
-        this.commandRunner.returnStatus = false;
-
-        if (commandResult[0] !== '0'){
-            return '';
-        }
-        const verboseCommandResult = await this.commandRunner.executeMultipleCommands(this.myDistroCommands(this.currentInstallPathCommandKey));
-        return verboseCommandResult[0];
     }
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -14,6 +14,7 @@ import { CommandExecutor } from '../Utils/CommandExecutor';
 import {
     DotnetConflictingGlobalWindowsInstallError,
     DotnetFileIntegrityCheckEvent,
+    DotnetInstallCancelledByUserError as DotnetInstallCancelledByUser,
     DotnetUnexpectedInstallerOSError,
     NetInstallerBeginExecutionEvent,
     NetInstallerEndExecutionEvent,
@@ -112,7 +113,7 @@ We cannot verify .NET is safe to download at this time. Please try again later.`
         else if(installerResult === '1602')
         {
             // Special code for when user cancels the install
-            const err = new DotnetInstallCancelledByUserError(new Error(
+            const err = new DotnetInstallCancelledByUser(new Error(
                 `The install of .NET was cancelled by the user. Aborting.`), getInstallKeyFromContext(this.acquisitionContext.acquisitionContext));
             this.acquisitionContext.eventStream.post(err);
             throw err.error;

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -109,6 +109,14 @@ We cannot verify .NET is safe to download at this time. Please try again later.`
         {
             return '0'; // These statuses are a success, we don't want to throw.
         }
+        else if(installerResult === '1602')
+        {
+            // Special code for when user cancels the install
+            const err = new DotnetInstallCancelledByUserError(new Error(
+                `The install of .NET was cancelled by the user. Aborting.`), getInstallKeyFromContext(this.acquisitionContext.acquisitionContext));
+            this.acquisitionContext.eventStream.post(err);
+            throw err.error;
+        }
         else
         {
             return installerResult;

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -15,6 +15,8 @@ import {
     DotnetConflictingGlobalWindowsInstallError,
     DotnetFileIntegrityCheckEvent,
     DotnetUnexpectedInstallerOSError,
+    NetInstallerBeginExecutionEvent,
+    NetInstallerEndExecutionEvent,
     OSXOpenNotAvailableError,
     SuppressedAcquisitionError
 } from '../EventStream/EventStreamEvents';
@@ -225,9 +227,11 @@ Please correct your PATH variable or make sure the 'open' utility is installed s
                 workingCommand = CommandExecutor.makeCommand(`open`, [`-W`, `${path.resolve(installerPath)}`]);
             }
 
+            this.acquisitionContext.eventStream.post(new NetInstallerBeginExecutionEvent(`The OS X .NET Installer has been launched.`));
             const commandResult = await this.commandRunner.execute(
                 workingCommand
             );
+            this.acquisitionContext.eventStream.post(new NetInstallerEndExecutionEvent(`The OS X .NET Installer has closed.`));
 
             this.commandRunner.returnStatus = false;
             return commandResult[0];
@@ -240,9 +244,13 @@ Please correct your PATH variable or make sure the 'open' utility is installed s
             {
                 commandOptions = [`/quiet`, `/install`, `/norestart`];
             }
+
+            this.acquisitionContext.eventStream.post(new NetInstallerBeginExecutionEvent(`The Windows .NET Installer has been launched.`));
             const commandResult = await this.commandRunner.execute(
                 CommandExecutor.makeCommand(command, commandOptions)
             );
+            this.acquisitionContext.eventStream.post(new NetInstallerEndExecutionEvent(`The Windows .NET Installer has closed.`));
+
             this.commandRunner.returnStatus = false;
             return commandResult[0];
         }

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -234,7 +234,7 @@ Please correct your PATH variable or make sure the 'open' utility is installed s
             this.acquisitionContext.eventStream.post(new NetInstallerEndExecutionEvent(`The OS X .NET Installer has closed.`));
 
             this.commandRunner.returnStatus = false;
-            return commandResult[0];
+            return commandResult;
         }
         else
         {
@@ -252,7 +252,7 @@ Please correct your PATH variable or make sure the 'open' utility is installed s
             this.acquisitionContext.eventStream.post(new NetInstallerEndExecutionEvent(`The Windows .NET Installer has closed.`));
 
             this.commandRunner.returnStatus = false;
-            return commandResult[0];
+            return commandResult;
         }
     }
 

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -521,6 +521,10 @@ export class CommandExecutionEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionEvent';
 }
 
+export class CommandExecutionUserAskDialogueEvent extends DotnetCustomMessageEvent {
+    public readonly eventName = 'CommandExecutionUserAskDialogueEvent';
+}
+
 export class CommandExecutionUserCompletedDialogueEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionUserCompletedDialogueEvent';
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -537,6 +537,10 @@ export class DotnetVersionParseEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetVersionParseEvent';
 }
 
+export class DotnetUpgradedEvent extends DotnetCustomMessageEvent {
+    public readonly eventName = 'DotnetUpgradedEvent';
+}
+
 export abstract class DotnetFileEvent extends DotnetAcquisitionMessage
 {
     constructor(public readonly eventMessage: string, public readonly time: string, public readonly file: string) { super(); }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -402,7 +402,7 @@ export class DotnetExistingPathResolutionCompleted extends DotnetAcquisitionSucc
 }
 
 export abstract class DotnetAcquisitionMessage extends IEvent {
-    public readonly type = EventType.DotnetAcquisitionMessage;
+    public type = EventType.DotnetAcquisitionMessage;
 
     public getProperties(): { [key: string]: string } | undefined {
         return undefined;
@@ -539,6 +539,11 @@ export class DotnetVersionParseEvent extends DotnetCustomMessageEvent {
 
 export class DotnetUpgradedEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetUpgradedEvent';
+    constructor(eventMsg : string)
+    {
+        super(eventMsg);
+        this.type = EventType.DotnetUpgradedEvent;
+    }
 }
 
 export class DotnetInstallLinuxChecks extends DotnetCustomMessageEvent {

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -559,6 +559,10 @@ export class CommandExecutionUnderSudoEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionUnderSudoEvent';
 }
 
+export class CommandExecutionUserRejectedPasswordRequest extends DotnetInstallExpectedAbort {
+    public readonly eventName = 'CommandExecutionUserRejectedPasswordRequest';
+}
+
 export class DotnetVersionParseEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetVersionParseEvent';
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -131,6 +131,28 @@ export abstract class DotnetNonAcquisitionError extends IEvent {
     }
 }
 
+export abstract class DotnetInstallExpectedAbort extends IEvent {
+    public readonly type = EventType.DotnetInstallExpectedAbort;
+    public isError = true;
+
+    /**
+     *
+     * @param error The error that triggered, so the call stack, etc. can be analyzed.
+     * @param installKey For acquisition errors, you MUST include this install key. For commands unrelated to acquiring or managing a specific dotnet version, you
+     * have the option to leave this parameter null. If it is NULL during acquisition the extension CANNOT properly manage what it has finished installing or not.
+     */
+    constructor(public readonly error: Error, public readonly installKey: string | null)
+    {
+        super();
+    }
+
+    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+        return {ErrorName : this.error.name,
+                ErrorMessage : this.error.message,
+                StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
+                InstallKey : this.installKey ?? 'null'};
+    }
+}
 
 export class SuppressedAcquisitionError extends IEvent {
     public readonly eventName = 'SuppressedAcquisitionError';
@@ -217,7 +239,7 @@ export class DotnetFeatureBandDoesNotExistError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetFeatureBandDoesNotExistError';
 }
 
-export class DotnetWSLSecurityError extends DotnetAcquisitionError {
+export class DotnetWSLSecurityError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetWSLSecurityError';
 }
 
@@ -247,8 +269,12 @@ export class DotnetAcquisitionScriptError extends DotnetAcquisitionVersionError 
     public readonly eventName = 'DotnetAcquisitionScriptError';
 }
 
-export class DotnetConflictingGlobalWindowsInstallError extends DotnetAcquisitionError {
+export class DotnetConflictingGlobalWindowsInstallError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetConflictingGlobalWindowsInstallError';
+}
+
+export class DotnetInstallCancelledByUserError extends DotnetInstallExpectedAbort {
+    public readonly eventName = 'DotnetInstallCancelledByUserError';
 }
 
 export class DotnetDebuggingMessage extends IEvent {
@@ -293,11 +319,11 @@ export class DotnetVersionResolutionError extends DotnetAcquisitionVersionError 
     public readonly eventName = 'DotnetVersionResolutionError';
 }
 
-export class DotnetConflictingLinuxInstallTypesError extends DotnetAcquisitionVersionError {
+export class DotnetConflictingLinuxInstallTypesError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetConflictingLinuxInstallTypesError';
 }
 
-export class DotnetCustomLinuxInstallExistsError extends DotnetAcquisitionVersionError {
+export class DotnetCustomLinuxInstallExistsError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetCustomLinuxInstallExistsError';
 }
 
@@ -338,7 +364,7 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
     }
 }
 
-export class DotnetAcquisitionDistroUnknownError extends DotnetAcquisitionError {
+export class DotnetAcquisitionDistroUnknownError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetAcquisitionDistroUnknownError';
 
     public getProperties(telemetry = false): { [key: string]: string } | undefined {

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -546,6 +546,15 @@ export class DotnetUpgradedEvent extends DotnetCustomMessageEvent {
     }
 }
 
+export class NetInstallerBeginExecutionEvent extends DotnetCustomMessageEvent {
+    public readonly eventName = 'NetInstallerBeginExecutionEvent';
+}
+
+export class NetInstallerEndExecutionEvent extends DotnetCustomMessageEvent {
+    public readonly eventName = 'NetInstallerEndExecutionEvent';
+}
+
+
 export class DotnetInstallLinuxChecks extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetInstallLinuxChecks';
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -541,6 +541,10 @@ export class DotnetUpgradedEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetUpgradedEvent';
 }
 
+export class DotnetInstallLinuxChecks extends DotnetCustomMessageEvent {
+    public readonly eventName = 'DotnetInstallLinuxChecks';
+}
+
 export abstract class DotnetFileEvent extends DotnetAcquisitionMessage
 {
     constructor(public readonly eventMessage: string, public readonly time: string, public readonly file: string) { super(); }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventType.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventType.ts
@@ -16,5 +16,6 @@ export enum EventType {
     DotnetAcquisitionInProgress,
     DotnetDebuggingMessage,
     DotnetTotalSuccessEvent,
+    DotnetUpgradedEvent,
     SuppressedAcquisitionError,
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventType.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventType.ts
@@ -18,4 +18,5 @@ export enum EventType {
     DotnetTotalSuccessEvent,
     DotnetUpgradedEvent,
     SuppressedAcquisitionError,
+    DotnetInstallExpectedAbort
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
@@ -12,6 +12,7 @@ import {
     DotnetAcquisitionVersionError,
     DotnetDebuggingMessage,
     DotnetExistingPathResolutionCompleted,
+    DotnetUpgradedEvent,
 } from './EventStreamEvents';
 import { EventType } from './EventType';
 import { IEvent } from './IEvent';
@@ -115,6 +116,10 @@ export class OutputChannelObserver implements IEventStreamObserver {
                 } else {
                     this.stopDownloadIndicator();
                 }
+                break;
+            case EventType.DotnetUpgradedEvent:
+                const upgradeMessage = event as DotnetUpgradedEvent;
+                this.outputChannel.appendLine(`${upgradeMessage.eventMessage}:`);
                 break;
             case EventType.DotnetDebuggingMessage:
                 const loggedMessage = event as DotnetDebuggingMessage;

--- a/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
@@ -9,7 +9,6 @@ import {
     DotnetAcquisitionError,
     DotnetAcquisitionInProgress,
     DotnetAcquisitionStarted,
-    DotnetAcquisitionVersionError,
     DotnetDebuggingMessage,
     DotnetExistingPathResolutionCompleted,
     DotnetInstallExpectedAbort,

--- a/vscode-dotnet-runtime-library/src/EventStream/StatusBarObserver.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/StatusBarObserver.ts
@@ -23,6 +23,7 @@ export class StatusBarObserver implements IEventStreamObserver {
                 this.setAndShowStatusBar('$(cloud-download) Downloading .NET...', this.showLogCommand, '', 'Downloading .NET...');
                 break;
             case EventType.DotnetAcquisitionCompleted:
+            case EventType.DotnetInstallExpectedAbort:
                 this.resetAndHideStatusBar();
                 break;
             case EventType.DotnetAcquisitionError:

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -89,6 +89,8 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
             let sanitizedCallerName = this.context?.acquisitionContext?.requestingExtensionId?.replace(/[^0-9a-z]/gi, ''); // Remove non-alphanumerics per OS requirements
             sanitizedCallerName = sanitizedCallerName?.substring(0, 69); // 70 Characters is the maximum limit we can use for the prompt.
             const options = { name: `${sanitizedCallerName ?? '.NET Install Tool'}` };
+
+            this.context?.eventStream.post(new CommandExecutionUserAskDialogueEvent(`Prompting user for command ${fullCommandString} under sudo.`));
             exec((fullCommandString), options, (error?: any, stdout?: any, stderr?: any) =>
             {
                 let commandResultString = '';

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -121,7 +121,7 @@ ${stderr}`));
 The user refused the password prompt.`),
                                 getInstallKeyFromContext(this.context?.acquisitionContext!));
                             this.context?.eventStream.post(err);
-                            throw err.error;
+                            reject(err.error);
                         }
                         reject(error);
                     }

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -19,6 +19,7 @@ import {
     CommandExecutionUnderSudoEvent,
     CommandExecutionUserAskDialogueEvent,
     CommandExecutionUserCompletedDialogueEvent,
+    CommandExecutionUserRejectedPasswordRequest,
     DotnetAlternativeCommandFoundEvent,
     DotnetCommandNotFoundEvent,
     DotnetWSLSecurityError
@@ -114,6 +115,14 @@ ${stderr}`));
                     this.context?.eventStream.post(new CommandExecutionUserCompletedDialogueEvent(`The command ${fullCommandString} failed to run under sudo.`));
                     if(terminalFailure)
                     {
+                        if(error.code === 126)
+                        {
+                            const err = new CommandExecutionUserRejectedPasswordRequest(new Error(`Cancelling .NET Install, as command ${fullCommandString} failed.
+The user refused the password prompt.`),
+                                getInstallKeyFromContext(this.context?.acquisitionContext!));
+                            this.context?.eventStream.post(err);
+                            throw err.error;
+                        }
                         reject(error);
                     }
                     else

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -17,6 +17,7 @@ import {
     CommandExecutionStdError,
     CommandExecutionStdOut,
     CommandExecutionUnderSudoEvent,
+    CommandExecutionUserAskDialogueEvent,
     CommandExecutionUserCompletedDialogueEvent,
     DotnetAlternativeCommandFoundEvent,
     DotnetCommandNotFoundEvent,

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -86,7 +86,9 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
         return new Promise<string>((resolve, reject) =>
         {
             // The '.' character is not allowed for sudo-prompt so we use 'NET'
-            const options = { name: `${this.context?.acquisitionContext?.requestingExtensionId} On behalf of NET Install Tool` };
+            let sanitizedCallerName = this.context?.acquisitionContext?.requestingExtensionId?.replace(/[^0-9a-z]/gi, ''); // Remove non-alphanumerics per OS requirements
+            sanitizedCallerName = sanitizedCallerName?.substring(0, 69); // 70 Characters is the maximum limit we can use for the prompt.
+            const options = { name: `${sanitizedCallerName ?? '.NET Install Tool'}` };
             exec((fullCommandString), options, (error?: any, stdout?: any, stderr?: any) =>
             {
                 let commandResultString = '';

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -104,7 +104,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             await provider.getInstalledGlobalDotnetPathIfExists(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'which dotnet');
+            assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/bin/dotnet');
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -104,7 +104,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             await provider.getInstalledGlobalDotnetPathIfExists(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/bin/dotnet');
+            assert.equal(mockExecutor.attemptedCommand, 'which dotnet');
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
@@ -104,7 +104,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             await provider.getInstalledGlobalDotnetPathIfExists(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/bin/dotnet');
+            assert.equal(mockExecutor.attemptedCommand, 'which dotnet');
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
@@ -53,7 +53,7 @@ suite('Red Hat For Linux Distro Logic Unit Tests', () =>
         if(shouldRun)
         {
             const distroFeedDir = await provider.getExpectedDotnetDistroFeedInstallationDirectory();
-            assert.equal(distroFeedDir, '/usr/lib64/dotnet/dotnet');
+            assert.equal(distroFeedDir, '/usr/lib64/dotnet');
         }
     }).timeout(standardTimeoutTime);
 
@@ -104,7 +104,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             await provider.getInstalledGlobalDotnetPathIfExists(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'which dotnet');
+            assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/bin/dotnet');
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-sdk-extension/package-lock.json
+++ b/vscode-dotnet-sdk-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-dotnet-sdk",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-dotnet-sdk",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/chai": "4.2.22",

--- a/vscode-dotnet-sdk-extension/package.json
+++ b/vscode-dotnet-sdk-extension/package.json
@@ -13,7 +13,7 @@
 	"description": "This extension installs and manages different versions of the .NET SDK.",
 	"appInsightsKey": "02dc18e0-7494-43b2-b2a3-18ada5fcb522",
 	"icon": "images/dotnetIcon.png",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"publisher": "ms-dotnettools",
 	"engines": {
 		"vscode": "^1.74.0"


### PR DESCRIPTION
Contains the final changes and version bumps for 2.0.1.

Besides the READ.ME and version bump, this PR includes a few changes that are smaller:
- Fixes to the update logic on linux, where we update instead of installing all over again. This did not used to work.
- Improves logging so we can tell in logs where people are hitting failures, e.g. if they declined the password prompt, or if they cancelled the installer we now have a specific message for that
- Fix a bug that allowed you to downgrade the SDK 
- Added a cancellation message and removed the failure message for when we decide the SDK cant be installed or the user cancels the operation. Made the status bar not flash red when this happens, which it used to before.
- Resolves symlinks on RHEL because it also can use symlinks for the dotnet path