### PR TITLE
Collect stack trace on axios error to diagnose better

### DIFF
--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -218,7 +218,7 @@ If you're on a proxy and disable registry access, you must set the proxy in our 
                 }
                 else
                 {
-                    const genericError = new Error(`Web Request to ${this.url} Failed: ${error.message}. Aborting. Please ensure that you are online.`);
+                    const genericError = new Error(`Web Request to ${this.url} Failed: ${error.message}. Aborting. Stack: ${'stack' in error ? error?.stack : 'unavailable.'}`);
                     this.context.eventStream.post(new WebRequestError(genericError, getInstallKeyFromContext(this.context.acquisitionContext)));
                     throw genericError;
                 }


### PR DESCRIPTION
This is a very simple change to allow our logs to get an error stack trace when axios fails. We have seen a lot of n r split is not a function and I believe this is a type error in either the axios or axios cache interceptor library. I cant tell where it is until we can get a repro with this info.

Manually tested it and it works.
