### PR TITLE
Focus on Output Channel to Indicate Install Progress for Global SDK

### DIFF
--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -85,7 +85,7 @@ namespace commandKeys {
 
 const commandPrefix = 'dotnet';
 const configPrefix = 'dotnetAcquisitionExtension';
-const displayChannelName = '.NET Runtime';
+const displayChannelName = '.NET Install Tool';
 const defaultTimeoutValue = 600;
 const moreInfoUrl = 'https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md';
 let disableActivationUnderTest = true;
@@ -210,6 +210,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
             }
 
             const globalInstallerResolver = new GlobalInstallerResolver(sdkContext, commandContext.version);
+            outputChannel.show(true);
             const dotnetPath = await sdkAcquisitionWorker.acquireGlobalSDK(globalInstallerResolver);
 
             new CommandExecutor(sdkContext, utilContext).setPathEnvVar(dotnetPath.dotnetPath, moreInfoUrl, displayWorker, vsCodeExtensionContext, true);


### PR DESCRIPTION
Currently in DevKit when people try to install the SDK they have no indication of progress unless they manually find our tab in the output window, which no one will do. This requires user intervention to occur, so when they click download, we'd like to navigate them to our output window, and it should not be so disruptive. 

We cant do this in DevKit since VS Code does not have an API to call into others output channels.