### PR TITLE
Reduce Linux Prompt to Single Ask

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
         "HKCU",
         "HKEY",
         "norestart",
+        "proccom",
         "programfiles",
         "REGHEXVALUE",
         "REGTYPE"

--- a/mock-webpack.ps1
+++ b/mock-webpack.ps1
@@ -1,3 +1,4 @@
 # The library doesn't get webpacked, but it needs the copy of items that would normally be webpacked
 # ... into the SDK or Runtime Extension for it to run in local dev scenarios.
 Copy-Item ".\vscode-dotnet-runtime-library\distro-data\" -Destination ".\vscode-dotnet-runtime-library\dist\Acquisition\" -Recurse -Force
+Copy-Item ".\vscode-dotnet-runtime-library\install scripts\" -Destination ".\vscode-dotnet-runtime-library\dist\utils\" -Recurse -Force

--- a/mock-webpack.sh
+++ b/mock-webpack.sh
@@ -2,3 +2,4 @@ echo ""
 echo "----------- Copying Library Webpacked Dependencies -----------"
 echo "" # See the build.ps1 for more details on why we do this
 cp -r ./vscode-dotnet-runtime-library/distro-data ./vscode-dotnet-runtime-library/dist/Acquisition
+cp -r ./vscode-dotnet-runtime-library/install-scripts ./vscode-dotnet-runtime-library/dist/utils

--- a/mock-webpack.sh
+++ b/mock-webpack.sh
@@ -2,4 +2,4 @@ echo ""
 echo "----------- Copying Library Webpacked Dependencies -----------"
 echo "" # See the build.ps1 for more details on why we do this
 cp -r ./vscode-dotnet-runtime-library/distro-data ./vscode-dotnet-runtime-library/dist/Acquisition
-cp -r ./vscode-dotnet-runtime-library/install-scripts ./vscode-dotnet-runtime-library/dist/utils
+cp -r "./vscode-dotnet-runtime-library/install scripts" ./vscode-dotnet-runtime-library/dist/utils

--- a/mock-webpack.sh
+++ b/mock-webpack.sh
@@ -2,4 +2,4 @@ echo ""
 echo "----------- Copying Library Webpacked Dependencies -----------"
 echo "" # See the build.ps1 for more details on why we do this
 cp -r ./vscode-dotnet-runtime-library/distro-data ./vscode-dotnet-runtime-library/dist/Acquisition
-cp -r "./vscode-dotnet-runtime-library/install scripts" ./vscode-dotnet-runtime-library/dist/utils
+cp -r "./vscode-dotnet-runtime-library/install scripts" ./vscode-dotnet-runtime-library/dist/Utils

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
+				"@types/chai-as-promised": "^7.1.8",
 				"axios": "^1.3.4",
 				"axios-cache-interceptor": "^1.0.1",
 				"axios-retry": "^3.4.0",
@@ -24,6 +25,7 @@
 				"open": "^8.4.0",
 				"public-ip": "5.0.0",
 				"rimraf": "3.0.2",
+				"safe-array-concat": "^1.1.0",
 				"safe-regex-test": "^1.0.0",
 				"shelljs": "^0.8.5",
 				"ts-loader": "^9.2.6",
@@ -31,6 +33,7 @@
 				"typescript": "4.4.4",
 				"vscode-dotnet-runtime-library": "file:../vscode-dotnet-runtime-library",
 				"vscode-test": "^1.6.1",
+				"webpack-permissions-plugin": "^1.0.9",
 				"yarn": "^1.22.19"
 			},
 			"devDependencies": {
@@ -377,8 +380,16 @@
 			"version": "4.3.5",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai/-/chai-4.3.5.tgz",
 			"integrity": "sha1-rmm8uxvrtoxKwLEenY7QRSazVis=",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/chai-as-promised": {
+			"version": "7.1.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz",
+			"integrity": "sha1-8rPYLVPFlia11rvAh2Z8y0tnf+k=",
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "*"
+			}
 		},
 		"node_modules/@types/eslint": {
 			"version": "8.4.5",
@@ -1000,13 +1011,14 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
+			"version": "1.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind/-/call-bind-1.0.5.tgz",
+			"integrity": "sha1-b6K3hFzg6km/TYue9kcnosLi5RM=",
 			"license": "MIT",
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.1",
+				"set-function-length": "^1.1.1"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -1380,6 +1392,20 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/define-data-property": {
+			"version": "1.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-data-property/-/define-data-property-1.1.1.tgz",
+			"integrity": "sha1-w1980KsJiDSA0SrFyyE3FVh4ALM=",
+			"license": "MIT",
+			"dependencies": {
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/define-lazy-prop": {
 			"version": "2.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -1505,6 +1531,12 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/err-code": {
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/err-code/-/err-code-1.1.2.tgz",
+			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+			"license": "MIT"
 		},
 		"node_modules/es-module-lexer": {
 			"version": "1.3.0",
@@ -1635,6 +1667,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+			"license": "MIT"
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1698,6 +1736,58 @@
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/file-js": {
+			"version": "0.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/file-js/-/file-js-0.3.0.tgz",
+			"integrity": "sha1-+rRr94I0bJKUSZ8fDSrQfYOPJdE=",
+			"license": "MIT",
+			"dependencies": {
+				"bluebird": "^3.4.7",
+				"minimatch": "^3.0.3",
+				"proper-lockfile": "^1.2.0"
+			}
+		},
+		"node_modules/filehound": {
+			"version": "1.17.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/filehound/-/filehound-1.17.6.tgz",
+			"integrity": "sha1-1dh71pQxbqZzvQZCt3a1CNP5ih0=",
+			"license": "MIT",
+			"dependencies": {
+				"bluebird": "^3.7.2",
+				"file-js": "0.3.0",
+				"lodash": "^4.17.21",
+				"minimatch": "^5.0.0",
+				"moment": "^2.29.1",
+				"unit-compare": "^1.0.1"
+			}
+		},
+		"node_modules/filehound/node_modules/bluebird": {
+			"version": "3.7.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bluebird/-/bluebird-3.7.2.tgz",
+			"integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
+			"license": "MIT"
+		},
+		"node_modules/filehound/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/filehound/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha1-HPy4z1Ui6mmVLNKvla4JR38SKpY=",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/fill-range": {
@@ -1827,10 +1917,13 @@
 			}
 		},
 		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
-			"license": "MIT"
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
@@ -1851,14 +1944,15 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.1.3",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-			"integrity": "sha1-BjyEMprZPoOJPH9PJD72P/o1E4U=",
+			"version": "1.2.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+			"integrity": "sha1-KBt2IpcRI+HvSzyQ/XU5MG2pPzs=",
 			"license": "MIT",
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.3"
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -1939,6 +2033,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha1-Kf923mnax0ibfAkYpXiOVkd8Myw=",
+			"license": "MIT",
+			"dependencies": {
+				"get-intrinsic": "^1.1.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/got": {
 			"version": "11.8.5",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz",
@@ -2000,6 +2106,30 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+			"integrity": "sha1-UrowtsXsh/2J+ldLwcORJcb2U0A=",
+			"license": "MIT",
+			"dependencies": {
+				"get-intrinsic": "^1.2.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-proto": {
+			"version": "1.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-proto/-/has-proto-1.0.1.tgz",
+			"integrity": "sha1-GIXBMFU4lYr/Rp/vN5N8InlUCOA=",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/has-symbols": {
 			"version": "1.0.3",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz",
@@ -2035,6 +2165,18 @@
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hasown/-/hasown-2.0.0.tgz",
+			"integrity": "sha1-9MUT1FSle3x+FlB3jeImsRcAVGw=",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/he": {
@@ -2705,6 +2847,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
+			"license": "MIT"
+		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -2947,6 +3095,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/moment": {
+			"version": "2.30.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/moment/-/moment-2.30.1.tgz",
+			"integrity": "sha1-+MkcB7enhuMMWZJt9TC06slpdK4=",
+			"license": "MIT",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/ms": {
@@ -3318,6 +3475,18 @@
 			"integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
 			"license": "MIT"
 		},
+		"node_modules/proper-lockfile": {
+			"version": "1.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
+			"integrity": "sha1-zv9d2J0+XxD7deHo52vHWAGlnDQ=",
+			"license": "MIT",
+			"dependencies": {
+				"err-code": "^1.0.0",
+				"extend": "^3.0.0",
+				"graceful-fs": "^4.1.2",
+				"retry": "^0.10.0"
+			}
+		},
 		"node_modules/proxy-from-env": {
 			"version": "1.1.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3677,6 +3846,15 @@
 				"lowercase-keys": "^2.0.0"
 			}
 		},
+		"node_modules/retry": {
+			"version": "0.10.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/retry/-/retry-0.10.1.tgz",
+			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/reusify/-/reusify-1.0.4.tgz",
@@ -3726,6 +3904,30 @@
 			"dependencies": {
 				"queue-microtask": "^1.2.2"
 			}
+		},
+		"node_modules/safe-array-concat": {
+			"version": "1.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+			"integrity": "sha1-jQyunLgG1tHAbgirE9hHKT6+BpI=",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"get-intrinsic": "^1.2.2",
+				"has-symbols": "^1.0.3",
+				"isarray": "^2.0.5"
+			},
+			"engines": {
+				"node": ">=0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-array-concat/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
+			"license": "MIT"
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
@@ -3795,6 +3997,22 @@
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"randombytes": "^2.1.0"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/set-function-length/-/set-function-length-1.2.0.tgz",
+			"integrity": "sha1-L4HcbBbHBZvaWrfILBHwOlFe2OE=",
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.2",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/setimmediate": {
@@ -4291,6 +4509,15 @@
 				"node": ">=4.2.0"
 			}
 		},
+		"node_modules/unit-compare": {
+			"version": "1.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unit-compare/-/unit-compare-1.0.1.tgz",
+			"integrity": "sha1-DHRZ8OW/U2N+qHPKPO4Y3i7so4Y=",
+			"license": "ISC",
+			"dependencies": {
+				"moment": "^2.14.1"
+			}
+		},
 		"node_modules/unzipper": {
 			"version": "0.10.11",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unzipper/-/unzipper-0.10.11.tgz",
@@ -4582,6 +4809,15 @@
 			},
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/webpack-permissions-plugin": {
+			"version": "1.0.9",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-permissions-plugin/-/webpack-permissions-plugin-1.0.9.tgz",
+			"integrity": "sha1-gK5aCe0ZkdvbL5/kYYuNVxlhbh4=",
+			"license": "MIT",
+			"dependencies": {
+				"filehound": "^1.17.6"
 			}
 		},
 		"node_modules/webpack-sources": {
@@ -4923,8 +5159,15 @@
 		"@types/chai": {
 			"version": "4.3.5",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai/-/chai-4.3.5.tgz",
-			"integrity": "sha1-rmm8uxvrtoxKwLEenY7QRSazVis=",
-			"dev": true
+			"integrity": "sha1-rmm8uxvrtoxKwLEenY7QRSazVis="
+		},
+		"@types/chai-as-promised": {
+			"version": "7.1.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz",
+			"integrity": "sha1-8rPYLVPFlia11rvAh2Z8y0tnf+k=",
+			"requires": {
+				"@types/chai": "*"
+			}
 		},
 		"@types/eslint": {
 			"version": "8.4.5",
@@ -5393,12 +5636,13 @@
 			}
 		},
 		"call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
+			"version": "1.0.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind/-/call-bind-1.0.5.tgz",
+			"integrity": "sha1-b6K3hFzg6km/TYue9kcnosLi5RM=",
 			"requires": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.1",
+				"set-function-length": "^1.1.1"
 			}
 		},
 		"camelcase": {
@@ -5641,6 +5885,16 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
 			"integrity": "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc="
 		},
+		"define-data-property": {
+			"version": "1.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-data-property/-/define-data-property-1.1.1.tgz",
+			"integrity": "sha1-w1980KsJiDSA0SrFyyE3FVh4ALM=",
+			"requires": {
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			}
+		},
 		"define-lazy-prop": {
 			"version": "2.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -5727,6 +5981,11 @@
 			"integrity": "sha1-Bjd+Pl9NN5/qesWS1a2JJ+DE1HU=",
 			"dev": true
 		},
+		"err-code": {
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/err-code/-/err-code-1.1.2.tgz",
+			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+		},
 		"es-module-lexer": {
 			"version": "1.3.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
@@ -5806,6 +6065,11 @@
 				}
 			}
 		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5858,6 +6122,52 @@
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"file-js": {
+			"version": "0.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/file-js/-/file-js-0.3.0.tgz",
+			"integrity": "sha1-+rRr94I0bJKUSZ8fDSrQfYOPJdE=",
+			"requires": {
+				"bluebird": "^3.4.7",
+				"minimatch": "^3.0.3",
+				"proper-lockfile": "^1.2.0"
+			}
+		},
+		"filehound": {
+			"version": "1.17.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/filehound/-/filehound-1.17.6.tgz",
+			"integrity": "sha1-1dh71pQxbqZzvQZCt3a1CNP5ih0=",
+			"requires": {
+				"bluebird": "^3.7.2",
+				"file-js": "0.3.0",
+				"lodash": "^4.17.21",
+				"minimatch": "^5.0.0",
+				"moment": "^2.29.1",
+				"unit-compare": "^1.0.1"
+			},
+			"dependencies": {
+				"bluebird": {
+					"version": "3.7.2",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bluebird/-/bluebird-3.7.2.tgz",
+					"integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28="
+				},
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "5.1.6",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-5.1.6.tgz",
+					"integrity": "sha1-HPy4z1Ui6mmVLNKvla4JR38SKpY=",
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				}
 			}
 		},
 		"fill-range": {
@@ -5935,9 +6245,9 @@
 			}
 		},
 		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw="
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -5950,13 +6260,14 @@
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
 		},
 		"get-intrinsic": {
-			"version": "1.1.3",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-			"integrity": "sha1-BjyEMprZPoOJPH9PJD72P/o1E4U=",
+			"version": "1.2.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+			"integrity": "sha1-KBt2IpcRI+HvSzyQ/XU5MG2pPzs=",
 			"requires": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.3"
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
 			}
 		},
 		"get-stream": {
@@ -6008,6 +6319,14 @@
 				"slash": "^3.0.0"
 			}
 		},
+		"gopd": {
+			"version": "1.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha1-Kf923mnax0ibfAkYpXiOVkd8Myw=",
+			"requires": {
+				"get-intrinsic": "^1.1.3"
+			}
+		},
 		"got": {
 			"version": "11.8.5",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz",
@@ -6049,6 +6368,19 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
 		},
+		"has-property-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+			"integrity": "sha1-UrowtsXsh/2J+ldLwcORJcb2U0A=",
+			"requires": {
+				"get-intrinsic": "^1.2.2"
+			}
+		},
+		"has-proto": {
+			"version": "1.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-proto/-/has-proto-1.0.1.tgz",
+			"integrity": "sha1-GIXBMFU4lYr/Rp/vN5N8InlUCOA="
+		},
 		"has-symbols": {
 			"version": "1.0.3",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz",
@@ -6069,6 +6401,14 @@
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"hasown": {
+			"version": "2.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hasown/-/hasown-2.0.0.tgz",
+			"integrity": "sha1-9MUT1FSle3x+FlB3jeImsRcAVGw=",
+			"requires": {
+				"function-bind": "^1.1.2"
 			}
 		},
 		"he": {
@@ -6512,6 +6852,11 @@
 				"p-locate": "^5.0.0"
 			}
 		},
+		"lodash": {
+			"version": "4.17.21",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
+		},
 		"log-symbols": {
 			"version": "4.1.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -6677,6 +7022,11 @@
 					}
 				}
 			}
+		},
+		"moment": {
+			"version": "2.30.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/moment/-/moment-2.30.1.tgz",
+			"integrity": "sha1-+MkcB7enhuMMWZJt9TC06slpdK4="
 		},
 		"ms": {
 			"version": "2.1.3",
@@ -6907,6 +7257,17 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
 		},
+		"proper-lockfile": {
+			"version": "1.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
+			"integrity": "sha1-zv9d2J0+XxD7deHo52vHWAGlnDQ=",
+			"requires": {
+				"err-code": "^1.0.0",
+				"extend": "^3.0.0",
+				"graceful-fs": "^4.1.2",
+				"retry": "^0.10.0"
+			}
+		},
 		"proxy-from-env": {
 			"version": "1.1.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -7134,6 +7495,11 @@
 				"lowercase-keys": "^2.0.0"
 			}
 		},
+		"retry": {
+			"version": "0.10.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/retry/-/retry-0.10.1.tgz",
+			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+		},
 		"reusify": {
 			"version": "1.0.4",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/reusify/-/reusify-1.0.4.tgz",
@@ -7155,6 +7521,24 @@
 			"dev": true,
 			"requires": {
 				"queue-microtask": "^1.2.2"
+			}
+		},
+		"safe-array-concat": {
+			"version": "1.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+			"integrity": "sha1-jQyunLgG1tHAbgirE9hHKT6+BpI=",
+			"requires": {
+				"call-bind": "^1.0.5",
+				"get-intrinsic": "^1.2.2",
+				"has-symbols": "^1.0.3",
+				"isarray": "^2.0.5"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "2.0.5",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isarray/-/isarray-2.0.5.tgz",
+					"integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM="
+				}
 			}
 		},
 		"safe-buffer": {
@@ -7193,6 +7577,18 @@
 			"integrity": "sha1-765diPRdeSQUHai1w6en5mP+/rg=",
 			"requires": {
 				"randombytes": "^2.1.0"
+			}
+		},
+		"set-function-length": {
+			"version": "1.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/set-function-length/-/set-function-length-1.2.0.tgz",
+			"integrity": "sha1-L4HcbBbHBZvaWrfILBHwOlFe2OE=",
+			"requires": {
+				"define-data-property": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.2",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.1"
 			}
 		},
 		"setimmediate": {
@@ -7515,6 +7911,14 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-4.4.4.tgz",
 			"integrity": "sha1-LNAaGh8WBwTTEB/VpY/w+fy4Aww="
 		},
+		"unit-compare": {
+			"version": "1.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unit-compare/-/unit-compare-1.0.1.tgz",
+			"integrity": "sha1-DHRZ8OW/U2N+qHPKPO4Y3i7so4Y=",
+			"requires": {
+				"moment": "^2.14.1"
+			}
+		},
 		"unzipper": {
 			"version": "0.10.11",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unzipper/-/unzipper-0.10.11.tgz",
@@ -7741,6 +8145,14 @@
 			"requires": {
 				"clone-deep": "^4.0.1",
 				"wildcard": "^2.0.0"
+			}
+		},
+		"webpack-permissions-plugin": {
+			"version": "1.0.9",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-permissions-plugin/-/webpack-permissions-plugin-1.0.9.tgz",
+			"integrity": "sha1-gK5aCe0ZkdvbL5/kYYuNVxlhbh4=",
+			"requires": {
+				"filehound": "^1.17.6"
 			}
 		},
 		"webpack-sources": {

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -68,7 +68,11 @@
 				"dotnetAcquisitionExtension.existingDotnetPath": {
 					"type": "array",
 					"description": "File Path to an existing installation of .NET. Used for both the .NET SDK and .NET Runtime.",
-					"examples": ["C:\\Program Files\\dotnet\\dotnet.exe", "/usr/local/share/dotnet/dotnet", "/usr/lib/dotnet/dotnet"]
+					"examples": [
+						"C:\\Program Files\\dotnet\\dotnet.exe",
+						"/usr/local/share/dotnet/dotnet",
+						"/usr/lib/dotnet/dotnet"
+					]
 				},
 				"dotnetAcquisitionExtension.proxyUrl": {
 					"type": "string",
@@ -88,6 +92,7 @@
 		"webpack": "webpack --mode development"
 	},
 	"dependencies": {
+		"@types/chai-as-promised": "^7.1.8",
 		"axios": "^1.3.4",
 		"axios-cache-interceptor": "^1.0.1",
 		"axios-retry": "^3.4.0",
@@ -103,6 +108,7 @@
 		"open": "^8.4.0",
 		"public-ip": "5.0.0",
 		"rimraf": "3.0.2",
+		"safe-array-concat": "^1.1.0",
 		"safe-regex-test": "^1.0.0",
 		"shelljs": "^0.8.5",
 		"ts-loader": "^9.2.6",
@@ -110,6 +116,7 @@
 		"typescript": "4.4.4",
 		"vscode-dotnet-runtime-library": "file:../vscode-dotnet-runtime-library",
 		"vscode-test": "^1.6.1",
+		"webpack-permissions-plugin": "^1.0.9",
 		"yarn": "^1.22.19"
 	},
 	"devDependencies": {

--- a/vscode-dotnet-runtime-extension/webpack.config.js
+++ b/vscode-dotnet-runtime-extension/webpack.config.js
@@ -4,6 +4,8 @@
 
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
+const { exec } = require('node:child_process');
+const PermissionsOutputPlugin = require('webpack-permissions-plugin');
 
 /**@type {import('webpack').Configuration}*/
 const config = {
@@ -50,6 +52,20 @@ const config = {
       { from: path.resolve(__dirname, '../images'), to: path.resolve(__dirname, 'images') },
       { from: path.resolve(__dirname, '../LICENSE.txt'), to: path.resolve(__dirname, 'LICENSE.txt') }
   ]}),
+  new PermissionsOutputPlugin({
+    buildFolders: [
+    ],
+    buildFiles: [
+      {
+        path: path.resolve(__dirname, 'dist', 'distro-data', 'distro-support.json'),
+        fileMode: '544'
+      },
+      {
+        path: path.resolve(__dirname, 'dist', 'install scripts', 'interprocess-communicator.sh'),
+        fileMode: '500'
+      }
+    ]
+  })
   ]
 };
 module.exports = config;

--- a/vscode-dotnet-runtime-extension/yarn.lock
+++ b/vscode-dotnet-runtime-extension/yarn.lock
@@ -152,7 +152,14 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/chai@^4.3.5":
+"@types/chai-as-promised@^7.1.8":
+  "integrity" "sha1-8rPYLVPFlia11rvAh2Z8y0tnf+k="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz"
+  "version" "7.1.8"
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*", "@types/chai@^4.3.5":
   "integrity" "sha1-rmm8uxvrtoxKwLEenY7QRSazVis="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/chai/-/chai-4.3.5.tgz"
   "version" "4.3.5"
@@ -546,10 +553,15 @@
     "buffers" "~0.1.1"
     "chainsaw" "~0.1.0"
 
-"bluebird@~3.4.1":
+"bluebird@^3.4.7", "bluebird@~3.4.1":
   "integrity" "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bluebird/-/bluebird-3.4.7.tgz"
   "version" "3.4.7"
+
+"bluebird@^3.7.2":
+  "integrity" "sha1-nyKcFb4nJFT/qXOs4NvueaGww28="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bluebird/-/bluebird-3.7.2.tgz"
+  "version" "3.7.2"
 
 "brace-expansion@^1.1.7":
   "integrity" "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0="
@@ -558,6 +570,13 @@
   dependencies:
     "balanced-match" "^1.0.0"
     "concat-map" "0.0.1"
+
+"brace-expansion@^2.0.1":
+  "integrity" "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz"
+  "version" "2.0.1"
+  dependencies:
+    "balanced-match" "^1.0.0"
 
 "braces@^3.0.2", "braces@~3.0.2":
   "integrity" "sha1-NFThpGLujVmeI23zNs2epPiv4Qc="
@@ -655,13 +674,14 @@
     "normalize-url" "^6.0.1"
     "responselike" "^2.0.0"
 
-"call-bind@^1.0.2":
-  "integrity" "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind/-/call-bind-1.0.2.tgz"
-  "version" "1.0.2"
+"call-bind@^1.0.2", "call-bind@^1.0.5":
+  "integrity" "sha1-b6K3hFzg6km/TYue9kcnosLi5RM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind/-/call-bind-1.0.5.tgz"
+  "version" "1.0.5"
   dependencies:
-    "function-bind" "^1.1.1"
-    "get-intrinsic" "^1.0.2"
+    "function-bind" "^1.1.2"
+    "get-intrinsic" "^1.2.1"
+    "set-function-length" "^1.1.1"
 
 "camelcase@^6.0.0":
   "integrity" "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo="
@@ -906,6 +926,15 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-2.0.1.tgz"
   "version" "2.0.1"
 
+"define-data-property@^1.1.1":
+  "integrity" "sha1-w1980KsJiDSA0SrFyyE3FVh4ALM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-data-property/-/define-data-property-1.1.1.tgz"
+  "version" "1.1.1"
+  dependencies:
+    "get-intrinsic" "^1.2.1"
+    "gopd" "^1.0.1"
+    "has-property-descriptors" "^1.0.0"
+
 "define-lazy-prop@^2.0.0":
   "integrity" "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz"
@@ -994,6 +1023,11 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/envinfo/-/envinfo-7.8.1.tgz"
   "version" "7.8.1"
 
+"err-code@^1.0.0":
+  "integrity" "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/err-code/-/err-code-1.1.2.tgz"
+  "version" "1.1.2"
+
 "es-module-lexer@^1.2.1":
   "integrity" "sha1-a+nJ4LRUOmDNFm/2+LTp2uCwwW8="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-module-lexer/-/es-module-lexer-1.3.0.tgz"
@@ -1064,6 +1098,11 @@
     "signal-exit" "^3.0.3"
     "strip-final-newline" "^2.0.0"
 
+"extend@^3.0.0":
+  "integrity" "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/extend/-/extend-3.0.2.tgz"
+  "version" "3.0.2"
+
 "fast-deep-equal@^3.1.1":
   "integrity" "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
@@ -1101,6 +1140,27 @@
   "version" "1.13.0"
   dependencies:
     "reusify" "^1.0.4"
+
+"file-js@0.3.0":
+  "integrity" "sha1-+rRr94I0bJKUSZ8fDSrQfYOPJdE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/file-js/-/file-js-0.3.0.tgz"
+  "version" "0.3.0"
+  dependencies:
+    "bluebird" "^3.4.7"
+    "minimatch" "^3.0.3"
+    "proper-lockfile" "^1.2.0"
+
+"filehound@^1.17.6":
+  "integrity" "sha1-1dh71pQxbqZzvQZCt3a1CNP5ih0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/filehound/-/filehound-1.17.6.tgz"
+  "version" "1.17.6"
+  dependencies:
+    "bluebird" "^3.7.2"
+    "file-js" "0.3.0"
+    "lodash" "^4.17.21"
+    "minimatch" "^5.0.0"
+    "moment" "^2.29.1"
+    "unit-compare" "^1.0.1"
 
 "fill-range@^7.0.1":
   "integrity" "sha1-GRmmp8df44ssfHflGYU12prN2kA="
@@ -1164,10 +1224,10 @@
     "mkdirp" ">=0.5 0"
     "rimraf" "2"
 
-"function-bind@^1.1.1":
-  "integrity" "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz"
-  "version" "1.1.1"
+"function-bind@^1.1.1", "function-bind@^1.1.2":
+  "integrity" "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.2.tgz"
+  "version" "1.1.2"
 
 "get-caller-file@^2.0.5":
   "integrity" "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
@@ -1179,14 +1239,15 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-func-name/-/get-func-name-2.0.0.tgz"
   "version" "2.0.0"
 
-"get-intrinsic@^1.0.2", "get-intrinsic@^1.1.3":
-  "integrity" "sha1-BjyEMprZPoOJPH9PJD72P/o1E4U="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.1.3.tgz"
-  "version" "1.1.3"
+"get-intrinsic@^1.1.3", "get-intrinsic@^1.2.1", "get-intrinsic@^1.2.2":
+  "integrity" "sha1-KBt2IpcRI+HvSzyQ/XU5MG2pPzs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.2.2.tgz"
+  "version" "1.2.2"
   dependencies:
-    "function-bind" "^1.1.1"
-    "has" "^1.0.3"
+    "function-bind" "^1.1.2"
+    "has-proto" "^1.0.1"
     "has-symbols" "^1.0.3"
+    "hasown" "^2.0.0"
 
 "get-stream@^4.1.0":
   "integrity" "sha1-wbJVV189wh1Zv8ec09K0axw6VLU="
@@ -1274,6 +1335,13 @@
     "merge2" "^1.4.1"
     "slash" "^3.0.0"
 
+"gopd@^1.0.1":
+  "integrity" "sha1-Kf923mnax0ibfAkYpXiOVkd8Myw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/gopd/-/gopd-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "get-intrinsic" "^1.1.3"
+
 "got@^11.8.0", "got@11.8.5":
   "integrity" "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz"
@@ -1345,6 +1413,18 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz"
   "version" "4.0.0"
 
+"has-property-descriptors@^1.0.0", "has-property-descriptors@^1.0.1":
+  "integrity" "sha1-UrowtsXsh/2J+ldLwcORJcb2U0A="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "get-intrinsic" "^1.2.2"
+
+"has-proto@^1.0.1":
+  "integrity" "sha1-GIXBMFU4lYr/Rp/vN5N8InlUCOA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-proto/-/has-proto-1.0.1.tgz"
+  "version" "1.0.1"
+
 "has-symbols@^1.0.2", "has-symbols@^1.0.3":
   "integrity" "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz"
@@ -1371,6 +1451,13 @@
   dependencies:
     "inherits" "^2.0.3"
     "minimalistic-assert" "^1.0.1"
+
+"hasown@^2.0.0":
+  "integrity" "sha1-9MUT1FSle3x+FlB3jeImsRcAVGw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hasown/-/hasown-2.0.0.tgz"
+  "version" "2.0.0"
+  dependencies:
+    "function-bind" "^1.1.2"
 
 "he@1.2.0":
   "integrity" "sha1-hK5l+n6vsWX922FWauFLrwVmTw8="
@@ -1583,6 +1670,11 @@
   dependencies:
     "is-docker" "^2.0.0"
 
+"isarray@^2.0.5":
+  "integrity" "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isarray/-/isarray-2.0.5.tgz"
+  "version" "2.0.5"
+
 "isarray@~1.0.0":
   "integrity" "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isarray/-/isarray-1.0.0.tgz"
@@ -1690,6 +1782,11 @@
   dependencies:
     "p-locate" "^5.0.0"
 
+"lodash@^4.17.21":
+  "integrity" "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash/-/lodash-4.17.21.tgz"
+  "version" "4.17.21"
+
 "log-symbols@4.1.0":
   "integrity" "sha1-P727lbRoOsn8eFER55LlWNSr1QM="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz"
@@ -1785,12 +1882,19 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
   "version" "1.0.1"
 
-"minimatch@^3.0.4", "minimatch@^3.1.1":
+"minimatch@^3.0.3", "minimatch@^3.0.4", "minimatch@^3.1.1":
   "integrity" "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz"
   "version" "3.1.2"
   dependencies:
     "brace-expansion" "^1.1.7"
+
+"minimatch@^5.0.0":
+  "integrity" "sha1-HPy4z1Ui6mmVLNKvla4JR38SKpY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-5.1.6.tgz"
+  "version" "5.1.6"
+  dependencies:
+    "brace-expansion" "^2.0.1"
 
 "minimatch@4.2.1":
   "integrity" "sha1-QNnVEaRr3E5WPCLDCAzenA2CmbQ="
@@ -1840,6 +1944,11 @@
     "yargs" "16.2.0"
     "yargs-parser" "20.2.4"
     "yargs-unparser" "2.0.0"
+
+"moment@^2.14.1", "moment@^2.29.1":
+  "integrity" "sha1-+MkcB7enhuMMWZJt9TC06slpdK4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/moment/-/moment-2.30.1.tgz"
+  "version" "2.30.1"
 
 "ms@2.1.2":
   "integrity" "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
@@ -2054,6 +2163,16 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
   "version" "2.0.1"
 
+"proper-lockfile@^1.2.0":
+  "integrity" "sha1-zv9d2J0+XxD7deHo52vHWAGlnDQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proper-lockfile/-/proper-lockfile-1.2.0.tgz"
+  "version" "1.2.0"
+  dependencies:
+    "err-code" "^1.0.0"
+    "extend" "^3.0.0"
+    "graceful-fs" "^4.1.2"
+    "retry" "^0.10.0"
+
 "proxy-from-env@^1.1.0":
   "integrity" "sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
@@ -2198,6 +2317,11 @@
   dependencies:
     "lowercase-keys" "^3.0.0"
 
+"retry@^0.10.0":
+  "integrity" "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/retry/-/retry-0.10.1.tgz"
+  "version" "0.10.1"
+
 "reusify@^1.0.4":
   "integrity" "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/reusify/-/reusify-1.0.4.tgz"
@@ -2223,6 +2347,16 @@
   "version" "1.2.0"
   dependencies:
     "queue-microtask" "^1.2.2"
+
+"safe-array-concat@^1.1.0":
+  "integrity" "sha1-jQyunLgG1tHAbgirE9hHKT6+BpI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-array-concat/-/safe-array-concat-1.1.0.tgz"
+  "version" "1.1.0"
+  dependencies:
+    "call-bind" "^1.0.5"
+    "get-intrinsic" "^1.2.2"
+    "has-symbols" "^1.0.3"
+    "isarray" "^2.0.5"
 
 "safe-buffer@^5.1.0":
   "integrity" "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
@@ -2282,6 +2416,17 @@
   "version" "6.0.1"
   dependencies:
     "randombytes" "^2.1.0"
+
+"set-function-length@^1.1.1":
+  "integrity" "sha1-L4HcbBbHBZvaWrfILBHwOlFe2OE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/set-function-length/-/set-function-length-1.2.0.tgz"
+  "version" "1.2.0"
+  dependencies:
+    "define-data-property" "^1.1.1"
+    "function-bind" "^1.1.2"
+    "get-intrinsic" "^1.2.2"
+    "gopd" "^1.0.1"
+    "has-property-descriptors" "^1.0.1"
 
 "setimmediate@~1.0.4":
   "integrity" "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
@@ -2497,6 +2642,13 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-4.4.4.tgz"
   "version" "4.4.4"
 
+"unit-compare@^1.0.1":
+  "integrity" "sha1-DHRZ8OW/U2N+qHPKPO4Y3i7so4Y="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unit-compare/-/unit-compare-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "moment" "^2.14.1"
+
 "unzipper@^0.10.11":
   "integrity" "sha1-C0mRRGRyy9uS7nQDkJ8mwkGceC4="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unzipper/-/unzipper-0.10.11.tgz"
@@ -2624,6 +2776,13 @@
   dependencies:
     "clone-deep" "^4.0.1"
     "wildcard" "^2.0.0"
+
+"webpack-permissions-plugin@^1.0.9":
+  "integrity" "sha1-gK5aCe0ZkdvbL5/kYYuNVxlhbh4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack-permissions-plugin/-/webpack-permissions-plugin-1.0.9.tgz"
+  "version" "1.0.9"
+  dependencies:
+    "filehound" "^1.17.6"
 
 "webpack-sources@^3.2.3":
   "integrity" "sha1-LU2quEUf1LJAzCcFX/agwszqDN4="

--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -40,7 +40,7 @@
 			{
 				"runUnderSudo": false,
 				"commandRoot": "apt-cache",
-				"commandParts": ["search", "{packageName}"]
+				"commandParts": ["search", "--names-only", "^{packageName}$"]
 			}
 		],
 		"isInstalledCommand":

--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -132,6 +132,30 @@
 				[
 					"aspnetcore-runtime-7.0"
 				]
+			},
+			{
+				"version": "8.0",
+				"sdk": [
+					"dotnet-sdk-8.0"
+				],
+				"runtime": [
+					"dotnet-runtime-8.0"
+				],
+				"aspnetcore": [
+					"aspnetcore-runtime-8.0"
+				]
+			},
+			{
+				"version": "9.0",
+				"sdk": [
+					"dotnet-sdk-9.0"
+				],
+				"runtime": [
+					"dotnet-runtime-9.0"
+				],
+				"aspnetcore": [
+					"aspnetcore-runtime-9.0"
+				]
 			}
 		],
 		"versions": [{
@@ -332,6 +356,30 @@
 				],
 				"aspnetcore": [
 					"aspnetcore-runtime-7.0"
+				]
+			},
+			{
+				"version": "8.0",
+				"sdk": [
+					"dotnet-sdk-8.0"
+				],
+				"runtime": [
+					"dotnet-runtime-8.0"
+				],
+				"aspnetcore": [
+					"aspnetcore-runtime-8.0"
+				]
+			},
+			{
+				"version": "9.0",
+				"sdk": [
+					"dotnet-sdk-9.0"
+				],
+				"runtime": [
+					"dotnet-runtime-9.0"
+				],
+				"aspnetcore": [
+					"aspnetcore-runtime-9.0"
 				]
 			}
 		],

--- a/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
+++ b/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
@@ -2,56 +2,36 @@
 EXECFOLDER=$1 # First argument is the working folder as this is launched with cwd of /root
 OKSIGNALFILE="$EXECFOLDER/ok.txt"
 COMMANDTORUNFILE="$EXECFOLDER/command.txt"
-OUTPUTFILE="/home/viru/vm.txt"
+OUTPUTFILE="/home/viru/om.txt"
+end=$((SECONDS+3600))
 while true
 do
         stop=false
-        until ((stop))
+        while [ $SECONDS -lt $end ];
         do
-            sleep 5
-            echo $(ls) >> "$OUTPUTFILE"
-            echo "$EXECFOLDER" >> "$OUTPUTFILE"
-            echo $(ls EXECFOLDER) >> "$OUTPUTFILE"
-            echo "$OKSIGNALFILE" >> "$OUTPUTFILE"
-            echo "$COMMANDTORUNFILE" >> "$OUTPUTFILE"
             if test -f "$COMMANDTORUNFILE"; then
-                echo "COMMAND FILE FOUND" >> "$OUTPUTFILE"
+                # echo "COMMAND FILE FOUND" >> "$OUTPUTFILE" # Leave this here as an example of debugging
                 COMMAND="$(cat "$COMMANDTORUNFILE" | awk '{$1=$1;print}')"
                 for validCmd in "${@:2}"
                 do
-                    echo "$COMMAND" >> "$OUTPUTFILE"
-                    echo "$validCmd" >> "$OUTPUTFILE"
                     if [ "$COMMAND" == "$validCmd" ]; then
                         IFS=' ' read -ra COMMANDARGS <<< "$COMMAND"
-                        echo "VALID CMD FOUND" >> "$OUTPUTFILE"
                     fi
                 done
                 if [ -z "$COMMANDARGS" ]; then
-                    echo "INVALID CMD FOUND" >> "$OUTPUTFILE"
+                    rm "$COMMANDTORUNFILE"
                     exit 111777 # Special exit code - arbitrarily picked for when the command is not expected
                 fi
-                OUT=$(sudo "${COMMANDARGS[@]}" 2> errFile)
+                OUT=$(sudo "${COMMANDARGS[@]}" 2> "$EXECFOLDER/stderr.txt")
                 STATUSCODE=$?
-                ERR=$(<errFile)
-                rm "errFile"
                 rm "$COMMANDTORUNFILE"
-                cat >| "$EXECFOLDER/stderr.txt" << EOF
-$ERR
-EOF
-                cat >| "$EXECFOLDER/stdout.txt" << EOF
-$OUT
-EOF
-                cat >| "$EXECFOLDER/status.txt" << EOF
-$STATUSCODE
-EOF
-                cat >| "$EXECFOLDER/output.json" << EOF
-" "
-EOF
+                $OUT | tee "$EXECFOLDER/stdout.txt"
+                $STATUSCODE | tee "$EXECFOLDER/status.txt"
+                " " | tee "$EXECFOLDER/output.json"
             fi
             if test -f "$OKSIGNALFILE"; then
-                echo "OK SIGNAL FILE FOUND" >> "$OUTPUTFILE"
                 rm "$OKSIGNALFILE"
             fi
-            echo "RELOOP" >> "$OUTPUTFILE"
+            sleep 5
         done
 done

--- a/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
+++ b/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
@@ -2,7 +2,7 @@
 EXECFOLDER=$1 # First argument is the working folder as this is launched with cwd of /root
 OKSIGNALFILE="$EXECFOLDER/ok.txt"
 COMMANDTORUNFILE="$EXECFOLDER/command.txt"
-OUTPUTFILE="/home/viru/om.txt"
+OUTPUTFILE="/home/test_output_.txt"
 end=$((SECONDS+3600))
 while true
 do

--- a/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
+++ b/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 OKSIGNALFILE=./ok.txt
 COMMANDTORUNFILE=./command.sh
 while true

--- a/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
+++ b/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 OKSIGNALFILE=./ok.txt
-COMMANDTORUNFILE=./command.sh
+COMMANDTORUNFILE=./command.txt
 while true
 do
         stop=false
         until ((stop))
         do
             sleep 5
+            echo $(ls)
+            echo "$PWD"
             if test -f "$COMMANDTORUNFILE"; then
                 COMMAND="$(cat "$COMMANDTORUNFILE" | awk '{$1=$1;print}')"
                 for validCmd in "$@"
@@ -15,9 +17,9 @@ do
                         IFS=' ' read -ra COMMANDARGS <<< "$COMMAND"
                     fi
                 done
-                if [ -z "$COMMANDARGS" ]; then
-                    exit 111777 # Special exit code - arbitrarily picked for when the command is not expected
-                fi
+                #if [ -z "$COMMANDARGS" ]; then
+                    # exit 111777 # Special exit code - arbitrarily picked for when the command is not expected
+                #fi
                 OUT=$(sudo "${COMMANDARGS[@]}" 2> errFile)
                 STATUSCODE=$?
                 ERR=$(<errFile)

--- a/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
+++ b/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
@@ -1,40 +1,57 @@
 #!/usr/bin/env bash
-OKSIGNALFILE=./ok.txt
-COMMANDTORUNFILE=./command.txt
+EXECFOLDER=$1 # First argument is the working folder as this is launched with cwd of /root
+OKSIGNALFILE="$EXECFOLDER/ok.txt"
+COMMANDTORUNFILE="$EXECFOLDER/command.txt"
+OUTPUTFILE="/home/viru/vm.txt"
 while true
 do
         stop=false
         until ((stop))
         do
             sleep 5
-            echo $(ls)
-            echo "$PWD"
+            echo $(ls) >> "$OUTPUTFILE"
+            echo "$EXECFOLDER" >> "$OUTPUTFILE"
+            echo $(ls EXECFOLDER) >> "$OUTPUTFILE"
+            echo "$OKSIGNALFILE" >> "$OUTPUTFILE"
+            echo "$COMMANDTORUNFILE" >> "$OUTPUTFILE"
             if test -f "$COMMANDTORUNFILE"; then
+                echo "COMMAND FILE FOUND" >> "$OUTPUTFILE"
                 COMMAND="$(cat "$COMMANDTORUNFILE" | awk '{$1=$1;print}')"
-                for validCmd in "$@"
+                for validCmd in "${@:2}"
                 do
+                    echo "$COMMAND" >> "$OUTPUTFILE"
+                    echo "$validCmd" >> "$OUTPUTFILE"
                     if [ "$COMMAND" == "$validCmd" ]; then
                         IFS=' ' read -ra COMMANDARGS <<< "$COMMAND"
+                        echo "VALID CMD FOUND" >> "$OUTPUTFILE"
                     fi
                 done
-                #if [ -z "$COMMANDARGS" ]; then
-                    # exit 111777 # Special exit code - arbitrarily picked for when the command is not expected
-                #fi
+                if [ -z "$COMMANDARGS" ]; then
+                    echo "INVALID CMD FOUND" >> "$OUTPUTFILE"
+                    exit 111777 # Special exit code - arbitrarily picked for when the command is not expected
+                fi
                 OUT=$(sudo "${COMMANDARGS[@]}" 2> errFile)
                 STATUSCODE=$?
                 ERR=$(<errFile)
                 rm "errFile"
                 rm "$COMMANDTORUNFILE"
-                cat > output.json << EOF
-{
-    "stdout": "$OUT",
-    "stderr": "$ERR",
-    "status": "$STATUSCODE"
-}
+                cat >| "$EXECFOLDER/stderr.txt" << EOF
+$ERR
+EOF
+                cat >| "$EXECFOLDER/stdout.txt" << EOF
+$OUT
+EOF
+                cat >| "$EXECFOLDER/status.txt" << EOF
+$STATUSCODE
+EOF
+                cat >| "$EXECFOLDER/output.json" << EOF
+" "
 EOF
             fi
             if test -f "$OKSIGNALFILE"; then
+                echo "OK SIGNAL FILE FOUND" >> "$OUTPUTFILE"
                 rm "$OKSIGNALFILE"
             fi
+            echo "RELOOP" >> "$OUTPUTFILE"
         done
 done

--- a/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
+++ b/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
@@ -2,7 +2,7 @@
 EXECFOLDER=$1 # First argument is the working folder as this is launched with cwd of /root
 OKSIGNALFILE="$EXECFOLDER/ok.txt"
 COMMANDTORUNFILE="$EXECFOLDER/command.txt"
-OUTPUTFILE="/home/test_output_.txt"
+#OUTPUTFILE="/home/test_output_.txt"
 end=$((SECONDS+3600))
 while true
 do

--- a/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
+++ b/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+OKSIGNALFILE=./ok.txt
+COMMANDTORUNFILE=./command.sh
+while true
+do
+        stop=false
+        until ((stop))
+        do
+            sleep 5
+            if test -f "$COMMANDTORUNFILE"; then
+                COMMAND="$(cat "$COMMANDTORUNFILE" | awk '{$1=$1;print}')"
+                for validCmd in "$@"
+                do
+                    if [ "$COMMAND" == "$validCmd" ]; then
+                        IFS=' ' read -ra COMMANDARGS <<< "$COMMAND"
+                    fi
+                done
+                if [ -z "$COMMANDARGS" ]; then
+                    exit 111777 # Special exit code - arbitrarily picked for when the command is not expected
+                fi
+                OUT=$(sudo "${COMMANDARGS[@]}" 2> errFile)
+                STATUSCODE=$?
+                ERR=$(<errFile)
+                rm "errFile"
+                rm "$COMMANDTORUNFILE"
+                cat > output.json << EOF
+{
+    "stdout": "$OUT",
+    "stderr": "$ERR",
+    "status": "$STATUSCODE"
+}
+EOF
+            fi
+            if test -f "$OKSIGNALFILE"; then
+                rm "$OKSIGNALFILE"
+            fi
+        done
+done

--- a/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
+++ b/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
@@ -15,6 +15,8 @@ do
                 for validCmd in "${@:2}"
                 do
                     if [ "$COMMAND" == "$validCmd" ]; then
+                        # Eventually we should split the cmd file to be line by line instead of space separated,
+                        # but it works for now because the commands are running under sudo
                         IFS=' ' read -ra COMMANDARGS <<< "$COMMAND"
                     fi
                 done

--- a/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
+++ b/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
@@ -22,12 +22,11 @@ do
                     rm "$COMMANDTORUNFILE"
                     exit 111777 # Special exit code - arbitrarily picked for when the command is not expected
                 fi
-                OUT=$(sudo "${COMMANDARGS[@]}" 2> "$EXECFOLDER/stderr.txt")
+                sudo "${COMMANDARGS[@]}" 2> "$EXECFOLDER/stderr.txt" 1> "$EXECFOLDER/stdout.txt"
                 STATUSCODE=$?
+                echo $STATUSCODE > "$EXECFOLDER/status.txt"
                 rm "$COMMANDTORUNFILE"
-                $OUT | tee "$EXECFOLDER/stdout.txt"
-                $STATUSCODE | tee "$EXECFOLDER/status.txt"
-                " " | tee "$EXECFOLDER/output.json"
+                touch "$EXECFOLDER/output.txt"
             fi
             if test -f "$OKSIGNALFILE"; then
                 rm "$OKSIGNALFILE"

--- a/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
+++ b/vscode-dotnet-runtime-library/install scripts/interprocess-communicator.sh
@@ -4,6 +4,13 @@ OKSIGNALFILE="$EXECFOLDER/ok.txt"
 COMMANDTORUNFILE="$EXECFOLDER/command.txt"
 #OUTPUTFILE="/home/test_output_.txt"
 end=$((SECONDS+3600))
+
+function finish {
+  rm "$COMMANDTORUNFILE"
+  rm "$OKSIGNALFILE"
+}
+trap finish EXIT
+
 while true
 do
         stop=false

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -182,7 +182,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
         }
         else
         {
-            const availableVersions = await this.myVersionPackages(installType);
+            const availableVersions = await this.myVersionPackages(installType, this.isMidFeedInjection);
             const simplifiedVersion = this.JsonDotnetVersion(fullySpecifiedVersion);
 
             for(const dotnetPackages of availableVersions)
@@ -200,7 +200,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
     public async getRecommendedDotnetVersion(installType : LinuxInstallType) : Promise<string>
     {
         let maxVersion = '0';
-        const json = await this.myVersionPackages(installType);
+        const json = await this.myVersionPackages(installType, this.isMidFeedInjection);
         for(const dotnetPackages of json)
         {
             if(Number(dotnetPackages.version) > Number(maxVersion))

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -218,7 +218,7 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
         return this.versionResolver.getMajorMinor(fullySpecifiedDotnetVersion);
     }
 
-    protected isPackageFoundInSearch(resultOfSearchCommand: any): boolean {
-        return resultOfSearchCommand !== '';
+    protected isPackageFoundInSearch(resultOfSearchCommand: any, searchCommandExitCode : string): boolean {
+        return resultOfSearchCommand.trim() !== '' && searchCommandExitCode === '0';
     }
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
@@ -199,8 +199,15 @@ export abstract class IDistroDotnetSDKProvider {
             {
                 let command = this.myDistroCommands(this.searchCommandKey);
                 command = CommandExecutor.replaceSubstringsInCommands(command, this.missingPackageNameKey, packageName);
-                const packageIsAvailableResult = (await this.commandRunner.executeMultipleCommands(command))[0];
-                const packageExists = this.isPackageFoundInSearch(packageIsAvailableResult);
+
+                const packageIsAvailableResult = (await this.commandRunner.executeMultipleCommands(command))[0].trim();
+                const oldReturnStatusSetting = this.commandRunner.returnStatus;
+
+                this.commandRunner.returnStatus = true;
+                const packageAvailableExitCode = (await this.commandRunner.executeMultipleCommands(command))[0].trim();
+                this.commandRunner.returnStatus = oldReturnStatusSetting;
+
+                const packageExists = this.isPackageFoundInSearch(packageIsAvailableResult, packageAvailableExitCode);
                 if(packageExists)
                 {
                     thisVersionPackage.packages.push(packageName);
@@ -337,5 +344,5 @@ export abstract class IDistroDotnetSDKProvider {
         throw err;
     }
 
-    protected abstract isPackageFoundInSearch(resultOfSearchCommand : any) : boolean;
+    protected abstract isPackageFoundInSearch(resultOfSearchCommand : any, searchCommandExitCode : string) : boolean;
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
@@ -274,7 +274,11 @@ export abstract class IDistroDotnetSDKProvider {
 
         const baseCommands = (Object.values(this.distroJson[this.distroVersion.distro])
             .filter((x : any) => x && Array.isArray(x) && ((x[0] as CommandExecutorCommand).commandParts))).flat();
-        const preInstallCommands = this.myVersionDetails()[this.preinstallCommandKey] as CommandExecutorCommand[];
+        let preInstallCommands = this.myVersionDetails()[this.preinstallCommandKey] as CommandExecutorCommand[];
+        if(!preInstallCommands)
+        {
+            preInstallCommands = [];
+        }
         const sudoCommands = (baseCommands as CommandExecutorCommand[]).concat(preInstallCommands).filter(x => x.runUnderSudo);
 
         for(const command of sudoCommands)

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallScriptAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallScriptAcquisitionWorker.ts
@@ -43,7 +43,7 @@ export class InstallScriptAcquisitionWorker implements IInstallScriptAcquisition
                 throw new Error('Unable to get script path.');
             }
 
-            await this.fileUtilities.writeFileOntoDisk(script, this.scriptFilePath, this.context.eventStream);
+            await this.fileUtilities.writeFileOntoDisk(script, this.scriptFilePath, false, this.context.eventStream);
             this.context.eventStream.post(new DotnetInstallScriptAcquisitionCompleted());
             return this.scriptFilePath;
         }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -571,6 +571,26 @@ export class CommandExecutionEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionEvent';
 }
 
+export class SudoProcAliveCheckBegin extends DotnetCustomMessageEvent {
+    public readonly eventName = 'SudoProcAliveCheckBegin';
+}
+
+export class SudoProcAliveCheckEnd extends DotnetCustomMessageEvent {
+    public readonly eventName = 'SudoProcAliveCheckEnd';
+}
+
+export class SudoProcCommandExchangeBegin extends DotnetCustomMessageEvent {
+    public readonly eventName = 'SudoProcCommandExchangeBegin';
+}
+
+export class SudoProcCommandExchangePing extends DotnetCustomMessageEvent {
+    public readonly eventName = 'SudoProcCommandExchangePing';
+}
+
+export class SudoProcCommandExchangeEnd extends DotnetCustomMessageEvent {
+    public readonly eventName = 'SudoProcCommandExchangeEnd';
+}
+
 export class CommandExecutionUserAskDialogueEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionUserAskDialogueEvent';
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -187,6 +187,18 @@ export class DotnetPreinstallDetectionError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetPreinstallDetectionError';
 }
 
+export class TimeoutSudoProcessSpawnerError extends DotnetAcquisitionError {
+    public readonly eventName = 'TimeoutSudoProcessSpawnerError';
+}
+
+export class TimeoutSudoCommandExecutionError extends DotnetAcquisitionError {
+    public readonly eventName = 'TimeoutSudoCommandExecutionError';
+}
+
+export class CommandExecutionNonZeroExitFailure extends DotnetAcquisitionError {
+    public readonly eventName = 'CommandExecutionNonZeroExitFailure';
+}
+
 export class DotnetNotInstallRelatedCommandFailed extends DotnetNonAcquisitionError {
     public readonly eventName = 'DotnetNotInstallRelatedCommandFailed';
 
@@ -486,6 +498,18 @@ export class DotnetGlobalAcquisitionBeginEvent extends DotnetCustomMessageEvent 
 
 export class DotnetGlobalVersionResolutionCompletionEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetGlobalVersionResolutionCompletionEvent';
+}
+
+export class CommandProcessesExecutionFailureNonTerminal extends DotnetCustomMessageEvent {
+    public readonly eventName = 'CommandProcessesExecutionFailureNonTerminal';
+}
+
+export class CommandProcessorExecutionBegin extends DotnetCustomMessageEvent {
+    public readonly eventName = 'CommandProcessorExecutionBegin';
+}
+
+export class CommandProcessorExecutionEnd extends DotnetCustomMessageEvent {
+    public readonly eventName = 'CommandProcessorExecutionEnd';
 }
 
 export class DotnetBeginGlobalInstallerExecution extends DotnetCustomMessageEvent {

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -607,6 +607,10 @@ export class CommandExecutionUserRejectedPasswordRequest extends DotnetInstallEx
     public readonly eventName = 'CommandExecutionUserRejectedPasswordRequest';
 }
 
+export class CommandExecutionUnknownCommandExecutionAttempt extends DotnetInstallExpectedAbort {
+    public readonly eventName = 'CommandExecutionUnknownCommandExecutionAttempt';
+}
+
 export class DotnetVersionParseEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetVersionParseEvent';
 }

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -70,6 +70,12 @@ export class CommandExecutor extends ICommandExecutor
     {
         const fullCommandString = CommandExecutor.prettifyCommandExecutorCommand(command, false);
         this.context?.eventStream.post(new CommandExecutionUnderSudoEvent(`The command ${fullCommandString} is being ran under sudo.`));
+        const shellScript = path.join(__dirname, 'installer.sh');
+        const shellContent = `
+#!/usr/bin/env bash
+sudo ${fullCommandString}
+        `;
+        await new FileUtilities().writeFileOntoDisk(shellContent, shellScript, this.context?.eventStream!)
 
         if(this.isRunningUnderWSL())
         {
@@ -94,12 +100,6 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
             const options = { name: `${sanitizedCallerName ?? '.NET Install Tool'}` };
 
             this.context?.eventStream.post(new CommandExecutionUserAskDialogueEvent(`Prompting user for command ${fullCommandString} under sudo.`));
-            const shellScript = path.join(__dirname, 'installer.sh');
-            const shellContent = `
-#!/usr/bin/env bash
-sudo ${fullCommandString}
-            `;
-            new FileUtilities().writeFileOntoDisk(shellContent, shellScript, this.context?.eventStream!)
             exec((`sh ${shellScript}`), options, (error?: any, stdout?: any, stderr?: any) =>
             {
                 let commandResultString = '';

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -216,7 +216,7 @@ ${stderr}`));
 The user refused the password prompt.`),
                                 getInstallKeyFromContext(this.context?.acquisitionContext!));
                             this.context?.eventStream.post(err);
-                            throw err.error;
+                            reject(err.error);
                         }
                         reject(error);
                     }

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -151,7 +151,8 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
             sanitizedCallerName = sanitizedCallerName?.substring(0, 69); // 70 Characters is the maximum limit we can use for the prompt.
             const options = { name: `${sanitizedCallerName ?? '.NET Install Tool'}` };
 
-            exec((`sh "${shellScriptPath}" ${this.validSudoCommands?.join(' ')}`), options, (error?: any, stdout?: any, stderr?: any) =>
+            fs.chmodSync(shellScriptPath, 0o500);
+            exec((`"${shellScriptPath}" ${this.validSudoCommands?.join(' ')}`), options, (error?: any, stdout?: any, stderr?: any) =>
             {
                 let commandResultString = '';
 

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -214,7 +214,7 @@ The user refused the password prompt.`),
         {
             this.context?.eventStream.post(new DotnetLockAcquiredEvent(`Lock Acquired.`, new Date().toISOString(), directoryLockPath, fakeLockFile));
 
-            await this.fileUtil.wipeDirectory(this.sudoProcessCommunicationDir, this.context?.eventStream, ['.txt', '.json']);
+            await this.fileUtil.wipeDirectory(this.sudoProcessCommunicationDir, this.context?.eventStream, ['.txt']);
 
             await this.fileUtil.writeFileOntoDisk('', processAliveOkSentinelFile, true, this.context?.eventStream);
             this.context?.eventStream.post(new SudoProcAliveCheckBegin(`Looking for Sudo Process Master, wrote OK file. ${new Date().toISOString()}`));
@@ -284,7 +284,7 @@ Process Directory: ${this.sudoProcessCommunicationDir} failed with error mode: $
         const stdoutFile = path.join(this.sudoProcessCommunicationDir, 'stdout.txt');
         const statusFile = path.join(this.sudoProcessCommunicationDir, 'status.txt');
 
-        const outputFile = path.join(this.sudoProcessCommunicationDir, 'output.json');
+        const outputFile = path.join(this.sudoProcessCommunicationDir, 'output.txt');
         const fakeLockFile = path.join(this.sudoProcessCommunicationDir, 'fakeLockFile'); // We need a file to lock the directory in the API besides the dir lock file
 
         await this.fileUtil.writeFileOntoDisk('', fakeLockFile, false, this.context?.eventStream!);
@@ -323,7 +323,7 @@ Process Directory: ${this.sudoProcessCommunicationDir} failed with error mode: $
                 status : (fs.readFileSync(statusFile, 'utf8')).trim()
             } as CommandProcessorOutput;
             this.context?.eventStream.post(new DotnetLockReleasedEvent(`Lock about to be released.`, new Date().toISOString(), directoryLockPath, fakeLockFile));
-            await this.fileUtil.wipeDirectory(this.sudoProcessCommunicationDir, this.context?.eventStream, ['.txt', '.json']);
+            await this.fileUtil.wipeDirectory(this.sudoProcessCommunicationDir, this.context?.eventStream, ['.txt']);
 
             return release();
         });

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -220,7 +220,7 @@ The user refused the password prompt.`),
             await this.fileUtil.writeFileOntoDisk('', processAliveOkSentinelFile, true, this.context?.eventStream);
             this.context?.eventStream.post(new SudoProcAliveCheckBegin(`Looking for Sudo Process Master, wrote OK file. ${new Date().toISOString()}`));
 
-            const waitTime = 60000; // TODO: Change this to for production 180000;
+            const waitTime = this.context?.timeoutSeconds ? ((this.context?.timeoutSeconds/3) * 1000) : 180000;
             await this.loopWithTimeoutOnCond(100, waitTime,
                 function processRespondedByDeletingOkFile() : boolean { return !fs.existsSync(processAliveOkSentinelFile) },
                 function setProcessIsAlive() : void { isLive = true; }
@@ -309,7 +309,8 @@ It had previously spawned: ${this.hasEverLaunchedSudoFork}.`), getInstallKeyFrom
             this.context?.eventStream.post(new SudoProcCommandExchangeBegin(`Handing command off to master process. ${new Date().toISOString()}`));
             this.context?.eventStream.post(new CommandProcessorExecutionBegin(`The command ${commandToExecuteString} was forwarded to the master process to run.`));
 
-            const waitTime = 60000; // TODO: Change this to for production 600000;
+
+            const waitTime = this.context?.timeoutSeconds ? (this.context?.timeoutSeconds * 1000) : 600000;
             await this.loopWithTimeoutOnCond(100, waitTime,
                 function ProcessFinishedExecutingAndWroteOutput() : boolean { return fs.existsSync(outputFile) },
                 function doNothing() : void { ; }

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -54,6 +54,7 @@ import { CommandProcessorOutput } from './CommandProcessorOutput';
 import { setTimeout } from 'timers';
 
 /* tslint:disable:no-any */
+/* tslint:disable:no-string-literal */
 
 export class CommandExecutor extends ICommandExecutor
 {
@@ -238,8 +239,9 @@ The user refused the password prompt.`),
 
         if(!isLive && errorIfDead)
         {
-            const err = new TimeoutSudoProcessSpawnerError(new Error(`We are unable to spawn the process needed to run commands under sudo for installing .NET.
-Process Directory: ${this.sudoProcessCommunicationDir} failed with error mode: ${errorIfDead} and had previously spawned: ${this.hasEverLaunchedSudoFork}.`), getInstallKeyFromContext(this.context?.acquisitionContext));
+            const err = new TimeoutSudoProcessSpawnerError(new Error(`We are unable to spawn the process to run commands under sudo for installing .NET.
+Process Directory: ${this.sudoProcessCommunicationDir} failed with error mode: ${errorIfDead}.
+It had previously spawned: ${this.hasEverLaunchedSudoFork}.`), getInstallKeyFromContext(this.context?.acquisitionContext));
             this.context?.eventStream.post(err);
             throw err.error;
         }
@@ -247,7 +249,7 @@ Process Directory: ${this.sudoProcessCommunicationDir} failed with error mode: $
         return isLive;
     }
 
-    private async loopWithTimeoutOnCond(sampleRatePerMs : number, durationToWaitBeforeTimeoutMs : number, conditionToStop : Function, doAfterStop : Function )
+    private async loopWithTimeoutOnCond(sampleRatePerMs : number, durationToWaitBeforeTimeoutMs : number, conditionToStop : () => boolean, doAfterStop : () => void )
     {
         return new Promise(async (resolve, reject) =>
         {
@@ -259,7 +261,7 @@ Process Directory: ${this.sudoProcessCommunicationDir} failed with error mode: $
                     return resolve('The promise succeeded.');
                 }
                 this.context?.eventStream.post(new SudoProcCommandExchangePing(`Ping : Waiting. ${new Date().toISOString()}`));
-                await new Promise(resolve => setTimeout(resolve, sampleRatePerMs));
+                await new Promise(waitAndResolve => setTimeout(waitAndResolve, sampleRatePerMs));
             }
 
             return reject('The promise timed out.');
@@ -333,7 +335,8 @@ Process Directory: ${this.sudoProcessCommunicationDir} failed with error mode: $
         if(!commandOutputJson && terminalFailure)
         {
             const err = new TimeoutSudoCommandExecutionError(new Error(`Timeout: The master process with command ${commandToExecuteString} never finished executing.
-Process Directory: ${this.sudoProcessCommunicationDir} failed with error mode: ${terminalFailure} and had previously spawned: ${this.hasEverLaunchedSudoFork}.`), getInstallKeyFromContext(this.context?.acquisitionContext));
+Process Directory: ${this.sudoProcessCommunicationDir} failed with error mode: ${terminalFailure}.
+It had previously spawned: ${this.hasEverLaunchedSudoFork}.`), getInstallKeyFromContext(this.context?.acquisitionContext));
             this.context?.eventStream.post(err);
             throw err.error;
         }

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -35,6 +35,7 @@ import { IUtilityContext } from './IUtilityContext';
 import { IVSCodeExtensionContext } from '../IVSCodeExtensionContext';
 import { IWindowDisplayWorker } from '../EventStream/IWindowDisplayWorker';
 import { IAcquisitionWorkerContext } from '../Acquisition/IAcquisitionWorkerContext';
+import { FileUtilities } from './FileUtilities';
 
 /* tslint:disable:no-any */
 
@@ -93,7 +94,13 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
             const options = { name: `${sanitizedCallerName ?? '.NET Install Tool'}` };
 
             this.context?.eventStream.post(new CommandExecutionUserAskDialogueEvent(`Prompting user for command ${fullCommandString} under sudo.`));
-            exec((fullCommandString), options, (error?: any, stdout?: any, stderr?: any) =>
+            const shellScript = path.join(__dirname, 'installer.sh');
+            const shellContent = `
+#!/usr/bin/env bash
+sudo ${fullCommandString}
+            `;
+            new FileUtilities().writeFileOntoDisk(shellContent, shellScript, this.context?.eventStream!)
+            exec((`sh ${shellScript}`), options, (error?: any, stdout?: any, stderr?: any) =>
             {
                 let commandResultString = '';
 

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -119,7 +119,7 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
         }
         this.returnStatus = oldReturnStatusSetting;
 
-        return this.executeSudoViaProcessCommmunication(fullCommandString, terminalFailure);
+        return this.executeSudoViaProcessCommunication(fullCommandString, terminalFailure);
     }
 
     /**
@@ -131,10 +131,6 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
      */
     private async startupSudoProc(fullCommandString : string, shellScriptPath : string, terminalFailure : boolean) : Promise<string>
     {
-        if (!fs.existsSync(this.sudoProcessCommunicationDir))
-        {
-            fs.mkdirSync(this.sudoProcessCommunicationDir);
-        }
         if(this.hasEverLaunchedSudoFork)
         {
             if(await this.sudoProcIsLive(false))
@@ -155,7 +151,7 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
             sanitizedCallerName = sanitizedCallerName?.substring(0, 69); // 70 Characters is the maximum limit we can use for the prompt.
             const options = { name: `${sanitizedCallerName ?? '.NET Install Tool'}` };
 
-            exec((`sh ${shellScriptPath} ${this.validSudoCommands?.join(' ')}`), options, (error?: any, stdout?: any, stderr?: any) =>
+            exec((`sh "${shellScriptPath}" ${this.validSudoCommands?.join(' ')}`), options, (error?: any, stdout?: any, stderr?: any) =>
             {
                 let commandResultString = '';
 
@@ -266,7 +262,7 @@ Process Directory: ${this.sudoProcessCommunicationDir} failed with error mode: $
      * @param failOnNonZeroExit Whether to fail if we get an exit code from the command besides 0.
      * @returns The output string of the command, or the string status code, depending on the mode of execution.
      */
-    private async executeSudoViaProcessCommmunication(commandToExecuteString : string, terminalFailure : boolean, failOnNonZeroExit = true) : Promise<string>
+    private async executeSudoViaProcessCommunication(commandToExecuteString : string, terminalFailure : boolean, failOnNonZeroExit = true) : Promise<string>
     {
         let commandOutputJson : CommandProcessorOutput | null = null;
         let statusCode = '1220'; // Special failure code for if code is never set error

--- a/vscode-dotnet-runtime-library/src/Utils/CommandProcessorOutput.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandProcessorOutput.ts
@@ -1,0 +1,20 @@
+/* --------------------------------------------------------------------------------------------
+ *  Licensed to the .NET Foundation under one or more agreements.
+ *  The .NET Foundation licenses this file to you under the MIT license.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export type CommandProcessorOutput =
+{
+    /**
+     * @property commandRoot
+     * The stdout of the command.
+     * @property commandParts
+     * The stderr of the command.
+     * @property status
+     * The exit code of the program/command after execution.
+     */
+    stdout : string,
+    stderr : string,
+    status : string
+}

--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -3,231 +3,244 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
- import * as eol from 'eol';
- import * as fs from 'fs';
- import * as path from 'path';
- import * as os from 'os';
- import * as proc from 'child_process';
- import * as crypto from 'crypto';
+import * as eol from 'eol';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as proc from 'child_process';
+import * as crypto from 'crypto';
 import { IFileUtilities } from './IFileUtilities';
- import * as lockfile from 'proper-lockfile';
+import * as lockfile from 'proper-lockfile';
 import { IEventStream } from '../EventStream/EventStream';
 import { DotnetCommandFallbackArchitectureEvent,
-    DotnetCommandFallbackOSEvent,
-    DotnetFileWriteRequestEvent,
-    DotnetLockAcquiredEvent,
-    DotnetLockAttemptingAcquireEvent,
-    DotnetLockErrorEvent,
-    DotnetLockReleasedEvent,
-    SuppressedAcquisitionError
+   DotnetCommandFallbackOSEvent,
+   DotnetFileWriteRequestEvent,
+   DotnetLockAcquiredEvent,
+   DotnetLockAttemptingAcquireEvent,
+   DotnetLockErrorEvent,
+   DotnetLockReleasedEvent,
+   SuppressedAcquisitionError
 } from '../EventStream/EventStreamEvents';
 /* tslint:disable:no-any */
 
 export class FileUtilities extends IFileUtilities
 {
-    public async writeFileOntoDisk(scriptContent: string, filePath: string, eventStream? : IEventStream)
-    {
-        eventStream?.post(new DotnetFileWriteRequestEvent(`Request to write`, new Date().toISOString(), filePath));
+   public async writeFileOntoDisk(scriptContent: string, filePath: string, alreadyHoldingLock : boolean = false, eventStream? : IEventStream)
+   {
+       eventStream?.post(new DotnetFileWriteRequestEvent(`Request to write`, new Date().toISOString(), filePath));
 
-        if (!fs.existsSync(path.dirname(filePath))) {
-            fs.mkdirSync(path.dirname(filePath), { recursive: true });
-        }
-        // Prepare to lock directory so we can check file exists atomically
-        const directoryLock = 'dir.lock';
-        const directoryLockPath = path.join(path.dirname(filePath), directoryLock);
+       if (!fs.existsSync(path.dirname(filePath))) {
+           fs.mkdirSync(path.dirname(filePath), { recursive: true });
+       }
+       // Prepare to lock directory so we can check file exists atomically
+       const directoryLock = 'dir.lock';
+       const directoryLockPath = path.join(path.dirname(filePath), directoryLock);
 
-        // Begin Critical Section
-        // This check is part of a RACE CONDITION, it is technically part of the critical section as you will fail if the file DNE,
-        //  but you cant lock the file until it exists. Since there is no context in which files written by this are deleted while this can run,
-        //  theoretically, this ok. The library SHOULD provide a RAII based system for locks, but it does not.
-        if(!fs.existsSync(filePath))
-        {
-            // Create an empty file, as proper-lockfile fails to lock a file if file dne
-            eventStream?.post(new DotnetFileWriteRequestEvent(`File did not exist upon write request.`, new Date().toISOString(), filePath));
-            fs.writeFileSync(filePath, '');
-        }
+       // Begin Critical Section
+       // This check is part of a RACE CONDITION, it is technically part of the critical section as you will fail if the file DNE,
+       //  but you cant lock the file until it exists. Since there is no context in which files written by this are deleted while this can run,
+       //  theoretically, this ok. The library SHOULD provide a RAII based system for locks, but it does not.
+       if(!fs.existsSync(filePath))
+       {
+           // Create an empty file, as proper-lockfile fails to lock a file if file dne
+           eventStream?.post(new DotnetFileWriteRequestEvent(`File did not exist upon write request.`, new Date().toISOString(), filePath));
+           fs.writeFileSync(filePath, '');
+       }
 
-        eventStream?.post(new DotnetLockAttemptingAcquireEvent(`Lock Acquisition request to begin.`, new Date().toISOString(), directoryLockPath, filePath));
-        await lockfile.lock(filePath, { lockfilePath: directoryLockPath, retries: { retries: 10, maxTimeout: 1000 } } )
-        .then(async (release) =>
-        {
-            eventStream?.post(new DotnetLockAcquiredEvent(`Lock Acquired.`, new Date().toISOString(), directoryLockPath, filePath));
+       if(!alreadyHoldingLock)
+       {
+           eventStream?.post(new DotnetLockAttemptingAcquireEvent(`Lock Acquisition request to begin.`, new Date().toISOString(), directoryLockPath, filePath));
+           await lockfile.lock(filePath, { lockfilePath: directoryLockPath, retries: { retries: 10, maxTimeout: 1000 } } )
+           .then(async (release) =>
+           {
+               eventStream?.post(new DotnetLockAcquiredEvent(`Lock Acquired.`, new Date().toISOString(), directoryLockPath, filePath));
 
-            // We would like to unlock the directory, but we can't grab a lock on the file if the directory is locked.
-            // Theoretically you could: add a new file-writer lock as a 3rd party lock ...
-            // Then, lock the file-writer, unlock the directory, then lock the file, then unlock file-writer, ...
-            // operate, then unlock file once the operation is done.
-            // For now, keep the entire directory locked.
+               // We would like to unlock the directory, but we can't grab a lock on the file if the directory is locked.
+               // Theoretically you could: add a new file-writer lock as a 3rd party lock ...
+               // Then, lock the file-writer, unlock the directory, then lock the file, then unlock file-writer, ...
+               // operate, then unlock file once the operation is done.
+               // For now, keep the entire directory locked.
 
-            scriptContent = eol.auto(scriptContent);
-            const existingScriptContent = fs.readFileSync(filePath).toString();
-            // fs.writeFile will replace the file if it exists.
-            // https://nodejs.org/api/fs.html#fswritefilefile-data-options-callback
-            if(scriptContent !== existingScriptContent)
-            {
-                fs.writeFileSync(filePath, scriptContent);
-                eventStream?.post(new DotnetFileWriteRequestEvent(`File content needed to be updated.`, new Date().toISOString(), filePath));
-            }
-            else
-            {
-                eventStream?.post(new DotnetFileWriteRequestEvent(`File content is an exact match, not writing file.`, new Date().toISOString(), filePath));
-            }
+               this.innerWriteFile(scriptContent, filePath, eventStream);
 
-            fs.chmodSync(filePath, 0o744);
-            eventStream?.post(new DotnetLockReleasedEvent(`Lock about to be released.`, new Date().toISOString(), directoryLockPath, filePath));
-            return release();
-        })
-        .catch((e : Error) =>
-        {
-            // Either the lock could not be acquired or releasing it failed
-            eventStream?.post(new DotnetLockErrorEvent(e, e.message, new Date().toISOString(), directoryLockPath, filePath));
-        });
-        // End Critical Section
-    }
+               eventStream?.post(new DotnetLockReleasedEvent(`Lock about to be released.`, new Date().toISOString(), directoryLockPath, filePath));
+               return release();
+           })
+           .catch((e : Error) =>
+           {
+               // Either the lock could not be acquired or releasing it failed
+               eventStream?.post(new DotnetLockErrorEvent(e, e.message, new Date().toISOString(), directoryLockPath, filePath));
+           });
+       }
+       else
+       {
+           this.innerWriteFile(scriptContent, filePath, eventStream);
+       }
+       // End Critical Section
+   }
 
-    /**
-     * @param directoryToWipe the directory to delete all of the files in if privilege to do so exists.
-     * @param fileExtensionsToDelete - if undefined, delete all files. if not, delete only files with extensions in this array in lower case.
-     */
-    public wipeDirectory(directoryToWipe : string, eventStream? : IEventStream, fileExtensionsToDelete? : string[])
-    {
-        if(!fs.existsSync(directoryToWipe))
-        {
-            return;
-        }
+   private innerWriteFile(scriptContent: string, filePath: string, eventStream? : IEventStream)
+   {
+       scriptContent = eol.auto(scriptContent);
+       const existingScriptContent = fs.readFileSync(filePath).toString();
+       // fs.writeFile will replace the file if it exists.
+       // https://nodejs.org/api/fs.html#fswritefilefile-data-options-callback
+       if(scriptContent !== existingScriptContent)
+       {
+           fs.writeFileSync(filePath, scriptContent);
+           eventStream?.post(new DotnetFileWriteRequestEvent(`File content needed to be updated.`, new Date().toISOString(), filePath));
+       }
+       else
+       {
+           eventStream?.post(new DotnetFileWriteRequestEvent(`File content is an exact match, not writing file.`, new Date().toISOString(), filePath));
+       }
 
-        // Use rimraf to delete all of the items in a directory without the directory itself.
-        fs.readdirSync(directoryToWipe).forEach(f =>
-        {
-            try
-            {
-                if(!fileExtensionsToDelete || path.extname(f).toLocaleLowerCase() in fileExtensionsToDelete)
-                fs.rmSync(`${directoryToWipe}/${f}`);
-            }
-            catch(error : any)
-            {
-                eventStream?.post(new SuppressedAcquisitionError(error, `Failed to delete ${f} when marked for deletion.`));
-            }
-        });
-    }
+       fs.chmodSync(filePath, 0o744);
+   }
 
-    /**
-     *
-     * @param nodeArchitecture the architecture in node style string of what to install
-     * @returns the architecture in the style that .net / the .net install scripts expect
-     *
-     * Node - amd64 is documented as an option for install scripts but its no longer used.
-     * s390x is also no longer used.
-     * ppc64le is supported but this version of node has no distinction of the endianness of the process.
-     * It has no mapping to mips or other node architectures.
-     *
-     * @remarks Falls back to string 'auto' if a mapping does not exist which is not a valid architecture.
-     */
-    public nodeArchToDotnetArch(nodeArchitecture : string, eventStream : IEventStream)
-    {
-        switch(nodeArchitecture)
-        {
-            case 'x64': {
-                return nodeArchitecture;
-            }
-            case 'ia32': {
-                return 'x86';
-            }
-            case 'x86': {
-                // In case the function is called twice
-                return 'x86';
-            }
-            case 'arm': {
-                return nodeArchitecture;
-            }
-            case 'arm64': {
-                return nodeArchitecture;
-            }
-            case 's390x': {
-                return 's390x';
-            }
-            default: {
-                eventStream.post(new DotnetCommandFallbackArchitectureEvent(`The architecture ${os.arch()} of the platform is unexpected, falling back to auto-arch.`));
-                return 'auto';
-            }
-        }
-    }
+   /**
+    * @param directoryToWipe the directory to delete all of the files in if privilege to do so exists.
+    * @param fileExtensionsToDelete - if undefined, delete all files. if not, delete only files with extensions in this array in lower case.
+    */
+   public wipeDirectory(directoryToWipe : string, eventStream? : IEventStream, fileExtensionsToDelete? : string[])
+   {
+       if(!fs.existsSync(directoryToWipe))
+       {
+           return;
+       }
 
-    /**
-     *
-     * @param nodeOS the OS in node style string of what to install
-     * @returns the OS in the style that .net / the .net install scripts expect
-     *
-     */
-    public nodeOSToDotnetOS(nodeOS : string, eventStream : IEventStream)
-    {
-        switch(nodeOS)
-        {
-            case 'win32': {
-                return 'win';
-            }
-            case 'darwin': {
-                return 'osx';
-            }
-            case 'linux': {
-                return nodeOS;
-            }
-            default: {
-                eventStream.post(new DotnetCommandFallbackOSEvent(`The OS ${os.platform()} of the platform is unexpected, falling back to auto-os.`));
-                return 'auto'
-            }
-        }
-    }
+       // Use rimraf to delete all of the items in a directory without the directory itself.
+       fs.readdirSync(directoryToWipe).forEach(f =>
+       {
+           try
+           {
+               if(!fileExtensionsToDelete || path.extname(f).toLocaleLowerCase() in fileExtensionsToDelete)
+               fs.rmSync(`${directoryToWipe}/${f}`);
+           }
+           catch(error : any)
+           {
+               eventStream?.post(new SuppressedAcquisitionError(error, `Failed to delete ${f} when marked for deletion.`));
+           }
+       });
+   }
 
-    /**
-     *
-     * @returns true if the process is running with admin privileges
-     */
-    public isElevated(eventStream? : IEventStream) : boolean
-    {
-        if(os.platform() !== 'win32')
-        {
-            try
-            {
-                const commandResult = proc.spawnSync('id', ['-u']);
-                return commandResult.status === 0;
-            }
-            catch(error : any)
-            {
-                eventStream?.post(new SuppressedAcquisitionError(error, `Failed to run 'id' to check for privilege, running without privilege.`))
-                return false;
-            }
-        }
+   /**
+    *
+    * @param nodeArchitecture the architecture in node style string of what to install
+    * @returns the architecture in the style that .net / the .net install scripts expect
+    *
+    * Node - amd64 is documented as an option for install scripts but its no longer used.
+    * s390x is also no longer used.
+    * ppc64le is supported but this version of node has no distinction of the endianness of the process.
+    * It has no mapping to mips or other node architectures.
+    *
+    * @remarks Falls back to string 'auto' if a mapping does not exist which is not a valid architecture.
+    */
+   public nodeArchToDotnetArch(nodeArchitecture : string, eventStream : IEventStream)
+   {
+       switch(nodeArchitecture)
+       {
+           case 'x64': {
+               return nodeArchitecture;
+           }
+           case 'ia32': {
+               return 'x86';
+           }
+           case 'x86': {
+               // In case the function is called twice
+               return 'x86';
+           }
+           case 'arm': {
+               return nodeArchitecture;
+           }
+           case 'arm64': {
+               return nodeArchitecture;
+           }
+           case 's390x': {
+               return 's390x';
+           }
+           default: {
+               eventStream.post(new DotnetCommandFallbackArchitectureEvent(`The architecture ${os.arch()} of the platform is unexpected, falling back to auto-arch.`));
+               return 'auto';
+           }
+       }
+   }
 
-        try
-        {
-            // If we can execute this command on Windows then we have admin rights.
-            proc.execFileSync( 'net', ['session'], { 'stdio': 'ignore' } );
-            return true;
-        }
-        catch ( error : any )
-        {
-            eventStream?.post(new SuppressedAcquisitionError(error, `Failed to run 'net' to check for privilege, running without privilege.`))
-            return false;
-        }
-    }
+   /**
+    *
+    * @param nodeOS the OS in node style string of what to install
+    * @returns the OS in the style that .net / the .net install scripts expect
+    *
+    */
+   public nodeOSToDotnetOS(nodeOS : string, eventStream : IEventStream)
+   {
+       switch(nodeOS)
+       {
+           case 'win32': {
+               return 'win';
+           }
+           case 'darwin': {
+               return 'osx';
+           }
+           case 'linux': {
+               return nodeOS;
+           }
+           default: {
+               eventStream.post(new DotnetCommandFallbackOSEvent(`The OS ${os.platform()} of the platform is unexpected, falling back to auto-os.`));
+               return 'auto'
+           }
+       }
+   }
 
-    private sha512Hasher(filePath : string)
-    {
-        return new Promise<string>((resolve, reject) =>
-        {
-            const hash = crypto.createHash('sha512');
-            const fileStream = fs.createReadStream(filePath);
-            fileStream.on('error', err => reject(err));
-            fileStream.on('data', chunk => hash.update(chunk));
-            fileStream.on('end', () => resolve(hash.digest('hex')));
-        })
-    };
+   /**
+    *
+    * @returns true if the process is running with admin privileges
+    */
+   public isElevated(eventStream? : IEventStream) : boolean
+   {
+       if(os.platform() !== 'win32')
+       {
+           try
+           {
+               const commandResult = proc.spawnSync('id', ['-u']);
+               return commandResult.status === 0;
+           }
+           catch(error : any)
+           {
+               eventStream?.post(new SuppressedAcquisitionError(error, `Failed to run 'id' to check for privilege, running without privilege.`))
+               return false;
+           }
+       }
 
-    public async getFileHash(filePath : string) : Promise<string | null>
-    {
-        const res = await this.sha512Hasher(filePath);
-        return res;
-    }
+       try
+       {
+           // If we can execute this command on Windows then we have admin rights.
+           proc.execFileSync( 'net', ['session'], { 'stdio': 'ignore' } );
+           return true;
+       }
+       catch ( error : any )
+       {
+           eventStream?.post(new SuppressedAcquisitionError(error, `Failed to run 'net' to check for privilege, running without privilege.`))
+           return false;
+       }
+   }
+
+   private sha512Hasher(filePath : string)
+   {
+       return new Promise<string>((resolve, reject) =>
+       {
+           const hash = crypto.createHash('sha512');
+           const fileStream = fs.createReadStream(filePath);
+           fileStream.on('error', err => reject(err));
+           fileStream.on('data', chunk => hash.update(chunk));
+           fileStream.on('end', () => resolve(hash.digest('hex')));
+       })
+   };
+
+   public async getFileHash(filePath : string) : Promise<string | null>
+   {
+       const res = await this.sha512Hasher(filePath);
+       return res;
+   }
 }
 

--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -25,7 +25,7 @@ import { DotnetCommandFallbackArchitectureEvent,
 
 export class FileUtilities extends IFileUtilities
 {
-   public async writeFileOntoDisk(scriptContent: string, filePath: string, alreadyHoldingLock : boolean = false, eventStream? : IEventStream)
+   public async writeFileOntoDisk(scriptContent: string, filePath: string, alreadyHoldingLock = false, eventStream? : IEventStream)
    {
        eventStream?.post(new DotnetFileWriteRequestEvent(`Request to write`, new Date().toISOString(), filePath));
 

--- a/vscode-dotnet-runtime-library/src/Utils/IFileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/IFileUtilities.ts
@@ -8,7 +8,7 @@ import { IEventStream } from '../EventStream/EventStream';
 
 export abstract class IFileUtilities
 {
-    public abstract writeFileOntoDisk(scriptContent: string, filePath: string, eventStream? : IEventStream) : void;
+    public abstract writeFileOntoDisk(scriptContent: string, filePath: string, alreadyHoldingLock : boolean, eventStream? : IEventStream) : void;
 
     /**
      * @param directoryToWipe the directory to delete all of the files in if privilege to do so exists.

--- a/vscode-dotnet-runtime-library/src/Utils/IFileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/IFileUtilities.ts
@@ -8,12 +8,12 @@ import { IEventStream } from '../EventStream/EventStream';
 
 export abstract class IFileUtilities
 {
-    public abstract writeFileOntoDisk(scriptContent: string, filePath: string, eventStream : IEventStream) : void;
+    public abstract writeFileOntoDisk(scriptContent: string, filePath: string, eventStream? : IEventStream) : void;
 
     /**
      * @param directoryToWipe the directory to delete all of the files in if privilege to do so exists.
      */
-    public abstract wipeDirectory(directoryToWipe : string, eventStream : IEventStream) : void;
+    public abstract wipeDirectory(directoryToWipe : string, eventStream? : IEventStream, fileExtensionsToDelete? : string[]) : void;
 
     /**
      *

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -480,7 +480,7 @@ export class MockDistroProvider extends IDistroDotnetSDKProvider
         return new GenericDistroSDKProvider(this.distroVersion, this.context, getMockUtilityContext()).JsonDotnetVersion(fullySpecifiedDotnetVersion);
     }
 
-    protected isPackageFoundInSearch(resultOfSearchCommand: any): boolean {
+    protected isPackageFoundInSearch(resultOfSearchCommand: any, searchCommandExitCode : string): boolean {
         return true;
     }
 }

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -335,6 +335,7 @@ export class MockCommandExecutor extends ICommandExecutor
 
         if(!command.runUnderSudo && this.fakeReturnValue === '')
         {
+            this.trueExecutor.returnStatus = this.returnStatus;
             return this.trueExecutor.execute(command, options);
         }
         else if(this.otherCommandsToMock.some(x => x.includes(command.commandRoot)))

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -368,9 +368,9 @@ export class MockFileUtilities extends IFileUtilities
 {
     private trueUtilities = new FileUtilities();
 
-    public writeFileOntoDisk(content : string, filePath : string)
+    public writeFileOntoDisk(content : string, filePath : string, alreadyHoldingLock = false)
     {
-        return this.trueUtilities.writeFileOntoDisk(content, filePath, new MockEventStream());
+        return this.trueUtilities.writeFileOntoDisk(content, filePath, alreadyHoldingLock, new MockEventStream());
     }
 
     public wipeDirectory(directoryToWipe : string, eventSteam : IEventStream, fileExtensionsToDelete? : string[])

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -373,9 +373,9 @@ export class MockFileUtilities extends IFileUtilities
         return this.trueUtilities.writeFileOntoDisk(content, filePath, new MockEventStream());
     }
 
-    public wipeDirectory(directoryToWipe : string, eventSteam : IEventStream)
+    public wipeDirectory(directoryToWipe : string, eventSteam : IEventStream, fileExtensionsToDelete? : string[])
     {
-        return this.trueUtilities.wipeDirectory(directoryToWipe, eventSteam);
+        return this.trueUtilities.wipeDirectory(directoryToWipe, eventSteam, fileExtensionsToDelete);
     }
 
     public isElevated()

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -104,7 +104,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             await provider.getInstalledGlobalDotnetPathIfExists(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'which dotnet');
+            assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/share/dotnet/dotnet');
         }
     }).timeout(standardTimeoutTime);
 
@@ -127,8 +127,8 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'apt-cache search --name-only ^dotnet-sdk-9.0$');
-            assert.equal(recVersion, '7.0.1xx');
+            assert.equal(mockExecutor.attemptedCommand, 'apt-cache search --names-only ^dotnet-sdk-9.0$', 'Searched for the newest package last with regex');
+            assert.equal(recVersion, '7.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -128,7 +128,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
             assert.equal(mockExecutor.attemptedCommand, 'dotnet --version', 'Searched for the newest package last with regex');
-            assert.equal(recVersion, '7.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
+            assert.equal(recVersion, '8.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -127,7 +127,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'apt-cache search dotnet-sdk-7.0');
+            assert.equal(mockExecutor.attemptedCommand, 'apt-cache search --name-only ^dotnet-sdk-9.0$');
             assert.equal(recVersion, '7.0.1xx');
         }
     }).timeout(standardTimeoutTime);

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -135,7 +135,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
     test('Gives Correct Version Support Info', async () => {
         if(shouldRun)
         {
-            let supported = await provider.isDotnetVersionSupported('8.0.101', installType);
+            let supported = await provider.isDotnetVersionSupported('11.0.101', installType);
             // In the mock data, 8.0 is not supported, so it should be false.
             assert.equal(supported, false);
             supported = await provider.isDotnetVersionSupported('7.0.101', installType);

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -104,7 +104,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             await provider.getInstalledGlobalDotnetPathIfExists(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/share/dotnet/dotnet');
+            assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/bin/dotnet');
         }
     }).timeout(standardTimeoutTime);
 
@@ -127,7 +127,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'apt-cache search --names-only ^dotnet-sdk-9.0$', 'Searched for the newest package last with regex');
+            assert.equal(mockExecutor.attemptedCommand, 'dotnet --version', 'Searched for the newest package last with regex');
             assert.equal(recVersion, '7.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
         }
     }).timeout(standardTimeoutTime);

--- a/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
@@ -131,7 +131,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
             assert.equal(mockExecutor.attemptedCommand, 'dotnet --version', 'Correct command run to get recommended version, uses newest package in distro json');
-            assert.equal(recVersion, '7.0.1xx', 'The most in support version is suggested : will eventually break if not updated');
+            assert.equal(recVersion, '8.0.1xx', 'The most in support version is suggested : will eventually break if not updated');
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
@@ -6,7 +6,7 @@
 import * as chai from 'chai';
 import * as os from 'os';
 import { MockCommandExecutor, MockEventStream } from '../mocks/MockObjects';
-import { DistroVersionPair, DotnetDistroSupportStatus } from '../../Acquisition/LinuxVersionResolver';
+import { DistroVersionPair, DotnetDistroSupportStatus, LinuxVersionResolver } from '../../Acquisition/LinuxVersionResolver';
 import { getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
 import { LinuxInstallType } from '../../Acquisition/LinuxInstallType';
 import { RedHatDistroSDKProvider } from '../../Acquisition/RedHatDistroSDKProvider';
@@ -18,7 +18,8 @@ const acquisitionContext = getMockAcquisitionContext(false, mockVersion);
 const mockExecutor = new MockCommandExecutor(acquisitionContext, getMockUtilityContext());
 const pair : DistroVersionPair = { distro : 'Red Hat Enterprise Linux', version : '9.0' };
 const provider : RedHatDistroSDKProvider = new RedHatDistroSDKProvider(pair, acquisitionContext, getMockUtilityContext(), mockExecutor);
-const shouldRun = os.platform() === 'linux';
+const versionResolver = new LinuxVersionResolver(acquisitionContext, getMockUtilityContext(), acquisitionContext.acquisitionContext!, mockExecutor);
+let shouldRun = os.platform() === 'linux';
 const installType : LinuxInstallType = 'sdk';
 const noDotnetString = `
 Command 'dotnet' not found, but can be installed with:
@@ -33,6 +34,8 @@ Command 'dotnet' not found, but can be installed with:
 suite('Red Hat For Linux Distro Logic Unit Tests', () =>
 {
     test('Package Check Succeeds', async () => {
+        shouldRun = os.platform() === 'linux' && (await versionResolver.getRunningDistro()).distro === 'Red Hat Enterprise Linux';
+
         if(shouldRun)
         {
             // assert this passes : we don't want the test to be reliant on machine state for whether the package exists or not, so don't check output
@@ -104,7 +107,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             await provider.getInstalledGlobalDotnetPathIfExists(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/share/dotnet/dotnet');
+            assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/bin/dotnet');
         }
     }).timeout(standardTimeoutTime);
 
@@ -127,7 +130,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'yum search dotnet-sdk-9.0 -q', 'Correct command run to get recommended version, uses newest package in distro json');
+            assert.equal(mockExecutor.attemptedCommand, 'dotnet --version', 'Correct command run to get recommended version, uses newest package in distro json');
             assert.equal(recVersion, '7.0.1xx', 'The most in support version is suggested : will eventually break if not updated');
         }
     }).timeout(standardTimeoutTime);

--- a/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
@@ -37,7 +37,7 @@ suite('Red Hat For Linux Distro Logic Unit Tests', () =>
         {
             // assert this passes : we don't want the test to be reliant on machine state for whether the package exists or not, so don't check output
             await provider.dotnetPackageExistsOnSystem(mockVersion, installType);
-            assert.equal(mockExecutor.attemptedCommand, 'yum list install dotnet-sdk-7.0 -q');
+            assert.equal(mockExecutor.attemptedCommand, 'yum list install dotnet-sdk-9.0 -q');
         }
     }).timeout(standardTimeoutTime);
 
@@ -127,7 +127,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'yum search dotnet-sdk-7.0 -q');
+            assert.equal(mockExecutor.attemptedCommand, 'yum search dotnet-sdk-9.0 -q');
             assert.equal(recVersion, '7.0.1xx');
         }
     }).timeout(standardTimeoutTime);
@@ -135,7 +135,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
     test('Gives Correct Version Support Info', async () => {
         if(shouldRun)
         {
-            let supported = await provider.isDotnetVersionSupported('8.0.101', installType);
+            let supported = await provider.isDotnetVersionSupported('11.0.101', installType);
             // In the mock data, 8.0 is not supported, so it should be false.
             assert.equal(supported, false);
             supported = await provider.isDotnetVersionSupported('7.0.101', installType);

--- a/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
@@ -104,7 +104,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             await provider.getInstalledGlobalDotnetPathIfExists(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'which dotnet');
+            assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/share/dotnet/dotnet');
         }
     }).timeout(standardTimeoutTime);
 
@@ -127,8 +127,8 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`;
         if(shouldRun)
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
-            assert.equal(mockExecutor.attemptedCommand, 'yum search dotnet-sdk-9.0 -q');
-            assert.equal(recVersion, '7.0.1xx');
+            assert.equal(mockExecutor.attemptedCommand, 'yum search dotnet-sdk-9.0 -q', 'Correct command run to get recommended version, uses newest package in distro json');
+            assert.equal(recVersion, '7.0.1xx', 'The most in support version is suggested : will eventually break if not updated');
         }
     }).timeout(standardTimeoutTime);
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1589
Currently, when the Linux SDK Global installs ask for permission, they need to ask it every single time a command is executed. This will change that problem by spawning a master process. The master process then communicates with the VS Code Extension over a shared user, non-world writeable folder.

The files exchanged are 'output', 'ok', 'command'. The OK file is used to ensure the process is alive, and if not, spawn it again.
The 'command' file is used to pass a command to the master process, which the process then cleans up. The 'output' is a txt file that is output by the process tells the extension to read the files representing stderr, stdout, and return status, like how current command execution in the extension works.

The master process is a shell script so that it can be platform agnostic and does not need a binary.

In addition, we validate that the commands requested are of a fixed set of commands passed to the master process upon creation and change the permissions of files in webpack so they are set from the very beginning. 