### PR TITLE
Use official templates so we get counted on the internal pie chart

### DIFF
--- a/1es-azure-pipeline.yml
+++ b/1es-azure-pipeline.yml
@@ -47,7 +47,7 @@ parameters:
     os: windows
 
 extends:
-  template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     sdl:
       sourceAnalysisPool:

--- a/1pr-azure-pipeline.yml
+++ b/1pr-azure-pipeline.yml
@@ -1,0 +1,67 @@
+# Name: dotnet.vscode-dotnet-runtime
+# URL: https://dev.azure.com/dnceng-public/public/_build?definitionId=60
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+  tags:
+    include:
+    - SDK-v*
+    - Runtime-v*
+pr:
+  autoCancel: false
+  branches:
+    include:
+    - '*'
+
+variables:
+- name: Codeql.Enabled
+  value: true
+
+# The public PR pool schema is different from the 1ES one. We use 'vmImage' which is a default azure pipeline schema. 'os' and 'name' have nothing to do with image selection here.
+# 1ES uses 'image' but defining an image this way using our public pools duseOneEngineeringPool not work as they aren't configured this way.
+# We can later add the flag 'useOneEngineeringPool' or one engineering system: false or true in all tasks to determine if we use vmImage or a 1es pool object.
+parameters:
+- name: pools
+  type: object
+  default:
+  - name: NetCore-Public
+    vmImage: ubuntu-latest
+    os: linux
+  - name: NetCore-Public
+    vmImage: macOS-latest
+    os: macOS
+  - name: NetCore-Public
+    vmImage: windows-latest
+    os: windows
+
+stages:
+- stage: o # o is just used so it looks like a bullet point in the output of devops
+  jobs:
+  - ${{ each image in parameters.pools }}:
+    - template: pipeline-templates/build-test.yaml
+      parameters:
+        pool:
+          vmImage: ${{ image.vmImage }}
+          os: ${{ image.os }}
+        useOneEngineeringPool: false
+  - template: pipeline-templates/upstream-verify.yaml
+    parameters:
+      pool:
+        vmImage: windows-latest
+        os: windows
+      useOneEngineeringPool: false
+  - template: pipeline-templates/lint.yaml
+    parameters:
+      pool:
+        vmImage: windows-latest
+        os: windows
+      useOneEngineeringPool: false
+  - template: pipeline-templates/package-vsix.yaml
+    parameters:
+      pool:
+        vmImage: windows-latest
+        os: windows
+      useOneEngineeringPool: false


### PR DESCRIPTION
The migration tool and doc examples all use the unofficial one ecks dee

Also create a dupe of the PR pipeline so we can migrate main to that file once it is checked in and then delete the other one to rename it to a more descriptive name.