### PR TITLE
Update Is Online Lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,10 @@
 			"license": "MIT",
 			"dependencies": {
 				"rimraf": "^5.0.1",
-				"vsce": "2.11.0"
+				"vsce": "^2.15.0"
 			},
 			"devDependencies": {
 				"@types/source-map-support": "^0.5.6"
-			}
-		},
-		"node_modules/@types/source-map-support": {
-			"version": "0.5.6",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/source-map-support/-/source-map-support-0.5.6.tgz",
-			"integrity": "sha1-qkqMmOxzofHzCoE1c6myFUpus5o=",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"source-map": "^0.6.0"
 			}
 		},
 		"node_modules/@isaacs/cliui": {
@@ -49,6 +39,16 @@
 			"optional": true,
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/@types/source-map-support": {
+			"version": "0.5.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/source-map-support/-/source-map-support-0.5.6.tgz",
+			"integrity": "sha1-qkqMmOxzofHzCoE1c6myFUpus5o=",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"source-map": "^0.6.0"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -345,9 +345,9 @@
 			}
 		},
 		"node_modules/detect-libc": {
-			"version": "2.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.0.1.tgz",
-			"integrity": "sha1-4Yl6qI+mrRl4YpN/vARB7zUu4M0=",
+			"version": "2.0.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.0.3.tgz",
+			"integrity": "sha1-8M1QO0D5k5uJRpfRmtUIleMM9wA=",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
@@ -790,10 +790,13 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q=",
-			"license": "MIT"
+			"version": "1.2.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/minipass": {
 			"version": "7.0.2",
@@ -823,9 +826,9 @@
 			"license": "MIT"
 		},
 		"node_modules/node-abi": {
-			"version": "3.24.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.24.0.tgz",
-			"integrity": "sha1-udAzk6SfLH4UfQyZ8YDmgMJ8FZk=",
+			"version": "3.57.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.57.0.tgz",
+			"integrity": "sha1-13LLiZI2wKpGd40NJSVpF88V6xU=",
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"
@@ -835,9 +838,9 @@
 			}
 		},
 		"node_modules/node-abi/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha1-EsW2Sa/b+QSXB3luIqQCiBTOUj8=",
+			"version": "7.6.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha1-Gkak20v/zM2Xt0O1AFyDJfI9Ti0=",
 			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -969,9 +972,9 @@
 			"license": "MIT"
 		},
 		"node_modules/prebuild-install": {
-			"version": "7.1.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prebuild-install/-/prebuild-install-7.1.1.tgz",
-			"integrity": "sha1-3pfVs0pwoMgTNP0kZB8qFwI1LkU=",
+			"version": "7.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prebuild-install/-/prebuild-install-7.1.2.tgz",
+			"integrity": "sha1-pf2ZhvWmJR+8R+Hlxl3nHmjAoFY=",
 			"license": "MIT",
 			"dependencies": {
 				"detect-libc": "^2.0.0",
@@ -1047,9 +1050,9 @@
 			}
 		},
 		"node_modules/readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+			"version": "3.6.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -1145,15 +1148,15 @@
 			"license": "MIT"
 		},
 		"node_modules/sax": {
-			"version": "1.2.4",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+			"version": "1.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sax/-/sax-1.3.0.tgz",
+			"integrity": "sha1-pdvnfbO+BcnR7neF29PqneUVk9A=",
 			"license": "ISC"
 		},
 		"node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+			"version": "5.7.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
@@ -1499,9 +1502,9 @@
 			"license": "MIT"
 		},
 		"node_modules/vsce": {
-			"version": "2.11.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vsce/-/vsce-2.11.0.tgz",
-			"integrity": "sha1-5gqsWOz8OuxuQAJOE+qMjSl2Su8=",
+			"version": "2.15.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vsce/-/vsce-2.15.0.tgz",
+			"integrity": "sha1-SpkueFMgkqNKdVFDxrbCyry31yk=",
 			"license": "MIT",
 			"dependencies": {
 				"azure-devops-node-api": "^11.0.1",
@@ -1742,11 +1745,6 @@
 			"integrity": "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=",
 			"optional": true
 		},
-		"ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha1-MYPjj66aZdfLXlOUXNWJfQJgoGo="
-		},
 		"@types/source-map-support": {
 			"version": "0.5.6",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/source-map-support/-/source-map-support-0.5.6.tgz",
@@ -1755,6 +1753,11 @@
 			"requires": {
 				"source-map": "^0.6.0"
 			}
+		},
+		"ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha1-MYPjj66aZdfLXlOUXNWJfQJgoGo="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -1941,9 +1944,9 @@
 			"integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
 		},
 		"detect-libc": {
-			"version": "2.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.0.1.tgz",
-			"integrity": "sha1-4Yl6qI+mrRl4YpN/vARB7zUu4M0="
+			"version": "2.0.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.0.3.tgz",
+			"integrity": "sha1-8M1QO0D5k5uJRpfRmtUIleMM9wA="
 		},
 		"dom-serializer": {
 			"version": "2.0.0",
@@ -2224,9 +2227,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q="
+			"version": "1.2.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw="
 		},
 		"minipass": {
 			"version": "7.0.2",
@@ -2249,17 +2252,17 @@
 			"integrity": "sha1-sf3cCyxG44Cgt6dvmE3UfEGhOAY="
 		},
 		"node-abi": {
-			"version": "3.24.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.24.0.tgz",
-			"integrity": "sha1-udAzk6SfLH4UfQyZ8YDmgMJ8FZk=",
+			"version": "3.57.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.57.0.tgz",
+			"integrity": "sha1-13LLiZI2wKpGd40NJSVpF88V6xU=",
 			"requires": {
 				"semver": "^7.3.5"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha1-EsW2Sa/b+QSXB3luIqQCiBTOUj8=",
+					"version": "7.6.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.0.tgz",
+					"integrity": "sha1-Gkak20v/zM2Xt0O1AFyDJfI9Ti0=",
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -2349,9 +2352,9 @@
 			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
 		},
 		"prebuild-install": {
-			"version": "7.1.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prebuild-install/-/prebuild-install-7.1.1.tgz",
-			"integrity": "sha1-3pfVs0pwoMgTNP0kZB8qFwI1LkU=",
+			"version": "7.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prebuild-install/-/prebuild-install-7.1.2.tgz",
+			"integrity": "sha1-pf2ZhvWmJR+8R+Hlxl3nHmjAoFY=",
 			"requires": {
 				"detect-libc": "^2.0.0",
 				"expand-template": "^2.0.3",
@@ -2404,9 +2407,9 @@
 			}
 		},
 		"readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+			"version": "3.6.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
 			"requires": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -2457,14 +2460,14 @@
 			"integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
 		},
 		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+			"version": "1.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sax/-/sax-1.3.0.tgz",
+			"integrity": "sha1-pdvnfbO+BcnR7neF29PqneUVk9A="
 		},
 		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+			"version": "5.7.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg="
 		},
 		"shebang-command": {
 			"version": "2.0.0",
@@ -2684,9 +2687,9 @@
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"vsce": {
-			"version": "2.11.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vsce/-/vsce-2.11.0.tgz",
-			"integrity": "sha1-5gqsWOz8OuxuQAJOE+qMjSl2Su8=",
+			"version": "2.15.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vsce/-/vsce-2.15.0.tgz",
+			"integrity": "sha1-SpkueFMgkqNKdVFDxrbCyry31yk=",
 			"requires": {
 				"azure-devops-node-api": "^11.0.1",
 				"chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"dependencies": {
 		"rimraf": "^5.0.1",
-		"vsce": "2.11.0"
+		"vsce": "^2.15.0"
 	},
 	"devDependencies": {
 		"@types/source-map-support": "^0.5.6"

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -21,7 +21,6 @@
 				"got": "11.8.5",
 				"hmac-drbg": "^1.0.1",
 				"https-proxy-agent": "^7.0.2",
-				"is-online": "^10.0.0",
 				"mocha": "^9.1.3",
 				"open": "^8.4.0",
 				"public-ip": "5.0.0",
@@ -75,7 +74,6 @@
 				"got": "11.8.5",
 				"http-cache-semantics": "4.1.1",
 				"https-proxy-agent": "^7.0.2",
-				"is-online": "9.0.1",
 				"mocha": "^9.1.3",
 				"open": "^8.4.0",
 				"p-retry": "^4.6.1",
@@ -736,22 +734,6 @@
 				"node": ">= 6.0.0"
 			}
 		},
-		"node_modules/aggregate-error": {
-			"version": "4.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-4.0.1.tgz",
-			"integrity": "sha1-JQkf4Vc7ngvokq7aFcfGalRfdY4=",
-			"license": "MIT",
-			"dependencies": {
-				"clean-stack": "^4.0.0",
-				"indent-string": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv/-/ajv-6.12.6.tgz",
@@ -1168,33 +1150,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0"
-			}
-		},
-		"node_modules/clean-stack": {
-			"version": "4.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-4.2.0.tgz",
-			"integrity": "sha1-xGTkzeSseJ9OBzXF11vrSdezCzE=",
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "5.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/clean-stack/node_modules/escape-string-regexp": {
-			"version": "5.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-			"integrity": "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cliui": {
@@ -2303,18 +2258,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
@@ -2437,185 +2380,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
-			}
-		},
-		"node_modules/is-online": {
-			"version": "10.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-10.0.0.tgz",
-			"integrity": "sha1-XgLO6fgi/ZwZsGDw7L3HmNNylaM=",
-			"license": "MIT",
-			"dependencies": {
-				"got": "^12.1.0",
-				"p-any": "^4.0.0",
-				"p-timeout": "^5.1.0",
-				"public-ip": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-online/node_modules/@sindresorhus/is": {
-			"version": "5.6.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-5.6.0.tgz",
-			"integrity": "sha1-Qd1gk9NGUs3bXVve7gTq/DOCZmg=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/is?sponsor=1"
-			}
-		},
-		"node_modules/is-online/node_modules/@szmarczak/http-timer": {
-			"version": "5.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-			"integrity": "sha1-x8G/EUHN1HUbA5nI/HuLZkzVvjo=",
-			"license": "MIT",
-			"dependencies": {
-				"defer-to-connect": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=14.16"
-			}
-		},
-		"node_modules/is-online/node_modules/cacheable-lookup": {
-			"version": "7.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-			"integrity": "sha1-NHaoIV0EbloyAqkgndE/7B+TOic=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.16"
-			}
-		},
-		"node_modules/is-online/node_modules/cacheable-request": {
-			"version": "10.2.14",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.14.tgz",
-			"integrity": "sha1-65FbZl/aQbeWUngt8/VTRJxAa50=",
-			"license": "MIT",
-			"dependencies": {
-				"@types/http-cache-semantics": "^4.0.2",
-				"get-stream": "^6.0.1",
-				"http-cache-semantics": "^4.1.1",
-				"keyv": "^4.5.3",
-				"mimic-response": "^4.0.0",
-				"normalize-url": "^8.0.0",
-				"responselike": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			}
-		},
-		"node_modules/is-online/node_modules/get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-online/node_modules/got": {
-			"version": "12.6.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz",
-			"integrity": "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk=",
-			"license": "MIT",
-			"dependencies": {
-				"@sindresorhus/is": "^5.2.0",
-				"@szmarczak/http-timer": "^5.0.1",
-				"cacheable-lookup": "^7.0.0",
-				"cacheable-request": "^10.2.8",
-				"decompress-response": "^6.0.0",
-				"form-data-encoder": "^2.1.2",
-				"get-stream": "^6.0.1",
-				"http2-wrapper": "^2.1.10",
-				"lowercase-keys": "^3.0.0",
-				"p-cancelable": "^3.0.0",
-				"responselike": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/got?sponsor=1"
-			}
-		},
-		"node_modules/is-online/node_modules/http2-wrapper": {
-			"version": "2.2.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-			"integrity": "sha1-MQloFT3N7bFg2LchFDY+9fzh9ko=",
-			"license": "MIT",
-			"dependencies": {
-				"quick-lru": "^5.1.1",
-				"resolve-alpn": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=10.19.0"
-			}
-		},
-		"node_modules/is-online/node_modules/lowercase-keys": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-			"integrity": "sha1-xefUQuN+rSR66dsRep0KRnyJ1PI=",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-online/node_modules/mimic-response": {
-			"version": "4.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-4.0.0.tgz",
-			"integrity": "sha1-NUaLGefHXRD1Fl6iXnWlzup89w8=",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-online/node_modules/normalize-url": {
-			"version": "8.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.1.tgz",
-			"integrity": "sha1-m32Wr5g2V3xY9Yg+k5Nl+hViOko=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-online/node_modules/p-cancelable": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
-			"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.20"
-			}
-		},
-		"node_modules/is-online/node_modules/responselike": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-3.0.0.tgz",
-			"integrity": "sha1-IN7LbCmK/w2+4cNVypVGHUKCNiY=",
-			"license": "MIT",
-			"dependencies": {
-				"lowercase-keys": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-plain-obj": {
@@ -3212,31 +2976,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-any": {
-			"version": "4.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-4.0.0.tgz",
-			"integrity": "sha1-DpyLD6PljMeeahxscVqpMmtqREc=",
-			"license": "MIT",
-			"dependencies": {
-				"p-cancelable": "^3.0.0",
-				"p-some": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-any/node_modules/p-cancelable": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
-			"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.20"
-			}
-		},
 		"node_modules/p-cancelable": {
 			"version": "2.1.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -3271,43 +3010,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-some": {
-			"version": "6.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-6.0.0.tgz",
-			"integrity": "sha1-RhOoIgOKvhJeQhUuqfdwWnlnUm8=",
-			"license": "MIT",
-			"dependencies": {
-				"aggregate-error": "^4.0.0",
-				"p-cancelable": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-some/node_modules/p-cancelable": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
-			"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.20"
-			}
-		},
-		"node_modules/p-timeout": {
-			"version": "5.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-5.1.0.tgz",
-			"integrity": "sha1-s8aRz0QVE4zi2c/gcduhHw/uCFs=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5383,15 +5085,6 @@
 				"debug": "4"
 			}
 		},
-		"aggregate-error": {
-			"version": "4.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-4.0.1.tgz",
-			"integrity": "sha1-JQkf4Vc7ngvokq7aFcfGalRfdY4=",
-			"requires": {
-				"clean-stack": "^4.0.0",
-				"indent-string": "^5.0.0"
-			}
-		},
 		"ajv": {
 			"version": "6.12.6",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv/-/ajv-6.12.6.tgz",
@@ -5659,21 +5352,6 @@
 			"version": "1.0.3",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
 			"integrity": "sha1-EBXs7UdB4V0GZkqVfbv1DQQeJqw="
-		},
-		"clean-stack": {
-			"version": "4.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-4.2.0.tgz",
-			"integrity": "sha1-xGTkzeSseJ9OBzXF11vrSdezCzE=",
-			"requires": {
-				"escape-string-regexp": "5.0.0"
-			},
-			"dependencies": {
-				"escape-string-regexp": {
-					"version": "5.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-					"integrity": "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg="
-				}
-			}
 		},
 		"cliui": {
 			"version": "7.0.4",
@@ -6410,11 +6088,6 @@
 				"resolve-cwd": "^3.0.0"
 			}
 		},
-		"indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU="
-		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
@@ -6490,111 +6163,6 @@
 			"version": "7.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
-		},
-		"is-online": {
-			"version": "10.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-10.0.0.tgz",
-			"integrity": "sha1-XgLO6fgi/ZwZsGDw7L3HmNNylaM=",
-			"requires": {
-				"got": "^12.1.0",
-				"p-any": "^4.0.0",
-				"p-timeout": "^5.1.0",
-				"public-ip": "^5.0.0"
-			},
-			"dependencies": {
-				"@sindresorhus/is": {
-					"version": "5.6.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-5.6.0.tgz",
-					"integrity": "sha1-Qd1gk9NGUs3bXVve7gTq/DOCZmg="
-				},
-				"@szmarczak/http-timer": {
-					"version": "5.0.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-					"integrity": "sha1-x8G/EUHN1HUbA5nI/HuLZkzVvjo=",
-					"requires": {
-						"defer-to-connect": "^2.0.1"
-					}
-				},
-				"cacheable-lookup": {
-					"version": "7.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-					"integrity": "sha1-NHaoIV0EbloyAqkgndE/7B+TOic="
-				},
-				"cacheable-request": {
-					"version": "10.2.14",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.14.tgz",
-					"integrity": "sha1-65FbZl/aQbeWUngt8/VTRJxAa50=",
-					"requires": {
-						"@types/http-cache-semantics": "^4.0.2",
-						"get-stream": "^6.0.1",
-						"http-cache-semantics": "^4.1.1",
-						"keyv": "^4.5.3",
-						"mimic-response": "^4.0.0",
-						"normalize-url": "^8.0.0",
-						"responselike": "^3.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "6.0.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
-					"integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c="
-				},
-				"got": {
-					"version": "12.6.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz",
-					"integrity": "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk=",
-					"requires": {
-						"@sindresorhus/is": "^5.2.0",
-						"@szmarczak/http-timer": "^5.0.1",
-						"cacheable-lookup": "^7.0.0",
-						"cacheable-request": "^10.2.8",
-						"decompress-response": "^6.0.0",
-						"form-data-encoder": "^2.1.2",
-						"get-stream": "^6.0.1",
-						"http2-wrapper": "^2.1.10",
-						"lowercase-keys": "^3.0.0",
-						"p-cancelable": "^3.0.0",
-						"responselike": "^3.0.0"
-					}
-				},
-				"http2-wrapper": {
-					"version": "2.2.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-					"integrity": "sha1-MQloFT3N7bFg2LchFDY+9fzh9ko=",
-					"requires": {
-						"quick-lru": "^5.1.1",
-						"resolve-alpn": "^1.2.0"
-					}
-				},
-				"lowercase-keys": {
-					"version": "3.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-					"integrity": "sha1-xefUQuN+rSR66dsRep0KRnyJ1PI="
-				},
-				"mimic-response": {
-					"version": "4.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-4.0.0.tgz",
-					"integrity": "sha1-NUaLGefHXRD1Fl6iXnWlzup89w8="
-				},
-				"normalize-url": {
-					"version": "8.0.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.1.tgz",
-					"integrity": "sha1-m32Wr5g2V3xY9Yg+k5Nl+hViOko="
-				},
-				"p-cancelable": {
-					"version": "3.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
-					"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA="
-				},
-				"responselike": {
-					"version": "3.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-3.0.0.tgz",
-					"integrity": "sha1-IN7LbCmK/w2+4cNVypVGHUKCNiY=",
-					"requires": {
-						"lowercase-keys": "^3.0.0"
-					}
-				}
-			}
 		},
 		"is-plain-obj": {
 			"version": "2.1.0",
@@ -6990,22 +6558,6 @@
 				"is-wsl": "^2.2.0"
 			}
 		},
-		"p-any": {
-			"version": "4.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-4.0.0.tgz",
-			"integrity": "sha1-DpyLD6PljMeeahxscVqpMmtqREc=",
-			"requires": {
-				"p-cancelable": "^3.0.0",
-				"p-some": "^6.0.0"
-			},
-			"dependencies": {
-				"p-cancelable": {
-					"version": "3.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
-					"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA="
-				}
-			}
-		},
 		"p-cancelable": {
 			"version": "2.1.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -7026,27 +6578,6 @@
 			"requires": {
 				"p-limit": "^3.0.2"
 			}
-		},
-		"p-some": {
-			"version": "6.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-6.0.0.tgz",
-			"integrity": "sha1-RhOoIgOKvhJeQhUuqfdwWnlnUm8=",
-			"requires": {
-				"aggregate-error": "^4.0.0",
-				"p-cancelable": "^3.0.0"
-			},
-			"dependencies": {
-				"p-cancelable": {
-					"version": "3.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
-					"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA="
-				}
-			}
-		},
-		"p-timeout": {
-			"version": "5.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-5.1.0.tgz",
-			"integrity": "sha1-s8aRz0QVE4zi2c/gcduhHw/uCFs="
 		},
 		"p-try": {
 			"version": "2.2.0",
@@ -7856,7 +7387,6 @@
 				"got": "11.8.5",
 				"http-cache-semantics": "4.1.1",
 				"https-proxy-agent": "^7.0.2",
-				"is-online": "9.0.1",
 				"mocha": "^9.1.3",
 				"open": "^8.4.0",
 				"p-retry": "^4.6.1",

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -21,7 +21,7 @@
 				"got": "11.8.5",
 				"hmac-drbg": "^1.0.1",
 				"https-proxy-agent": "^7.0.2",
-				"is-online": "^9.0.1",
+				"is-online": "^10.0.0",
 				"mocha": "^9.1.3",
 				"open": "^8.4.0",
 				"public-ip": "5.0.0",
@@ -429,9 +429,9 @@
 			}
 		},
 		"node_modules/@types/http-cache-semantics": {
-			"version": "4.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI=",
+			"version": "4.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+			"integrity": "sha1-uXnrrTkZeZyXmxfHJiHAvAoxxsQ=",
 			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
@@ -737,16 +737,19 @@
 			}
 		},
 		"node_modules/aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+			"version": "4.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-4.0.1.tgz",
+			"integrity": "sha1-JQkf4Vc7ngvokq7aFcfGalRfdY4=",
 			"license": "MIT",
 			"dependencies": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
+				"clean-stack": "^4.0.0",
+				"indent-string": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ajv": {
@@ -1168,12 +1171,30 @@
 			}
 		},
 		"node_modules/clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
+			"version": "4.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-4.2.0.tgz",
+			"integrity": "sha1-xGTkzeSseJ9OBzXF11vrSdezCzE=",
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/clean-stack/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg=",
 			"license": "MIT",
 			"engines": {
-				"node": ">=6"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cliui": {
@@ -1467,12 +1488,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/duplexer3": {
-			"version": "0.1.5",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer3/-/duplexer3-0.1.5.tgz",
-			"integrity": "sha1-C15Ne61d6JAepEQGJMjh0gCZIX4=",
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.4.191",
@@ -1817,9 +1832,9 @@
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.5",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.5.tgz",
-			"integrity": "sha1-VNTW0GLA+n2dF/6wCEYVUOO6gCA=",
+			"version": "1.15.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
+			"integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs=",
 			"funding": [
 				{
 					"type": "individual",
@@ -2289,12 +2304,15 @@
 			}
 		},
 		"node_modules/indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
+			"version": "5.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU=",
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/inflight": {
@@ -2422,16 +2440,79 @@
 			}
 		},
 		"node_modules/is-online": {
-			"version": "9.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-9.0.1.tgz",
-			"integrity": "sha1-caNCAvqCa65vP/i+pCDFZXNEil8=",
+			"version": "10.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-10.0.0.tgz",
+			"integrity": "sha1-XgLO6fgi/ZwZsGDw7L3HmNNylaM=",
 			"license": "MIT",
 			"dependencies": {
-				"got": "^11.8.0",
-				"p-any": "^3.0.0",
-				"p-timeout": "^3.2.0",
-				"public-ip": "^4.0.4"
+				"got": "^12.1.0",
+				"p-any": "^4.0.0",
+				"p-timeout": "^5.1.0",
+				"public-ip": "^5.0.0"
 			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-online/node_modules/@sindresorhus/is": {
+			"version": "5.6.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-5.6.0.tgz",
+			"integrity": "sha1-Qd1gk9NGUs3bXVve7gTq/DOCZmg=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
+		"node_modules/is-online/node_modules/@szmarczak/http-timer": {
+			"version": "5.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+			"integrity": "sha1-x8G/EUHN1HUbA5nI/HuLZkzVvjo=",
+			"license": "MIT",
+			"dependencies": {
+				"defer-to-connect": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
+		"node_modules/is-online/node_modules/cacheable-lookup": {
+			"version": "7.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+			"integrity": "sha1-NHaoIV0EbloyAqkgndE/7B+TOic=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
+		"node_modules/is-online/node_modules/cacheable-request": {
+			"version": "10.2.14",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.14.tgz",
+			"integrity": "sha1-65FbZl/aQbeWUngt8/VTRJxAa50=",
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-cache-semantics": "^4.0.2",
+				"get-stream": "^6.0.1",
+				"http-cache-semantics": "^4.1.1",
+				"keyv": "^4.5.3",
+				"mimic-response": "^4.0.0",
+				"normalize-url": "^8.0.0",
+				"responselike": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
+		"node_modules/is-online/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -2439,172 +2520,102 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-online/node_modules/@sindresorhus/is": {
-			"version": "0.14.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/is-online/node_modules/@szmarczak/http-timer": {
-			"version": "1.1.2",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-			"integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
+		"node_modules/is-online/node_modules/got": {
+			"version": "12.6.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz",
+			"integrity": "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk=",
 			"license": "MIT",
 			"dependencies": {
-				"defer-to-connect": "^1.0.1"
+				"@sindresorhus/is": "^5.2.0",
+				"@szmarczak/http-timer": "^5.0.1",
+				"cacheable-lookup": "^7.0.0",
+				"cacheable-request": "^10.2.8",
+				"decompress-response": "^6.0.0",
+				"form-data-encoder": "^2.1.2",
+				"get-stream": "^6.0.1",
+				"http2-wrapper": "^2.1.10",
+				"lowercase-keys": "^3.0.0",
+				"p-cancelable": "^3.0.0",
+				"responselike": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
 			}
 		},
-		"node_modules/is-online/node_modules/cacheable-request": {
-			"version": "6.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-6.1.0.tgz",
-			"integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
+		"node_modules/is-online/node_modules/http2-wrapper": {
+			"version": "2.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+			"integrity": "sha1-MQloFT3N7bFg2LchFDY+9fzh9ko=",
 			"license": "MIT",
 			"dependencies": {
-				"clone-response": "^1.0.2",
-				"get-stream": "^5.1.0",
-				"http-cache-semantics": "^4.0.0",
-				"keyv": "^3.0.0",
-				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^4.1.0",
-				"responselike": "^1.0.2"
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.2.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10.19.0"
 			}
 		},
-		"node_modules/is-online/node_modules/decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"license": "MIT",
-			"dependencies": {
-				"mimic-response": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/is-online/node_modules/defer-to-connect": {
-			"version": "1.1.3",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-			"integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE=",
-			"license": "MIT"
-		},
-		"node_modules/is-online/node_modules/json-buffer": {
+		"node_modules/is-online/node_modules/lowercase-keys": {
 			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-			"license": "MIT"
-		},
-		"node_modules/is-online/node_modules/keyv": {
-			"version": "3.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-3.1.0.tgz",
-			"integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
-			"license": "MIT",
-			"dependencies": {
-				"json-buffer": "3.0.0"
-			}
-		},
-		"node_modules/is-online/node_modules/normalize-url": {
-			"version": "4.5.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-4.5.1.tgz",
-			"integrity": "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo=",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+			"integrity": "sha1-xefUQuN+rSR66dsRep0KRnyJ1PI=",
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/is-online/node_modules/p-cancelable": {
-			"version": "1.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/is-online/node_modules/public-ip": {
-			"version": "4.0.4",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-4.0.4.tgz",
-			"integrity": "sha1-s3hKWh/xuB0BW5oYRQvmX/2SnrM=",
-			"license": "MIT",
-			"dependencies": {
-				"dns-socket": "^4.2.2",
-				"got": "^9.6.0",
-				"is-ip": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-online/node_modules/public-ip/node_modules/get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+		"node_modules/is-online/node_modules/mimic-response": {
+			"version": "4.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-4.0.0.tgz",
+			"integrity": "sha1-NUaLGefHXRD1Fl6iXnWlzup89w8=",
 			"license": "MIT",
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
 			"engines": {
-				"node": ">=6"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-online/node_modules/public-ip/node_modules/got": {
-			"version": "9.6.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-9.6.0.tgz",
-			"integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
+		"node_modules/is-online/node_modules/normalize-url": {
+			"version": "8.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.1.tgz",
+			"integrity": "sha1-m32Wr5g2V3xY9Yg+k5Nl+hViOko=",
 			"license": "MIT",
-			"dependencies": {
-				"@sindresorhus/is": "^0.14.0",
-				"@szmarczak/http-timer": "^1.1.2",
-				"cacheable-request": "^6.0.0",
-				"decompress-response": "^3.3.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^4.1.0",
-				"lowercase-keys": "^1.0.1",
-				"mimic-response": "^1.0.1",
-				"p-cancelable": "^1.0.0",
-				"to-readable-stream": "^1.0.0",
-				"url-parse-lax": "^3.0.0"
-			},
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-online/node_modules/public-ip/node_modules/lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+		"node_modules/is-online/node_modules/p-cancelable": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
+			"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA=",
 			"license": "MIT",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=12.20"
 			}
 		},
 		"node_modules/is-online/node_modules/responselike": {
-			"version": "1.0.2",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-1.0.2.tgz",
-			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-3.0.0.tgz",
+			"integrity": "sha1-IN7LbCmK/w2+4cNVypVGHUKCNiY=",
 			"license": "MIT",
 			"dependencies": {
-				"lowercase-keys": "^1.0.0"
-			}
-		},
-		"node_modules/is-online/node_modules/responselike/node_modules/lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
-			"license": "MIT",
+				"lowercase-keys": "^3.0.0"
+			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-plain-obj": {
@@ -3202,19 +3213,28 @@
 			}
 		},
 		"node_modules/p-any": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-3.0.0.tgz",
-			"integrity": "sha1-eYR67tcLXToQ6mJSlsDD0ukKh7k=",
+			"version": "4.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-4.0.0.tgz",
+			"integrity": "sha1-DpyLD6PljMeeahxscVqpMmtqREc=",
 			"license": "MIT",
 			"dependencies": {
-				"p-cancelable": "^2.0.0",
-				"p-some": "^5.0.0"
+				"p-cancelable": "^3.0.0",
+				"p-some": "^6.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-any/node_modules/p-cancelable": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
+			"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20"
 			}
 		},
 		"node_modules/p-cancelable": {
@@ -3224,15 +3244,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/p-limit": {
@@ -3266,31 +3277,40 @@
 			}
 		},
 		"node_modules/p-some": {
-			"version": "5.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-5.0.0.tgz",
-			"integrity": "sha1-i3MMdLT+UWnXJkokCtAQtuvGhqQ=",
+			"version": "6.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-6.0.0.tgz",
+			"integrity": "sha1-RhOoIgOKvhJeQhUuqfdwWnlnUm8=",
 			"license": "MIT",
 			"dependencies": {
-				"aggregate-error": "^3.0.0",
-				"p-cancelable": "^2.0.0"
+				"aggregate-error": "^4.0.0",
+				"p-cancelable": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-timeout": {
-			"version": "3.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
+		"node_modules/p-some/node_modules/p-cancelable": {
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
+			"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA=",
 			"license": "MIT",
-			"dependencies": {
-				"p-finally": "^1.0.0"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12.20"
+			}
+		},
+		"node_modules/p-timeout": {
+			"version": "5.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-5.1.0.tgz",
+			"integrity": "sha1-s8aRz0QVE4zi2c/gcduhHw/uCFs=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-try": {
@@ -3447,15 +3467,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/prepend-http": {
-			"version": "2.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/process-nextick-args": {
@@ -4265,15 +4276,6 @@
 				"randombytes": "^2.1.0"
 			}
 		},
-		"node_modules/to-readable-stream": {
-			"version": "1.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4534,18 +4536,6 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
-			}
-		},
-		"node_modules/url-parse-lax": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"license": "MIT",
-			"dependencies": {
-				"prepend-http": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -5140,9 +5130,9 @@
 			}
 		},
 		"@types/http-cache-semantics": {
-			"version": "4.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI="
+			"version": "4.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+			"integrity": "sha1-uXnrrTkZeZyXmxfHJiHAvAoxxsQ="
 		},
 		"@types/json-schema": {
 			"version": "7.0.11",
@@ -5394,12 +5384,12 @@
 			}
 		},
 		"aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+			"version": "4.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-4.0.1.tgz",
+			"integrity": "sha1-JQkf4Vc7ngvokq7aFcfGalRfdY4=",
 			"requires": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
+				"clean-stack": "^4.0.0",
+				"indent-string": "^5.0.0"
 			}
 		},
 		"ajv": {
@@ -5671,9 +5661,19 @@
 			"integrity": "sha1-EBXs7UdB4V0GZkqVfbv1DQQeJqw="
 		},
 		"clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs="
+			"version": "4.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-4.2.0.tgz",
+			"integrity": "sha1-xGTkzeSseJ9OBzXF11vrSdezCzE=",
+			"requires": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "5.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+					"integrity": "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg="
+				}
+			}
 		},
 		"cliui": {
 			"version": "7.0.4",
@@ -5869,11 +5869,6 @@
 			"requires": {
 				"dns-packet": "^5.2.4"
 			}
-		},
-		"duplexer3": {
-			"version": "0.1.5",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer3/-/duplexer3-0.1.5.tgz",
-			"integrity": "sha1-C15Ne61d6JAepEQGJMjh0gCZIX4="
 		},
 		"electron-to-chromium": {
 			"version": "1.4.191",
@@ -6120,9 +6115,9 @@
 			"integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE="
 		},
 		"follow-redirects": {
-			"version": "1.15.5",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.5.tgz",
-			"integrity": "sha1-VNTW0GLA+n2dF/6wCEYVUOO6gCA="
+			"version": "1.15.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
+			"integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs="
 		},
 		"form-data": {
 			"version": "4.0.0",
@@ -6416,9 +6411,9 @@
 			}
 		},
 		"indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE="
+			"version": "5.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -6497,135 +6492,106 @@
 			"integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
 		},
 		"is-online": {
-			"version": "9.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-9.0.1.tgz",
-			"integrity": "sha1-caNCAvqCa65vP/i+pCDFZXNEil8=",
+			"version": "10.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-10.0.0.tgz",
+			"integrity": "sha1-XgLO6fgi/ZwZsGDw7L3HmNNylaM=",
 			"requires": {
-				"got": "^11.8.0",
-				"p-any": "^3.0.0",
-				"p-timeout": "^3.2.0",
-				"public-ip": "^4.0.4"
+				"got": "^12.1.0",
+				"p-any": "^4.0.0",
+				"p-timeout": "^5.1.0",
+				"public-ip": "^5.0.0"
 			},
 			"dependencies": {
 				"@sindresorhus/is": {
-					"version": "0.14.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-0.14.0.tgz",
-					"integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o="
+					"version": "5.6.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-5.6.0.tgz",
+					"integrity": "sha1-Qd1gk9NGUs3bXVve7gTq/DOCZmg="
 				},
 				"@szmarczak/http-timer": {
-					"version": "1.1.2",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-					"integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
+					"version": "5.0.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+					"integrity": "sha1-x8G/EUHN1HUbA5nI/HuLZkzVvjo=",
 					"requires": {
-						"defer-to-connect": "^1.0.1"
+						"defer-to-connect": "^2.0.1"
 					}
+				},
+				"cacheable-lookup": {
+					"version": "7.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+					"integrity": "sha1-NHaoIV0EbloyAqkgndE/7B+TOic="
 				},
 				"cacheable-request": {
-					"version": "6.1.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-6.1.0.tgz",
-					"integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
+					"version": "10.2.14",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.14.tgz",
+					"integrity": "sha1-65FbZl/aQbeWUngt8/VTRJxAa50=",
 					"requires": {
-						"clone-response": "^1.0.2",
-						"get-stream": "^5.1.0",
-						"http-cache-semantics": "^4.0.0",
-						"keyv": "^3.0.0",
-						"lowercase-keys": "^2.0.0",
-						"normalize-url": "^4.1.0",
-						"responselike": "^1.0.2"
+						"@types/http-cache-semantics": "^4.0.2",
+						"get-stream": "^6.0.1",
+						"http-cache-semantics": "^4.1.1",
+						"keyv": "^4.5.3",
+						"mimic-response": "^4.0.0",
+						"normalize-url": "^8.0.0",
+						"responselike": "^3.0.0"
 					}
 				},
-				"decompress-response": {
-					"version": "3.3.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-3.3.0.tgz",
-					"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+				"get-stream": {
+					"version": "6.0.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c="
+				},
+				"got": {
+					"version": "12.6.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz",
+					"integrity": "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk=",
 					"requires": {
-						"mimic-response": "^1.0.0"
+						"@sindresorhus/is": "^5.2.0",
+						"@szmarczak/http-timer": "^5.0.1",
+						"cacheable-lookup": "^7.0.0",
+						"cacheable-request": "^10.2.8",
+						"decompress-response": "^6.0.0",
+						"form-data-encoder": "^2.1.2",
+						"get-stream": "^6.0.1",
+						"http2-wrapper": "^2.1.10",
+						"lowercase-keys": "^3.0.0",
+						"p-cancelable": "^3.0.0",
+						"responselike": "^3.0.0"
 					}
 				},
-				"defer-to-connect": {
-					"version": "1.1.3",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-					"integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE="
+				"http2-wrapper": {
+					"version": "2.2.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+					"integrity": "sha1-MQloFT3N7bFg2LchFDY+9fzh9ko=",
+					"requires": {
+						"quick-lru": "^5.1.1",
+						"resolve-alpn": "^1.2.0"
+					}
 				},
-				"json-buffer": {
+				"lowercase-keys": {
 					"version": "3.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.0.tgz",
-					"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+					"integrity": "sha1-xefUQuN+rSR66dsRep0KRnyJ1PI="
 				},
-				"keyv": {
-					"version": "3.1.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-3.1.0.tgz",
-					"integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
-					"requires": {
-						"json-buffer": "3.0.0"
-					}
+				"mimic-response": {
+					"version": "4.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-4.0.0.tgz",
+					"integrity": "sha1-NUaLGefHXRD1Fl6iXnWlzup89w8="
 				},
 				"normalize-url": {
-					"version": "4.5.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-4.5.1.tgz",
-					"integrity": "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo="
+					"version": "8.0.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.1.tgz",
+					"integrity": "sha1-m32Wr5g2V3xY9Yg+k5Nl+hViOko="
 				},
 				"p-cancelable": {
-					"version": "1.1.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-1.1.0.tgz",
-					"integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw="
-				},
-				"public-ip": {
-					"version": "4.0.4",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-4.0.4.tgz",
-					"integrity": "sha1-s3hKWh/xuB0BW5oYRQvmX/2SnrM=",
-					"requires": {
-						"dns-socket": "^4.2.2",
-						"got": "^9.6.0",
-						"is-ip": "^3.1.0"
-					},
-					"dependencies": {
-						"get-stream": {
-							"version": "4.1.0",
-							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-4.1.0.tgz",
-							"integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
-							"requires": {
-								"pump": "^3.0.0"
-							}
-						},
-						"got": {
-							"version": "9.6.0",
-							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-9.6.0.tgz",
-							"integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
-							"requires": {
-								"@sindresorhus/is": "^0.14.0",
-								"@szmarczak/http-timer": "^1.1.2",
-								"cacheable-request": "^6.0.0",
-								"decompress-response": "^3.3.0",
-								"duplexer3": "^0.1.4",
-								"get-stream": "^4.1.0",
-								"lowercase-keys": "^1.0.1",
-								"mimic-response": "^1.0.1",
-								"p-cancelable": "^1.0.0",
-								"to-readable-stream": "^1.0.0",
-								"url-parse-lax": "^3.0.0"
-							}
-						},
-						"lowercase-keys": {
-							"version": "1.0.1",
-							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-							"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
-						}
-					}
+					"version": "3.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
+					"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA="
 				},
 				"responselike": {
-					"version": "1.0.2",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-1.0.2.tgz",
-					"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+					"version": "3.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-3.0.0.tgz",
+					"integrity": "sha1-IN7LbCmK/w2+4cNVypVGHUKCNiY=",
 					"requires": {
-						"lowercase-keys": "^1.0.0"
-					},
-					"dependencies": {
-						"lowercase-keys": {
-							"version": "1.0.1",
-							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-							"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
-						}
+						"lowercase-keys": "^3.0.0"
 					}
 				}
 			}
@@ -7025,23 +6991,25 @@
 			}
 		},
 		"p-any": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-3.0.0.tgz",
-			"integrity": "sha1-eYR67tcLXToQ6mJSlsDD0ukKh7k=",
+			"version": "4.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-4.0.0.tgz",
+			"integrity": "sha1-DpyLD6PljMeeahxscVqpMmtqREc=",
 			"requires": {
-				"p-cancelable": "^2.0.0",
-				"p-some": "^5.0.0"
+				"p-cancelable": "^3.0.0",
+				"p-some": "^6.0.0"
+			},
+			"dependencies": {
+				"p-cancelable": {
+					"version": "3.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
+					"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA="
+				}
 			}
 		},
 		"p-cancelable": {
 			"version": "2.1.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
 			"integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8="
-		},
-		"p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "3.1.0",
@@ -7060,21 +7028,25 @@
 			}
 		},
 		"p-some": {
-			"version": "5.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-5.0.0.tgz",
-			"integrity": "sha1-i3MMdLT+UWnXJkokCtAQtuvGhqQ=",
+			"version": "6.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-6.0.0.tgz",
+			"integrity": "sha1-RhOoIgOKvhJeQhUuqfdwWnlnUm8=",
 			"requires": {
-				"aggregate-error": "^3.0.0",
-				"p-cancelable": "^2.0.0"
+				"aggregate-error": "^4.0.0",
+				"p-cancelable": "^3.0.0"
+			},
+			"dependencies": {
+				"p-cancelable": {
+					"version": "3.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
+					"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA="
+				}
 			}
 		},
 		"p-timeout": {
-			"version": "3.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
-			"requires": {
-				"p-finally": "^1.0.0"
-			}
+			"version": "5.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-5.1.0.tgz",
+			"integrity": "sha1-s8aRz0QVE4zi2c/gcduhHw/uCFs="
 		},
 		"p-try": {
 			"version": "2.2.0",
@@ -7176,11 +7148,6 @@
 					}
 				}
 			}
-		},
-		"prepend-http": {
-			"version": "2.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
@@ -7686,11 +7653,6 @@
 				}
 			}
 		},
-		"to-readable-stream": {
-			"version": "1.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E="
-		},
 		"to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7859,14 +7821,6 @@
 			"integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
 			"requires": {
 				"punycode": "^2.1.0"
-			}
-		},
-		"url-parse-lax": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"requires": {
-				"prepend-http": "^2.0.0"
 			}
 		},
 		"util-deprecate": {

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -110,7 +110,6 @@
 		"got": "11.8.5",
 		"hmac-drbg": "^1.0.1",
 		"https-proxy-agent": "^7.0.2",
-		"is-online": "^10.0.0",
 		"mocha": "^9.1.3",
 		"open": "^8.4.0",
 		"public-ip": "5.0.0",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -110,7 +110,7 @@
 		"got": "11.8.5",
 		"hmac-drbg": "^1.0.1",
 		"https-proxy-agent": "^7.0.2",
-		"is-online": "^9.0.1",
+		"is-online": "^10.0.0",
 		"mocha": "^9.1.3",
 		"open": "^8.4.0",
 		"public-ip": "5.0.0",

--- a/vscode-dotnet-runtime-extension/yarn.lock
+++ b/vscode-dotnet-runtime-extension/yarn.lock
@@ -181,7 +181,7 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/http-cache-semantics@*", "@types/http-cache-semantics@^4.0.1", "@types/http-cache-semantics@^4.0.2":
+"@types/http-cache-semantics@*", "@types/http-cache-semantics@^4.0.1":
   "integrity" "sha1-uXnrrTkZeZyXmxfHJiHAvAoxxsQ="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz"
   "version" "4.0.4"
@@ -420,14 +420,6 @@
   dependencies:
     "debug" "4"
 
-"aggregate-error@^4.0.0":
-  "integrity" "sha1-JQkf4Vc7ngvokq7aFcfGalRfdY4="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-4.0.1.tgz"
-  "version" "4.0.1"
-  dependencies:
-    "clean-stack" "^4.0.0"
-    "indent-string" "^5.0.0"
-
 "ajv-keywords@^3.5.2":
   "integrity" "sha1-MfKdpatuANHC0yms97WSlhTVAU0="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv-keywords/-/ajv-keywords-3.5.2.tgz"
@@ -611,11 +603,11 @@
   "version" "7.0.0"
 
 "cacheable-request@^10.2.8":
-  "integrity" "sha1-65FbZl/aQbeWUngt8/VTRJxAa50="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.14.tgz"
-  "version" "10.2.14"
+  "integrity" "sha1-twErtKKs2xjLVNLf91HXZrNQCEI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.13.tgz"
+  "version" "10.2.13"
   dependencies:
-    "@types/http-cache-semantics" "^4.0.2"
+    "@types/http-cache-semantics" "^4.0.1"
     "get-stream" "^6.0.1"
     "http-cache-semantics" "^4.1.1"
     "keyv" "^4.5.3"
@@ -722,13 +714,6 @@
   "integrity" "sha1-EBXs7UdB4V0GZkqVfbv1DQQeJqw="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz"
   "version" "1.0.3"
-
-"clean-stack@^4.0.0":
-  "integrity" "sha1-xGTkzeSseJ9OBzXF11vrSdezCzE="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-4.2.0.tgz"
-  "version" "4.2.0"
-  dependencies:
-    "escape-string-regexp" "5.0.0"
 
 "cliui@^7.0.2":
   "integrity" "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08="
@@ -980,11 +965,6 @@
   "integrity" "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   "version" "4.0.0"
-
-"escape-string-regexp@5.0.0":
-  "integrity" "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz"
-  "version" "5.0.0"
 
 "eslint-scope@5.1.1":
   "integrity" "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw="
@@ -1280,23 +1260,6 @@
     "p-cancelable" "^3.0.0"
     "responselike" "^3.0.0"
 
-"got@^12.1.0":
-  "integrity" "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz"
-  "version" "12.6.1"
-  dependencies:
-    "@sindresorhus/is" "^5.2.0"
-    "@szmarczak/http-timer" "^5.0.1"
-    "cacheable-lookup" "^7.0.0"
-    "cacheable-request" "^10.2.8"
-    "decompress-response" "^6.0.0"
-    "form-data-encoder" "^2.1.2"
-    "get-stream" "^6.0.1"
-    "http2-wrapper" "^2.1.10"
-    "lowercase-keys" "^3.0.0"
-    "p-cancelable" "^3.0.0"
-    "responselike" "^3.0.0"
-
 "got@11.8.5":
   "integrity" "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz"
@@ -1417,9 +1380,9 @@
     "resolve-alpn" "^1.0.0"
 
 "http2-wrapper@^2.1.10":
-  "integrity" "sha1-MQloFT3N7bFg2LchFDY+9fzh9ko="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.1.tgz"
-  "version" "2.2.1"
+  "integrity" "sha1-uArRmdIWt9NoAZUHe9e5Bg+p1/M="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.0.tgz"
+  "version" "2.2.0"
   dependencies:
     "quick-lru" "^5.1.1"
     "resolve-alpn" "^1.2.0"
@@ -1462,11 +1425,6 @@
   dependencies:
     "pkg-dir" "^4.2.0"
     "resolve-cwd" "^3.0.0"
-
-"indent-string@^5.0.0":
-  "integrity" "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz"
-  "version" "5.0.0"
 
 "inflight@^1.0.4":
   "integrity" "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
@@ -1543,16 +1501,6 @@
   "integrity" "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz"
   "version" "7.0.0"
-
-"is-online@^10.0.0":
-  "integrity" "sha1-XgLO6fgi/ZwZsGDw7L3HmNNylaM="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-10.0.0.tgz"
-  "version" "10.0.0"
-  dependencies:
-    "got" "^12.1.0"
-    "p-any" "^4.0.0"
-    "p-timeout" "^5.1.0"
-    "public-ip" "^5.0.0"
 
 "is-plain-obj@^2.1.0":
   "integrity" "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc="
@@ -1902,9 +1850,9 @@
   "version" "6.1.0"
 
 "normalize-url@^8.0.0":
-  "integrity" "sha1-m32Wr5g2V3xY9Yg+k5Nl+hViOko="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.1.tgz"
-  "version" "8.0.1"
+  "integrity" "sha1-WT29KE90Po3Pal3fj63/FJyCcBo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.0.tgz"
+  "version" "8.0.0"
 
 "npm-run-path@^4.0.1":
   "integrity" "sha1-t+zR5e1T2o43pV4cImnguX7XSOo="
@@ -1940,14 +1888,6 @@
     "define-lazy-prop" "^2.0.0"
     "is-docker" "^2.1.1"
     "is-wsl" "^2.2.0"
-
-"p-any@^4.0.0":
-  "integrity" "sha1-DpyLD6PljMeeahxscVqpMmtqREc="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-4.0.0.tgz"
-  "version" "4.0.0"
-  dependencies:
-    "p-cancelable" "^3.0.0"
-    "p-some" "^6.0.0"
 
 "p-cancelable@^2.0.0":
   "integrity" "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8="
@@ -1986,19 +1926,6 @@
   "version" "5.0.0"
   dependencies:
     "p-limit" "^3.0.2"
-
-"p-some@^6.0.0":
-  "integrity" "sha1-RhOoIgOKvhJeQhUuqfdwWnlnUm8="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-6.0.0.tgz"
-  "version" "6.0.0"
-  dependencies:
-    "aggregate-error" "^4.0.0"
-    "p-cancelable" "^3.0.0"
-
-"p-timeout@^5.1.0":
-  "integrity" "sha1-s8aRz0QVE4zi2c/gcduhHw/uCFs="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-5.1.0.tgz"
-  "version" "5.1.0"
 
 "p-try@^2.0.0":
   "integrity" "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
@@ -2077,7 +2004,7 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
   "version" "1.1.0"
 
-"public-ip@^5.0.0", "public-ip@5.0.0":
+"public-ip@5.0.0":
   "integrity" "sha1-s5L8yIVSw7NpM6KGBolIgWUV+So="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-5.0.0.tgz"
   "version" "5.0.0"
@@ -2567,7 +2494,6 @@
     "got" "11.8.5"
     "http-cache-semantics" "4.1.1"
     "https-proxy-agent" "^7.0.2"
-    "is-online" "9.0.1"
     "mocha" "^9.1.3"
     "open" "^8.4.0"
     "p-retry" "^4.6.1"

--- a/vscode-dotnet-runtime-extension/yarn.lock
+++ b/vscode-dotnet-runtime-extension/yarn.lock
@@ -101,11 +101,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     "fastq" "^1.6.0"
 
-"@sindresorhus/is@^0.14.0":
-  "integrity" "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-0.14.0.tgz"
-  "version" "0.14.0"
-
 "@sindresorhus/is@^4.0.0":
   "integrity" "sha1-PHycRuZ4/u/nouW7YJ09vWZf+z8="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-4.6.0.tgz"
@@ -115,13 +110,6 @@
   "integrity" "sha1-Qd1gk9NGUs3bXVve7gTq/DOCZmg="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-5.6.0.tgz"
   "version" "5.6.0"
-
-"@szmarczak/http-timer@^1.1.2":
-  "integrity" "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-1.1.2.tgz"
-  "version" "1.1.2"
-  dependencies:
-    "defer-to-connect" "^1.0.1"
 
 "@szmarczak/http-timer@^4.0.5":
   "integrity" "sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac="
@@ -193,10 +181,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/http-cache-semantics@*", "@types/http-cache-semantics@^4.0.1":
-  "integrity" "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz"
-  "version" "4.0.1"
+"@types/http-cache-semantics@*", "@types/http-cache-semantics@^4.0.1", "@types/http-cache-semantics@^4.0.2":
+  "integrity" "sha1-uXnrrTkZeZyXmxfHJiHAvAoxxsQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz"
+  "version" "4.0.4"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.8":
   "integrity" "sha1-1CG2xSejA398hEM/0sQingFoY9M="
@@ -432,13 +420,13 @@
   dependencies:
     "debug" "4"
 
-"aggregate-error@^3.0.0":
-  "integrity" "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz"
-  "version" "3.1.0"
+"aggregate-error@^4.0.0":
+  "integrity" "sha1-JQkf4Vc7ngvokq7aFcfGalRfdY4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-4.0.1.tgz"
+  "version" "4.0.1"
   dependencies:
-    "clean-stack" "^2.0.0"
-    "indent-string" "^4.0.0"
+    "clean-stack" "^4.0.0"
+    "indent-string" "^5.0.0"
 
 "ajv-keywords@^3.5.2":
   "integrity" "sha1-MfKdpatuANHC0yms97WSlhTVAU0="
@@ -623,30 +611,17 @@
   "version" "7.0.0"
 
 "cacheable-request@^10.2.8":
-  "integrity" "sha1-twErtKKs2xjLVNLf91HXZrNQCEI="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.13.tgz"
-  "version" "10.2.13"
+  "integrity" "sha1-65FbZl/aQbeWUngt8/VTRJxAa50="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.14.tgz"
+  "version" "10.2.14"
   dependencies:
-    "@types/http-cache-semantics" "^4.0.1"
+    "@types/http-cache-semantics" "^4.0.2"
     "get-stream" "^6.0.1"
     "http-cache-semantics" "^4.1.1"
     "keyv" "^4.5.3"
     "mimic-response" "^4.0.0"
     "normalize-url" "^8.0.0"
     "responselike" "^3.0.0"
-
-"cacheable-request@^6.0.0":
-  "integrity" "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-6.1.0.tgz"
-  "version" "6.1.0"
-  dependencies:
-    "clone-response" "^1.0.2"
-    "get-stream" "^5.1.0"
-    "http-cache-semantics" "^4.0.0"
-    "keyv" "^3.0.0"
-    "lowercase-keys" "^2.0.0"
-    "normalize-url" "^4.1.0"
-    "responselike" "^1.0.2"
 
 "cacheable-request@^7.0.2":
   "integrity" "sha1-6g0LiJNkolhUdXMByhKy2nf5HSc="
@@ -748,10 +723,12 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz"
   "version" "1.0.3"
 
-"clean-stack@^2.0.0":
-  "integrity" "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz"
-  "version" "2.2.0"
+"clean-stack@^4.0.0":
+  "integrity" "sha1-xGTkzeSseJ9OBzXF11vrSdezCzE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-4.2.0.tgz"
+  "version" "4.2.0"
+  dependencies:
+    "escape-string-regexp" "5.0.0"
 
 "cliui@^7.0.2":
   "integrity" "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08="
@@ -875,13 +852,6 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decamelize/-/decamelize-4.0.0.tgz"
   "version" "4.0.0"
 
-"decompress-response@^3.3.0":
-  "integrity" "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-3.3.0.tgz"
-  "version" "3.3.0"
-  dependencies:
-    "mimic-response" "^1.0.0"
-
 "decompress-response@^6.0.0":
   "integrity" "sha1-yjh2Et234QS9FthaqwDV7PCcZvw="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz"
@@ -895,11 +865,6 @@
   "version" "3.0.1"
   dependencies:
     "type-detect" "^4.0.0"
-
-"defer-to-connect@^1.0.1":
-  "integrity" "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-1.1.3.tgz"
-  "version" "1.1.3"
 
 "defer-to-connect@^2.0.0", "defer-to-connect@^2.0.1":
   "integrity" "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc="
@@ -961,11 +926,6 @@
   dependencies:
     "dns-packet" "^5.2.4"
 
-"duplexer3@^0.1.4":
-  "integrity" "sha1-C15Ne61d6JAepEQGJMjh0gCZIX4="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer3/-/duplexer3-0.1.5.tgz"
-  "version" "0.1.5"
-
 "electron-to-chromium@^1.4.188":
   "integrity" "sha1-Ad1L8yUCpIziS/OJC1VTocX5NTk="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.191.tgz"
@@ -1020,6 +980,11 @@
   "integrity" "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   "version" "4.0.0"
+
+"escape-string-regexp@5.0.0":
+  "integrity" "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz"
+  "version" "5.0.0"
 
 "eslint-scope@5.1.1":
   "integrity" "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw="
@@ -1164,9 +1129,9 @@
   "version" "5.0.2"
 
 "follow-redirects@^1.15.4":
-  "integrity" "sha1-VNTW0GLA+n2dF/6wCEYVUOO6gCA="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.5.tgz"
-  "version" "1.15.5"
+  "integrity" "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz"
+  "version" "1.15.6"
 
 "form-data-encoder@^2.1.2":
   "integrity" "sha1-Jh6jXSpw1I0w7HqWAxMPpVFenNU="
@@ -1211,13 +1176,6 @@
     "has-proto" "^1.0.1"
     "has-symbols" "^1.0.3"
     "hasown" "^2.0.0"
-
-"get-stream@^4.1.0":
-  "integrity" "sha1-wbJVV189wh1Zv8ec09K0axw6VLU="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-4.1.0.tgz"
-  "version" "4.1.0"
-  dependencies:
-    "pump" "^3.0.0"
 
 "get-stream@^5.1.0":
   "integrity" "sha1-SWaheV7lrOZecGxLe+txJX1uItM="
@@ -1305,23 +1263,6 @@
   dependencies:
     "get-intrinsic" "^1.1.3"
 
-"got@^11.8.0", "got@11.8.5":
-  "integrity" "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz"
-  "version" "11.8.5"
-  dependencies:
-    "@sindresorhus/is" "^4.0.0"
-    "@szmarczak/http-timer" "^4.0.5"
-    "@types/cacheable-request" "^6.0.1"
-    "@types/responselike" "^1.0.0"
-    "cacheable-lookup" "^5.0.3"
-    "cacheable-request" "^7.0.2"
-    "decompress-response" "^6.0.0"
-    "http2-wrapper" "^1.0.0-beta.5.2"
-    "lowercase-keys" "^2.0.0"
-    "p-cancelable" "^2.0.0"
-    "responselike" "^2.0.0"
-
 "got@^12.0.0":
   "integrity" "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz"
@@ -1339,22 +1280,39 @@
     "p-cancelable" "^3.0.0"
     "responselike" "^3.0.0"
 
-"got@^9.6.0":
-  "integrity" "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-9.6.0.tgz"
-  "version" "9.6.0"
+"got@^12.1.0":
+  "integrity" "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz"
+  "version" "12.6.1"
   dependencies:
-    "@sindresorhus/is" "^0.14.0"
-    "@szmarczak/http-timer" "^1.1.2"
-    "cacheable-request" "^6.0.0"
-    "decompress-response" "^3.3.0"
-    "duplexer3" "^0.1.4"
-    "get-stream" "^4.1.0"
-    "lowercase-keys" "^1.0.1"
-    "mimic-response" "^1.0.1"
-    "p-cancelable" "^1.0.0"
-    "to-readable-stream" "^1.0.0"
-    "url-parse-lax" "^3.0.0"
+    "@sindresorhus/is" "^5.2.0"
+    "@szmarczak/http-timer" "^5.0.1"
+    "cacheable-lookup" "^7.0.0"
+    "cacheable-request" "^10.2.8"
+    "decompress-response" "^6.0.0"
+    "form-data-encoder" "^2.1.2"
+    "get-stream" "^6.0.1"
+    "http2-wrapper" "^2.1.10"
+    "lowercase-keys" "^3.0.0"
+    "p-cancelable" "^3.0.0"
+    "responselike" "^3.0.0"
+
+"got@11.8.5":
+  "integrity" "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz"
+  "version" "11.8.5"
+  dependencies:
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    "cacheable-lookup" "^5.0.3"
+    "cacheable-request" "^7.0.2"
+    "decompress-response" "^6.0.0"
+    "http2-wrapper" "^1.0.0-beta.5.2"
+    "lowercase-keys" "^2.0.0"
+    "p-cancelable" "^2.0.0"
+    "responselike" "^2.0.0"
 
 "graceful-fs@^4.1.2", "graceful-fs@^4.2.4", "graceful-fs@^4.2.9":
   "integrity" "sha1-FH06AG2kyjzhRyjHrvwofDZ9emw="
@@ -1459,9 +1417,9 @@
     "resolve-alpn" "^1.0.0"
 
 "http2-wrapper@^2.1.10":
-  "integrity" "sha1-uArRmdIWt9NoAZUHe9e5Bg+p1/M="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.0.tgz"
-  "version" "2.2.0"
+  "integrity" "sha1-MQloFT3N7bFg2LchFDY+9fzh9ko="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.1.tgz"
+  "version" "2.2.1"
   dependencies:
     "quick-lru" "^5.1.1"
     "resolve-alpn" "^1.2.0"
@@ -1505,10 +1463,10 @@
     "pkg-dir" "^4.2.0"
     "resolve-cwd" "^3.0.0"
 
-"indent-string@^4.0.0":
-  "integrity" "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-4.0.0.tgz"
-  "version" "4.0.0"
+"indent-string@^5.0.0":
+  "integrity" "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz"
+  "version" "5.0.0"
 
 "inflight@^1.0.4":
   "integrity" "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
@@ -1586,15 +1544,15 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz"
   "version" "7.0.0"
 
-"is-online@^9.0.1":
-  "integrity" "sha1-caNCAvqCa65vP/i+pCDFZXNEil8="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-9.0.1.tgz"
-  "version" "9.0.1"
+"is-online@^10.0.0":
+  "integrity" "sha1-XgLO6fgi/ZwZsGDw7L3HmNNylaM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-10.0.0.tgz"
+  "version" "10.0.0"
   dependencies:
-    "got" "^11.8.0"
-    "p-any" "^3.0.0"
-    "p-timeout" "^3.2.0"
-    "public-ip" "^4.0.4"
+    "got" "^12.1.0"
+    "p-any" "^4.0.0"
+    "p-timeout" "^5.1.0"
+    "public-ip" "^5.0.0"
 
 "is-plain-obj@^2.1.0":
   "integrity" "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc="
@@ -1687,11 +1645,6 @@
   dependencies:
     "argparse" "^2.0.1"
 
-"json-buffer@3.0.0":
-  "integrity" "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.0.tgz"
-  "version" "3.0.0"
-
 "json-buffer@3.0.1":
   "integrity" "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz"
@@ -1716,13 +1669,6 @@
     "pako" "~1.0.2"
     "readable-stream" "~2.3.6"
     "setimmediate" "^1.0.5"
-
-"keyv@^3.0.0":
-  "integrity" "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-3.1.0.tgz"
-  "version" "3.1.0"
-  dependencies:
-    "json-buffer" "3.0.0"
 
 "keyv@^4.0.0", "keyv@^4.5.3":
   "integrity" "sha1-AIc9KwRt9zeWMVe9BPKUyoGMnCU="
@@ -1774,16 +1720,6 @@
   dependencies:
     "chalk" "^4.1.0"
     "is-unicode-supported" "^0.1.0"
-
-"lowercase-keys@^1.0.0":
-  "integrity" "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz"
-  "version" "1.0.1"
-
-"lowercase-keys@^1.0.1":
-  "integrity" "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz"
-  "version" "1.0.1"
 
 "lowercase-keys@^2.0.0":
   "integrity" "sha1-JgPni3tLAAbLyi+8yKMgJVislHk="
@@ -1837,7 +1773,7 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz"
   "version" "2.1.0"
 
-"mimic-response@^1.0.0", "mimic-response@^1.0.1":
+"mimic-response@^1.0.0":
   "integrity" "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-1.0.1.tgz"
   "version" "1.0.1"
@@ -1960,20 +1896,15 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz"
   "version" "3.0.0"
 
-"normalize-url@^4.1.0":
-  "integrity" "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-4.5.1.tgz"
-  "version" "4.5.1"
-
 "normalize-url@^6.0.1":
   "integrity" "sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-6.1.0.tgz"
   "version" "6.1.0"
 
 "normalize-url@^8.0.0":
-  "integrity" "sha1-WT29KE90Po3Pal3fj63/FJyCcBo="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.0.tgz"
-  "version" "8.0.0"
+  "integrity" "sha1-m32Wr5g2V3xY9Yg+k5Nl+hViOko="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.1.tgz"
+  "version" "8.0.1"
 
 "npm-run-path@^4.0.1":
   "integrity" "sha1-t+zR5e1T2o43pV4cImnguX7XSOo="
@@ -2010,18 +1941,13 @@
     "is-docker" "^2.1.1"
     "is-wsl" "^2.2.0"
 
-"p-any@^3.0.0":
-  "integrity" "sha1-eYR67tcLXToQ6mJSlsDD0ukKh7k="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-3.0.0.tgz"
-  "version" "3.0.0"
+"p-any@^4.0.0":
+  "integrity" "sha1-DpyLD6PljMeeahxscVqpMmtqREc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-4.0.0.tgz"
+  "version" "4.0.0"
   dependencies:
-    "p-cancelable" "^2.0.0"
-    "p-some" "^5.0.0"
-
-"p-cancelable@^1.0.0":
-  "integrity" "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-1.1.0.tgz"
-  "version" "1.1.0"
+    "p-cancelable" "^3.0.0"
+    "p-some" "^6.0.0"
 
 "p-cancelable@^2.0.0":
   "integrity" "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8="
@@ -2032,11 +1958,6 @@
   "integrity" "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz"
   "version" "3.0.0"
-
-"p-finally@^1.0.0":
-  "integrity" "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz"
-  "version" "1.0.0"
 
 "p-limit@^2.2.0":
   "integrity" "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE="
@@ -2066,20 +1987,18 @@
   dependencies:
     "p-limit" "^3.0.2"
 
-"p-some@^5.0.0":
-  "integrity" "sha1-i3MMdLT+UWnXJkokCtAQtuvGhqQ="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-5.0.0.tgz"
-  "version" "5.0.0"
+"p-some@^6.0.0":
+  "integrity" "sha1-RhOoIgOKvhJeQhUuqfdwWnlnUm8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    "aggregate-error" "^3.0.0"
-    "p-cancelable" "^2.0.0"
+    "aggregate-error" "^4.0.0"
+    "p-cancelable" "^3.0.0"
 
-"p-timeout@^3.2.0":
-  "integrity" "sha1-x+F6vJcdKnli74NiazXWNazyPf4="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz"
-  "version" "3.2.0"
-  dependencies:
-    "p-finally" "^1.0.0"
+"p-timeout@^5.1.0":
+  "integrity" "sha1-s8aRz0QVE4zi2c/gcduhHw/uCFs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-5.1.0.tgz"
+  "version" "5.1.0"
 
 "p-try@^2.0.0":
   "integrity" "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
@@ -2138,11 +2057,6 @@
   dependencies:
     "find-up" "^4.0.0"
 
-"prepend-http@^2.0.0":
-  "integrity" "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prepend-http/-/prepend-http-2.0.0.tgz"
-  "version" "2.0.0"
-
 "process-nextick-args@~2.0.0":
   "integrity" "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
@@ -2163,16 +2077,7 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
   "version" "1.1.0"
 
-"public-ip@^4.0.4":
-  "integrity" "sha1-s3hKWh/xuB0BW5oYRQvmX/2SnrM="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-4.0.4.tgz"
-  "version" "4.0.4"
-  dependencies:
-    "dns-socket" "^4.2.2"
-    "got" "^9.6.0"
-    "is-ip" "^3.1.0"
-
-"public-ip@5.0.0":
+"public-ip@^5.0.0", "public-ip@5.0.0":
   "integrity" "sha1-s5L8yIVSw7NpM6KGBolIgWUV+So="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-5.0.0.tgz"
   "version" "5.0.0"
@@ -2280,13 +2185,6 @@
     "is-core-module" "^2.9.0"
     "path-parse" "^1.0.7"
     "supports-preserve-symlinks-flag" "^1.0.0"
-
-"responselike@^1.0.2":
-  "integrity" "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-1.0.2.tgz"
-  "version" "1.0.2"
-  dependencies:
-    "lowercase-keys" "^1.0.0"
 
 "responselike@^2.0.0":
   "integrity" "sha1-JjkbzDF091D5p56sxAoSpcQtdyM="
@@ -2559,11 +2457,6 @@
     "commander" "^2.20.0"
     "source-map-support" "~0.5.20"
 
-"to-readable-stream@^1.0.0":
-  "integrity" "sha1-zgqgwvPfat+FLvtASng+d8BHV3E="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-readable-stream/-/to-readable-stream-1.0.0.tgz"
-  "version" "1.0.0"
-
 "to-regex-range@^5.0.1":
   "integrity" "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz"
@@ -2643,13 +2536,6 @@
   "version" "4.4.1"
   dependencies:
     "punycode" "^2.1.0"
-
-"url-parse-lax@^3.0.0":
-  "integrity" "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-parse-lax/-/url-parse-lax-3.0.0.tgz"
-  "version" "3.0.0"
-  dependencies:
-    "prepend-http" "^2.0.0"
 
 "util-deprecate@~1.0.1":
   "integrity" "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="

--- a/vscode-dotnet-runtime-library/package-lock.json
+++ b/vscode-dotnet-runtime-library/package-lock.json
@@ -30,7 +30,7 @@
 				"got": "11.8.5",
 				"http-cache-semantics": "4.1.1",
 				"https-proxy-agent": "^7.0.2",
-				"is-online": "9.0.1",
+				"is-online": "^10.0.0",
 				"mocha": "^9.1.3",
 				"open": "^8.4.0",
 				"p-retry": "^4.6.1",
@@ -251,9 +251,9 @@
 			}
 		},
 		"node_modules/@types/http-cache-semantics": {
-			"version": "4.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI=",
+			"version": "4.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+			"integrity": "sha1-uXnrrTkZeZyXmxfHJiHAvAoxxsQ=",
 			"license": "MIT"
 		},
 		"node_modules/@types/keyv": {
@@ -365,16 +365,19 @@
 			}
 		},
 		"node_modules/aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+			"version": "4.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-4.0.1.tgz",
+			"integrity": "sha1-JQkf4Vc7ngvokq7aFcfGalRfdY4=",
 			"license": "MIT",
 			"dependencies": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
+				"clean-stack": "^4.0.0",
+				"indent-string": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ansi-colors": {
@@ -755,12 +758,30 @@
 			}
 		},
 		"node_modules/clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
+			"version": "4.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-4.2.0.tgz",
+			"integrity": "sha1-xGTkzeSseJ9OBzXF11vrSdezCzE=",
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/clean-stack/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg=",
 			"license": "MIT",
 			"engines": {
-				"node": ">=6"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cliui": {
@@ -1003,12 +1024,6 @@
 				"readable-stream": "^2.0.2"
 			}
 		},
-		"node_modules/duplexer3": {
-			"version": "0.1.5",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer3/-/duplexer3-0.1.5.tgz",
-			"integrity": "sha1-C15Ne61d6JAepEQGJMjh0gCZIX4=",
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1162,9 +1177,9 @@
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.5",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.5.tgz",
-			"integrity": "sha1-VNTW0GLA+n2dF/6wCEYVUOO6gCA=",
+			"version": "1.15.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
+			"integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs=",
 			"funding": [
 				{
 					"type": "individual",
@@ -1559,12 +1574,15 @@
 			}
 		},
 		"node_modules/indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
+			"version": "5.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU=",
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/inflight": {
@@ -1794,16 +1812,79 @@
 			}
 		},
 		"node_modules/is-online": {
-			"version": "9.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-9.0.1.tgz",
-			"integrity": "sha1-caNCAvqCa65vP/i+pCDFZXNEil8=",
+			"version": "10.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-10.0.0.tgz",
+			"integrity": "sha1-XgLO6fgi/ZwZsGDw7L3HmNNylaM=",
 			"license": "MIT",
 			"dependencies": {
-				"got": "^11.8.0",
-				"p-any": "^3.0.0",
-				"p-timeout": "^3.2.0",
-				"public-ip": "^4.0.4"
+				"got": "^12.1.0",
+				"p-any": "^4.0.0",
+				"p-timeout": "^5.1.0",
+				"public-ip": "^5.0.0"
 			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-online/node_modules/@sindresorhus/is": {
+			"version": "5.6.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-5.6.0.tgz",
+			"integrity": "sha1-Qd1gk9NGUs3bXVve7gTq/DOCZmg=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
+		"node_modules/is-online/node_modules/@szmarczak/http-timer": {
+			"version": "5.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+			"integrity": "sha1-x8G/EUHN1HUbA5nI/HuLZkzVvjo=",
+			"license": "MIT",
+			"dependencies": {
+				"defer-to-connect": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
+		"node_modules/is-online/node_modules/cacheable-lookup": {
+			"version": "7.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+			"integrity": "sha1-NHaoIV0EbloyAqkgndE/7B+TOic=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
+		"node_modules/is-online/node_modules/cacheable-request": {
+			"version": "10.2.14",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.14.tgz",
+			"integrity": "sha1-65FbZl/aQbeWUngt8/VTRJxAa50=",
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-cache-semantics": "^4.0.2",
+				"get-stream": "^6.0.1",
+				"http-cache-semantics": "^4.1.1",
+				"keyv": "^4.5.3",
+				"mimic-response": "^4.0.0",
+				"normalize-url": "^8.0.0",
+				"responselike": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
+		"node_modules/is-online/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -1811,172 +1892,93 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-online/node_modules/@sindresorhus/is": {
-			"version": "0.14.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/is-online/node_modules/@szmarczak/http-timer": {
-			"version": "1.1.2",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-			"integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
+		"node_modules/is-online/node_modules/got": {
+			"version": "12.6.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz",
+			"integrity": "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk=",
 			"license": "MIT",
 			"dependencies": {
-				"defer-to-connect": "^1.0.1"
+				"@sindresorhus/is": "^5.2.0",
+				"@szmarczak/http-timer": "^5.0.1",
+				"cacheable-lookup": "^7.0.0",
+				"cacheable-request": "^10.2.8",
+				"decompress-response": "^6.0.0",
+				"form-data-encoder": "^2.1.2",
+				"get-stream": "^6.0.1",
+				"http2-wrapper": "^2.1.10",
+				"lowercase-keys": "^3.0.0",
+				"p-cancelable": "^3.0.0",
+				"responselike": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
 			}
 		},
-		"node_modules/is-online/node_modules/cacheable-request": {
-			"version": "6.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-6.1.0.tgz",
-			"integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
+		"node_modules/is-online/node_modules/http2-wrapper": {
+			"version": "2.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+			"integrity": "sha1-MQloFT3N7bFg2LchFDY+9fzh9ko=",
 			"license": "MIT",
 			"dependencies": {
-				"clone-response": "^1.0.2",
-				"get-stream": "^5.1.0",
-				"http-cache-semantics": "^4.0.0",
-				"keyv": "^3.0.0",
-				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^4.1.0",
-				"responselike": "^1.0.2"
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.2.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10.19.0"
 			}
 		},
-		"node_modules/is-online/node_modules/decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"license": "MIT",
-			"dependencies": {
-				"mimic-response": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/is-online/node_modules/defer-to-connect": {
-			"version": "1.1.3",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-			"integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE=",
-			"license": "MIT"
-		},
-		"node_modules/is-online/node_modules/json-buffer": {
+		"node_modules/is-online/node_modules/lowercase-keys": {
 			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-			"license": "MIT"
-		},
-		"node_modules/is-online/node_modules/keyv": {
-			"version": "3.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-3.1.0.tgz",
-			"integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
-			"license": "MIT",
-			"dependencies": {
-				"json-buffer": "3.0.0"
-			}
-		},
-		"node_modules/is-online/node_modules/normalize-url": {
-			"version": "4.5.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-4.5.1.tgz",
-			"integrity": "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo=",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+			"integrity": "sha1-xefUQuN+rSR66dsRep0KRnyJ1PI=",
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/is-online/node_modules/p-cancelable": {
-			"version": "1.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/is-online/node_modules/public-ip": {
-			"version": "4.0.4",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-4.0.4.tgz",
-			"integrity": "sha1-s3hKWh/xuB0BW5oYRQvmX/2SnrM=",
-			"license": "MIT",
-			"dependencies": {
-				"dns-socket": "^4.2.2",
-				"got": "^9.6.0",
-				"is-ip": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-online/node_modules/public-ip/node_modules/get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+		"node_modules/is-online/node_modules/mimic-response": {
+			"version": "4.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-4.0.0.tgz",
+			"integrity": "sha1-NUaLGefHXRD1Fl6iXnWlzup89w8=",
 			"license": "MIT",
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
 			"engines": {
-				"node": ">=6"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-online/node_modules/public-ip/node_modules/got": {
-			"version": "9.6.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-9.6.0.tgz",
-			"integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
+		"node_modules/is-online/node_modules/normalize-url": {
+			"version": "8.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.1.tgz",
+			"integrity": "sha1-m32Wr5g2V3xY9Yg+k5Nl+hViOko=",
 			"license": "MIT",
-			"dependencies": {
-				"@sindresorhus/is": "^0.14.0",
-				"@szmarczak/http-timer": "^1.1.2",
-				"cacheable-request": "^6.0.0",
-				"decompress-response": "^3.3.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^4.1.0",
-				"lowercase-keys": "^1.0.1",
-				"mimic-response": "^1.0.1",
-				"p-cancelable": "^1.0.0",
-				"to-readable-stream": "^1.0.0",
-				"url-parse-lax": "^3.0.0"
+			"engines": {
+				"node": ">=14.16"
 			},
-			"engines": {
-				"node": ">=8.6"
-			}
-		},
-		"node_modules/is-online/node_modules/public-ip/node_modules/lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-online/node_modules/responselike": {
-			"version": "1.0.2",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-1.0.2.tgz",
-			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"version": "3.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-3.0.0.tgz",
+			"integrity": "sha1-IN7LbCmK/w2+4cNVypVGHUKCNiY=",
 			"license": "MIT",
 			"dependencies": {
-				"lowercase-keys": "^1.0.0"
-			}
-		},
-		"node_modules/is-online/node_modules/responselike/node_modules/lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
-			"license": "MIT",
+				"lowercase-keys": "^3.0.0"
+			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-plain-obj": {
@@ -2494,28 +2496,19 @@
 			}
 		},
 		"node_modules/p-any": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-3.0.0.tgz",
-			"integrity": "sha1-eYR67tcLXToQ6mJSlsDD0ukKh7k=",
+			"version": "4.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-4.0.0.tgz",
+			"integrity": "sha1-DpyLD6PljMeeahxscVqpMmtqREc=",
 			"license": "MIT",
 			"dependencies": {
-				"p-cancelable": "^2.0.0",
-				"p-some": "^5.0.0"
+				"p-cancelable": "^3.0.0",
+				"p-some": "^6.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-any/node_modules/p-cancelable": {
-			"version": "2.1.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/p-cancelable": {
@@ -2525,15 +2518,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.20"
-			}
-		},
-		"node_modules/p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/p-limit": {
@@ -2580,40 +2564,31 @@
 			}
 		},
 		"node_modules/p-some": {
-			"version": "5.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-5.0.0.tgz",
-			"integrity": "sha1-i3MMdLT+UWnXJkokCtAQtuvGhqQ=",
+			"version": "6.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-6.0.0.tgz",
+			"integrity": "sha1-RhOoIgOKvhJeQhUuqfdwWnlnUm8=",
 			"license": "MIT",
 			"dependencies": {
-				"aggregate-error": "^3.0.0",
-				"p-cancelable": "^2.0.0"
+				"aggregate-error": "^4.0.0",
+				"p-cancelable": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-some/node_modules/p-cancelable": {
-			"version": "2.1.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/p-timeout": {
-			"version": "3.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
+			"version": "5.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-5.1.0.tgz",
+			"integrity": "sha1-s8aRz0QVE4zi2c/gcduhHw/uCFs=",
 			"license": "MIT",
-			"dependencies": {
-				"p-finally": "^1.0.0"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/path-exists": {
@@ -2665,15 +2640,6 @@
 			"version": "3.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pify/-/pify-3.0.0.tgz",
 			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/prepend-http": {
-			"version": "2.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -3257,15 +3223,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/to-readable-stream": {
-			"version": "1.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3487,18 +3444,6 @@
 				"listenercount": "~1.0.1",
 				"readable-stream": "~2.3.6",
 				"setimmediate": "~1.0.4"
-			}
-		},
-		"node_modules/url-parse-lax": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"license": "MIT",
-			"dependencies": {
-				"prepend-http": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -3808,9 +3753,9 @@
 			}
 		},
 		"@types/http-cache-semantics": {
-			"version": "4.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI="
+			"version": "4.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+			"integrity": "sha1-uXnrrTkZeZyXmxfHJiHAvAoxxsQ="
 		},
 		"@types/keyv": {
 			"version": "3.1.4",
@@ -3904,12 +3849,12 @@
 			}
 		},
 		"aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+			"version": "4.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-4.0.1.tgz",
+			"integrity": "sha1-JQkf4Vc7ngvokq7aFcfGalRfdY4=",
 			"requires": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
+				"clean-stack": "^4.0.0",
+				"indent-string": "^5.0.0"
 			}
 		},
 		"ansi-colors": {
@@ -4169,9 +4114,19 @@
 			}
 		},
 		"clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs="
+			"version": "4.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-4.2.0.tgz",
+			"integrity": "sha1-xGTkzeSseJ9OBzXF11vrSdezCzE=",
+			"requires": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "5.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+					"integrity": "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg="
+				}
+			}
 		},
 		"cliui": {
 			"version": "7.0.4",
@@ -4332,11 +4287,6 @@
 				"readable-stream": "^2.0.2"
 			}
 		},
-		"duplexer3": {
-			"version": "0.1.5",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer3/-/duplexer3-0.1.5.tgz",
-			"integrity": "sha1-C15Ne61d6JAepEQGJMjh0gCZIX4="
-		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4438,9 +4388,9 @@
 			"integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE="
 		},
 		"follow-redirects": {
-			"version": "1.15.5",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.5.tgz",
-			"integrity": "sha1-VNTW0GLA+n2dF/6wCEYVUOO6gCA="
+			"version": "1.15.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
+			"integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs="
 		},
 		"form-data-encoder": {
 			"version": "2.1.4",
@@ -4689,9 +4639,9 @@
 			}
 		},
 		"indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE="
+			"version": "5.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -4828,135 +4778,101 @@
 			}
 		},
 		"is-online": {
-			"version": "9.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-9.0.1.tgz",
-			"integrity": "sha1-caNCAvqCa65vP/i+pCDFZXNEil8=",
+			"version": "10.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-10.0.0.tgz",
+			"integrity": "sha1-XgLO6fgi/ZwZsGDw7L3HmNNylaM=",
 			"requires": {
-				"got": "^11.8.0",
-				"p-any": "^3.0.0",
-				"p-timeout": "^3.2.0",
-				"public-ip": "^4.0.4"
+				"got": "^12.1.0",
+				"p-any": "^4.0.0",
+				"p-timeout": "^5.1.0",
+				"public-ip": "^5.0.0"
 			},
 			"dependencies": {
 				"@sindresorhus/is": {
-					"version": "0.14.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-0.14.0.tgz",
-					"integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o="
+					"version": "5.6.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-5.6.0.tgz",
+					"integrity": "sha1-Qd1gk9NGUs3bXVve7gTq/DOCZmg="
 				},
 				"@szmarczak/http-timer": {
-					"version": "1.1.2",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-					"integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
+					"version": "5.0.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+					"integrity": "sha1-x8G/EUHN1HUbA5nI/HuLZkzVvjo=",
 					"requires": {
-						"defer-to-connect": "^1.0.1"
+						"defer-to-connect": "^2.0.1"
 					}
+				},
+				"cacheable-lookup": {
+					"version": "7.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+					"integrity": "sha1-NHaoIV0EbloyAqkgndE/7B+TOic="
 				},
 				"cacheable-request": {
-					"version": "6.1.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-6.1.0.tgz",
-					"integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
+					"version": "10.2.14",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.14.tgz",
+					"integrity": "sha1-65FbZl/aQbeWUngt8/VTRJxAa50=",
 					"requires": {
-						"clone-response": "^1.0.2",
-						"get-stream": "^5.1.0",
-						"http-cache-semantics": "^4.0.0",
-						"keyv": "^3.0.0",
-						"lowercase-keys": "^2.0.0",
-						"normalize-url": "^4.1.0",
-						"responselike": "^1.0.2"
+						"@types/http-cache-semantics": "^4.0.2",
+						"get-stream": "^6.0.1",
+						"http-cache-semantics": "^4.1.1",
+						"keyv": "^4.5.3",
+						"mimic-response": "^4.0.0",
+						"normalize-url": "^8.0.0",
+						"responselike": "^3.0.0"
 					}
 				},
-				"decompress-response": {
-					"version": "3.3.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-3.3.0.tgz",
-					"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+				"get-stream": {
+					"version": "6.0.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c="
+				},
+				"got": {
+					"version": "12.6.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz",
+					"integrity": "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk=",
 					"requires": {
-						"mimic-response": "^1.0.0"
+						"@sindresorhus/is": "^5.2.0",
+						"@szmarczak/http-timer": "^5.0.1",
+						"cacheable-lookup": "^7.0.0",
+						"cacheable-request": "^10.2.8",
+						"decompress-response": "^6.0.0",
+						"form-data-encoder": "^2.1.2",
+						"get-stream": "^6.0.1",
+						"http2-wrapper": "^2.1.10",
+						"lowercase-keys": "^3.0.0",
+						"p-cancelable": "^3.0.0",
+						"responselike": "^3.0.0"
 					}
 				},
-				"defer-to-connect": {
-					"version": "1.1.3",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-					"integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE="
+				"http2-wrapper": {
+					"version": "2.2.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+					"integrity": "sha1-MQloFT3N7bFg2LchFDY+9fzh9ko=",
+					"requires": {
+						"quick-lru": "^5.1.1",
+						"resolve-alpn": "^1.2.0"
+					}
 				},
-				"json-buffer": {
+				"lowercase-keys": {
 					"version": "3.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.0.tgz",
-					"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+					"integrity": "sha1-xefUQuN+rSR66dsRep0KRnyJ1PI="
 				},
-				"keyv": {
-					"version": "3.1.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-3.1.0.tgz",
-					"integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
-					"requires": {
-						"json-buffer": "3.0.0"
-					}
+				"mimic-response": {
+					"version": "4.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-4.0.0.tgz",
+					"integrity": "sha1-NUaLGefHXRD1Fl6iXnWlzup89w8="
 				},
 				"normalize-url": {
-					"version": "4.5.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-4.5.1.tgz",
-					"integrity": "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo="
-				},
-				"p-cancelable": {
-					"version": "1.1.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-1.1.0.tgz",
-					"integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw="
-				},
-				"public-ip": {
-					"version": "4.0.4",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-4.0.4.tgz",
-					"integrity": "sha1-s3hKWh/xuB0BW5oYRQvmX/2SnrM=",
-					"requires": {
-						"dns-socket": "^4.2.2",
-						"got": "^9.6.0",
-						"is-ip": "^3.1.0"
-					},
-					"dependencies": {
-						"get-stream": {
-							"version": "4.1.0",
-							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-4.1.0.tgz",
-							"integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
-							"requires": {
-								"pump": "^3.0.0"
-							}
-						},
-						"got": {
-							"version": "9.6.0",
-							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-9.6.0.tgz",
-							"integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
-							"requires": {
-								"@sindresorhus/is": "^0.14.0",
-								"@szmarczak/http-timer": "^1.1.2",
-								"cacheable-request": "^6.0.0",
-								"decompress-response": "^3.3.0",
-								"duplexer3": "^0.1.4",
-								"get-stream": "^4.1.0",
-								"lowercase-keys": "^1.0.1",
-								"mimic-response": "^1.0.1",
-								"p-cancelable": "^1.0.0",
-								"to-readable-stream": "^1.0.0",
-								"url-parse-lax": "^3.0.0"
-							}
-						},
-						"lowercase-keys": {
-							"version": "1.0.1",
-							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-							"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
-						}
-					}
+					"version": "8.0.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.1.tgz",
+					"integrity": "sha1-m32Wr5g2V3xY9Yg+k5Nl+hViOko="
 				},
 				"responselike": {
-					"version": "1.0.2",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-1.0.2.tgz",
-					"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+					"version": "3.0.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-3.0.0.tgz",
+					"integrity": "sha1-IN7LbCmK/w2+4cNVypVGHUKCNiY=",
 					"requires": {
-						"lowercase-keys": "^1.0.0"
-					},
-					"dependencies": {
-						"lowercase-keys": {
-							"version": "1.0.1",
-							"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-							"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
-						}
+						"lowercase-keys": "^3.0.0"
 					}
 				}
 			}
@@ -5293,30 +5209,18 @@
 			}
 		},
 		"p-any": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-3.0.0.tgz",
-			"integrity": "sha1-eYR67tcLXToQ6mJSlsDD0ukKh7k=",
+			"version": "4.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-4.0.0.tgz",
+			"integrity": "sha1-DpyLD6PljMeeahxscVqpMmtqREc=",
 			"requires": {
-				"p-cancelable": "^2.0.0",
-				"p-some": "^5.0.0"
-			},
-			"dependencies": {
-				"p-cancelable": {
-					"version": "2.1.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
-					"integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8="
-				}
+				"p-cancelable": "^3.0.0",
+				"p-some": "^6.0.0"
 			}
 		},
 		"p-cancelable": {
 			"version": "3.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
 			"integrity": "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA="
-		},
-		"p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "3.1.0",
@@ -5344,28 +5248,18 @@
 			}
 		},
 		"p-some": {
-			"version": "5.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-5.0.0.tgz",
-			"integrity": "sha1-i3MMdLT+UWnXJkokCtAQtuvGhqQ=",
+			"version": "6.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-6.0.0.tgz",
+			"integrity": "sha1-RhOoIgOKvhJeQhUuqfdwWnlnUm8=",
 			"requires": {
-				"aggregate-error": "^3.0.0",
-				"p-cancelable": "^2.0.0"
-			},
-			"dependencies": {
-				"p-cancelable": {
-					"version": "2.1.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
-					"integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8="
-				}
+				"aggregate-error": "^4.0.0",
+				"p-cancelable": "^3.0.0"
 			}
 		},
 		"p-timeout": {
-			"version": "3.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
-			"requires": {
-				"p-finally": "^1.0.0"
-			}
+			"version": "5.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-5.1.0.tgz",
+			"integrity": "sha1-s8aRz0QVE4zi2c/gcduhHw/uCFs="
 		},
 		"path-exists": {
 			"version": "4.0.0",
@@ -5396,11 +5290,6 @@
 			"version": "3.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pify/-/pify-3.0.0.tgz",
 			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-		},
-		"prepend-http": {
-			"version": "2.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
@@ -5777,11 +5666,6 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk="
 		},
-		"to-readable-stream": {
-			"version": "1.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E="
-		},
 		"to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5937,14 +5821,6 @@
 				"listenercount": "~1.0.1",
 				"readable-stream": "~2.3.6",
 				"setimmediate": "~1.0.4"
-			}
-		},
-		"url-parse-lax": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"requires": {
-				"prepend-http": "^2.0.0"
 			}
 		},
 		"util-deprecate": {

--- a/vscode-dotnet-runtime-library/package-lock.json
+++ b/vscode-dotnet-runtime-library/package-lock.json
@@ -30,7 +30,6 @@
 				"got": "11.8.5",
 				"http-cache-semantics": "4.1.1",
 				"https-proxy-agent": "^7.0.2",
-				"is-online": "^10.0.0",
 				"mocha": "^9.1.3",
 				"open": "^8.4.0",
 				"p-retry": "^4.6.1",
@@ -362,22 +361,6 @@
 			},
 			"engines": {
 				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/aggregate-error": {
-			"version": "4.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-4.0.1.tgz",
-			"integrity": "sha1-JQkf4Vc7ngvokq7aFcfGalRfdY4=",
-			"license": "MIT",
-			"dependencies": {
-				"clean-stack": "^4.0.0",
-				"indent-string": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ansi-colors": {
@@ -755,33 +738,6 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/clean-stack": {
-			"version": "4.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-4.2.0.tgz",
-			"integrity": "sha1-xGTkzeSseJ9OBzXF11vrSdezCzE=",
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "5.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/clean-stack/node_modules/escape-string-regexp": {
-			"version": "5.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-			"integrity": "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cliui": {
@@ -1573,18 +1529,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
@@ -1809,176 +1753,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-online": {
-			"version": "10.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-10.0.0.tgz",
-			"integrity": "sha1-XgLO6fgi/ZwZsGDw7L3HmNNylaM=",
-			"license": "MIT",
-			"dependencies": {
-				"got": "^12.1.0",
-				"p-any": "^4.0.0",
-				"p-timeout": "^5.1.0",
-				"public-ip": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-online/node_modules/@sindresorhus/is": {
-			"version": "5.6.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-5.6.0.tgz",
-			"integrity": "sha1-Qd1gk9NGUs3bXVve7gTq/DOCZmg=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/is?sponsor=1"
-			}
-		},
-		"node_modules/is-online/node_modules/@szmarczak/http-timer": {
-			"version": "5.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-			"integrity": "sha1-x8G/EUHN1HUbA5nI/HuLZkzVvjo=",
-			"license": "MIT",
-			"dependencies": {
-				"defer-to-connect": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=14.16"
-			}
-		},
-		"node_modules/is-online/node_modules/cacheable-lookup": {
-			"version": "7.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-			"integrity": "sha1-NHaoIV0EbloyAqkgndE/7B+TOic=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.16"
-			}
-		},
-		"node_modules/is-online/node_modules/cacheable-request": {
-			"version": "10.2.14",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.14.tgz",
-			"integrity": "sha1-65FbZl/aQbeWUngt8/VTRJxAa50=",
-			"license": "MIT",
-			"dependencies": {
-				"@types/http-cache-semantics": "^4.0.2",
-				"get-stream": "^6.0.1",
-				"http-cache-semantics": "^4.1.1",
-				"keyv": "^4.5.3",
-				"mimic-response": "^4.0.0",
-				"normalize-url": "^8.0.0",
-				"responselike": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			}
-		},
-		"node_modules/is-online/node_modules/get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-online/node_modules/got": {
-			"version": "12.6.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz",
-			"integrity": "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk=",
-			"license": "MIT",
-			"dependencies": {
-				"@sindresorhus/is": "^5.2.0",
-				"@szmarczak/http-timer": "^5.0.1",
-				"cacheable-lookup": "^7.0.0",
-				"cacheable-request": "^10.2.8",
-				"decompress-response": "^6.0.0",
-				"form-data-encoder": "^2.1.2",
-				"get-stream": "^6.0.1",
-				"http2-wrapper": "^2.1.10",
-				"lowercase-keys": "^3.0.0",
-				"p-cancelable": "^3.0.0",
-				"responselike": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/got?sponsor=1"
-			}
-		},
-		"node_modules/is-online/node_modules/http2-wrapper": {
-			"version": "2.2.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-			"integrity": "sha1-MQloFT3N7bFg2LchFDY+9fzh9ko=",
-			"license": "MIT",
-			"dependencies": {
-				"quick-lru": "^5.1.1",
-				"resolve-alpn": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=10.19.0"
-			}
-		},
-		"node_modules/is-online/node_modules/lowercase-keys": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-			"integrity": "sha1-xefUQuN+rSR66dsRep0KRnyJ1PI=",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-online/node_modules/mimic-response": {
-			"version": "4.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-4.0.0.tgz",
-			"integrity": "sha1-NUaLGefHXRD1Fl6iXnWlzup89w8=",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-online/node_modules/normalize-url": {
-			"version": "8.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.1.tgz",
-			"integrity": "sha1-m32Wr5g2V3xY9Yg+k5Nl+hViOko=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-online/node_modules/responselike": {
-			"version": "3.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-3.0.0.tgz",
-			"integrity": "sha1-IN7LbCmK/w2+4cNVypVGHUKCNiY=",
-			"license": "MIT",
-			"dependencies": {
-				"lowercase-keys": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-plain-obj": {
@@ -2495,22 +2269,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-any": {
-			"version": "4.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-4.0.0.tgz",
-			"integrity": "sha1-DpyLD6PljMeeahxscVqpMmtqREc=",
-			"license": "MIT",
-			"dependencies": {
-				"p-cancelable": "^3.0.0",
-				"p-some": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/p-cancelable": {
 			"version": "3.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
@@ -2561,34 +2319,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/p-some": {
-			"version": "6.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-6.0.0.tgz",
-			"integrity": "sha1-RhOoIgOKvhJeQhUuqfdwWnlnUm8=",
-			"license": "MIT",
-			"dependencies": {
-				"aggregate-error": "^4.0.0",
-				"p-cancelable": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-timeout": {
-			"version": "5.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-5.1.0.tgz",
-			"integrity": "sha1-s8aRz0QVE4zi2c/gcduhHw/uCFs=",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/path-exists": {
@@ -3848,15 +3578,6 @@
 				"debug": "4"
 			}
 		},
-		"aggregate-error": {
-			"version": "4.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-4.0.1.tgz",
-			"integrity": "sha1-JQkf4Vc7ngvokq7aFcfGalRfdY4=",
-			"requires": {
-				"clean-stack": "^4.0.0",
-				"indent-string": "^5.0.0"
-			}
-		},
 		"ansi-colors": {
 			"version": "4.1.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -4111,21 +3832,6 @@
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
 				"readdirp": "~3.6.0"
-			}
-		},
-		"clean-stack": {
-			"version": "4.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-4.2.0.tgz",
-			"integrity": "sha1-xGTkzeSseJ9OBzXF11vrSdezCzE=",
-			"requires": {
-				"escape-string-regexp": "5.0.0"
-			},
-			"dependencies": {
-				"escape-string-regexp": {
-					"version": "5.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-					"integrity": "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg="
-				}
 			}
 		},
 		"cliui": {
@@ -4638,11 +4344,6 @@
 				}
 			}
 		},
-		"indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU="
-		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
@@ -4775,106 +4476,6 @@
 			"integrity": "sha1-WdUK2kxFJReE6ZBPUkbHQvB6Qvw=",
 			"requires": {
 				"has-tostringtag": "^1.0.0"
-			}
-		},
-		"is-online": {
-			"version": "10.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-10.0.0.tgz",
-			"integrity": "sha1-XgLO6fgi/ZwZsGDw7L3HmNNylaM=",
-			"requires": {
-				"got": "^12.1.0",
-				"p-any": "^4.0.0",
-				"p-timeout": "^5.1.0",
-				"public-ip": "^5.0.0"
-			},
-			"dependencies": {
-				"@sindresorhus/is": {
-					"version": "5.6.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-5.6.0.tgz",
-					"integrity": "sha1-Qd1gk9NGUs3bXVve7gTq/DOCZmg="
-				},
-				"@szmarczak/http-timer": {
-					"version": "5.0.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-					"integrity": "sha1-x8G/EUHN1HUbA5nI/HuLZkzVvjo=",
-					"requires": {
-						"defer-to-connect": "^2.0.1"
-					}
-				},
-				"cacheable-lookup": {
-					"version": "7.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-					"integrity": "sha1-NHaoIV0EbloyAqkgndE/7B+TOic="
-				},
-				"cacheable-request": {
-					"version": "10.2.14",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.14.tgz",
-					"integrity": "sha1-65FbZl/aQbeWUngt8/VTRJxAa50=",
-					"requires": {
-						"@types/http-cache-semantics": "^4.0.2",
-						"get-stream": "^6.0.1",
-						"http-cache-semantics": "^4.1.1",
-						"keyv": "^4.5.3",
-						"mimic-response": "^4.0.0",
-						"normalize-url": "^8.0.0",
-						"responselike": "^3.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "6.0.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
-					"integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c="
-				},
-				"got": {
-					"version": "12.6.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz",
-					"integrity": "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk=",
-					"requires": {
-						"@sindresorhus/is": "^5.2.0",
-						"@szmarczak/http-timer": "^5.0.1",
-						"cacheable-lookup": "^7.0.0",
-						"cacheable-request": "^10.2.8",
-						"decompress-response": "^6.0.0",
-						"form-data-encoder": "^2.1.2",
-						"get-stream": "^6.0.1",
-						"http2-wrapper": "^2.1.10",
-						"lowercase-keys": "^3.0.0",
-						"p-cancelable": "^3.0.0",
-						"responselike": "^3.0.0"
-					}
-				},
-				"http2-wrapper": {
-					"version": "2.2.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-					"integrity": "sha1-MQloFT3N7bFg2LchFDY+9fzh9ko=",
-					"requires": {
-						"quick-lru": "^5.1.1",
-						"resolve-alpn": "^1.2.0"
-					}
-				},
-				"lowercase-keys": {
-					"version": "3.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-					"integrity": "sha1-xefUQuN+rSR66dsRep0KRnyJ1PI="
-				},
-				"mimic-response": {
-					"version": "4.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-4.0.0.tgz",
-					"integrity": "sha1-NUaLGefHXRD1Fl6iXnWlzup89w8="
-				},
-				"normalize-url": {
-					"version": "8.0.1",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.1.tgz",
-					"integrity": "sha1-m32Wr5g2V3xY9Yg+k5Nl+hViOko="
-				},
-				"responselike": {
-					"version": "3.0.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-3.0.0.tgz",
-					"integrity": "sha1-IN7LbCmK/w2+4cNVypVGHUKCNiY=",
-					"requires": {
-						"lowercase-keys": "^3.0.0"
-					}
-				}
 			}
 		},
 		"is-plain-obj": {
@@ -5208,15 +4809,6 @@
 				"is-wsl": "^2.2.0"
 			}
 		},
-		"p-any": {
-			"version": "4.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-4.0.0.tgz",
-			"integrity": "sha1-DpyLD6PljMeeahxscVqpMmtqREc=",
-			"requires": {
-				"p-cancelable": "^3.0.0",
-				"p-some": "^6.0.0"
-			}
-		},
 		"p-cancelable": {
 			"version": "3.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz",
@@ -5246,20 +4838,6 @@
 				"@types/retry": "^0.12.0",
 				"retry": "^0.13.1"
 			}
-		},
-		"p-some": {
-			"version": "6.0.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-6.0.0.tgz",
-			"integrity": "sha1-RhOoIgOKvhJeQhUuqfdwWnlnUm8=",
-			"requires": {
-				"aggregate-error": "^4.0.0",
-				"p-cancelable": "^3.0.0"
-			}
-		},
-		"p-timeout": {
-			"version": "5.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-5.1.0.tgz",
-			"integrity": "sha1-s8aRz0QVE4zi2c/gcduhHw/uCFs="
 		},
 		"path-exists": {
 			"version": "4.0.0",

--- a/vscode-dotnet-runtime-library/package.json
+++ b/vscode-dotnet-runtime-library/package.json
@@ -50,7 +50,6 @@
 		"got": "11.8.5",
 		"http-cache-semantics": "4.1.1",
 		"https-proxy-agent": "^7.0.2",
-		"is-online": "^10.0.0",
 		"mocha": "^9.1.3",
 		"open": "^8.4.0",
 		"p-retry": "^4.6.1",

--- a/vscode-dotnet-runtime-library/package.json
+++ b/vscode-dotnet-runtime-library/package.json
@@ -50,7 +50,7 @@
 		"got": "11.8.5",
 		"http-cache-semantics": "4.1.1",
 		"https-proxy-agent": "^7.0.2",
-		"is-online": "9.0.1",
+		"is-online": "^10.0.0",
 		"mocha": "^9.1.3",
 		"open": "^8.4.0",
 		"p-retry": "^4.6.1",

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -29,6 +29,7 @@ import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IAcquisitionInvoker } from './IAcquisitionInvoker';
 import { IDotnetInstallationContext } from './IDotnetInstallationContext';
 import { IInstallScriptAcquisitionWorker } from './IInstallScriptAcquisitionWorker';
+/* tslint:disable:no-any */
 
 export class AcquisitionInvoker extends IAcquisitionInvoker {
     protected readonly scriptWorker: IInstallScriptAcquisitionWorker;
@@ -46,9 +47,11 @@ You will need to restart VS Code after these changes. If PowerShell is still not
     private async isOnline(installContext : IDotnetInstallationContext) : Promise<boolean>
     {
         const googleDNS = '8.8.8.8';
-        const expectedDNSResolutionTime = Math.max(installContext.timeoutSeconds * 10, 100); // Assumption: DNS resolution should take less than 1/100 of the time it'd take to download .NET, 100 is there to prevent 0 error
-        const DNSResolver = new dns.Resolver({ timeout: expectedDNSResolutionTime });
-        await Promise.resolve(DNSResolver.resolve(googleDNS,  function(error : any)
+        const expectedDNSResolutionTime = Math.max(installContext.timeoutSeconds * 10, 100); // Assumption: DNS resolution should take less than 1/100 of the time it'd take to download .NET.
+        // ... 100 ms is there as a default to prevent the dns resolver from throwing a runtime error if the user sets timeoutSeconds to 0.
+
+        const dnsResolver = new dns.Resolver({ timeout: expectedDNSResolutionTime });
+        await Promise.resolve(dnsResolver.resolve(googleDNS,  function(error : any)
         {
             if (error)
             {

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -75,7 +75,7 @@ You will need to restart VS Code after these changes. If PowerShell is still not
                             this.eventStream.post(new DotnetAcquisitionScriptOutput(installKey, `STDERR: ${TelemetryUtilities.HashAllPaths(stderr)}`));
                         }
 
-                        const online = await isOnline();
+                        const online = await isOnline.default();
                         if (!online)
                         {
                             const offlineError = new Error('No internet connection: Cannot install .NET');

--- a/vscode-dotnet-runtime-library/yarn.lock
+++ b/vscode-dotnet-runtime-library/yarn.lock
@@ -35,11 +35,6 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz"
   "version" "2.0.4"
 
-"@sindresorhus/is@^0.14.0":
-  "integrity" "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-0.14.0.tgz"
-  "version" "0.14.0"
-
 "@sindresorhus/is@^4.0.0":
   "integrity" "sha1-PHycRuZ4/u/nouW7YJ09vWZf+z8="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-4.6.0.tgz"
@@ -49,13 +44,6 @@
   "integrity" "sha1-Qd1gk9NGUs3bXVve7gTq/DOCZmg="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@sindresorhus/is/-/is-5.6.0.tgz"
   "version" "5.6.0"
-
-"@szmarczak/http-timer@^1.1.2":
-  "integrity" "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@szmarczak/http-timer/-/http-timer-1.1.2.tgz"
-  "version" "1.1.2"
-  dependencies:
-    "defer-to-connect" "^1.0.1"
 
 "@szmarczak/http-timer@^4.0.5":
   "integrity" "sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac="
@@ -106,10 +94,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/http-cache-semantics@*", "@types/http-cache-semantics@^4.0.1":
-  "integrity" "sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz"
-  "version" "4.0.1"
+"@types/http-cache-semantics@*", "@types/http-cache-semantics@^4.0.1", "@types/http-cache-semantics@^4.0.2":
+  "integrity" "sha1-uXnrrTkZeZyXmxfHJiHAvAoxxsQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz"
+  "version" "4.0.4"
 
 "@types/keyv@^3.1.4":
   "integrity" "sha1-PM2xxnUbDH5SMAvNrNW8v4+qdbY="
@@ -202,13 +190,13 @@
   dependencies:
     "debug" "4"
 
-"aggregate-error@^3.0.0":
-  "integrity" "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz"
-  "version" "3.1.0"
+"aggregate-error@^4.0.0":
+  "integrity" "sha1-JQkf4Vc7ngvokq7aFcfGalRfdY4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-4.0.1.tgz"
+  "version" "4.0.1"
   dependencies:
-    "clean-stack" "^2.0.0"
-    "indent-string" "^4.0.0"
+    "clean-stack" "^4.0.0"
+    "indent-string" "^5.0.0"
 
 "ansi-colors@4.1.1":
   "integrity" "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g="
@@ -369,30 +357,17 @@
   "version" "7.0.0"
 
 "cacheable-request@^10.2.8":
-  "integrity" "sha1-twErtKKs2xjLVNLf91HXZrNQCEI="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.13.tgz"
-  "version" "10.2.13"
+  "integrity" "sha1-65FbZl/aQbeWUngt8/VTRJxAa50="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.14.tgz"
+  "version" "10.2.14"
   dependencies:
-    "@types/http-cache-semantics" "^4.0.1"
+    "@types/http-cache-semantics" "^4.0.2"
     "get-stream" "^6.0.1"
     "http-cache-semantics" "^4.1.1"
     "keyv" "^4.5.3"
     "mimic-response" "^4.0.0"
     "normalize-url" "^8.0.0"
     "responselike" "^3.0.0"
-
-"cacheable-request@^6.0.0":
-  "integrity" "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-6.1.0.tgz"
-  "version" "6.1.0"
-  dependencies:
-    "clone-response" "^1.0.2"
-    "get-stream" "^5.1.0"
-    "http-cache-semantics" "^4.0.0"
-    "keyv" "^3.0.0"
-    "lowercase-keys" "^2.0.0"
-    "normalize-url" "^4.1.0"
-    "responselike" "^1.0.2"
 
 "cacheable-request@^7.0.2":
   "integrity" "sha1-ejPr8IYTF4tANjW+e4mdPmm76Bc="
@@ -493,10 +468,12 @@
   optionalDependencies:
     "fsevents" "~2.3.2"
 
-"clean-stack@^2.0.0":
-  "integrity" "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz"
-  "version" "2.2.0"
+"clean-stack@^4.0.0":
+  "integrity" "sha1-xGTkzeSseJ9OBzXF11vrSdezCzE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-4.2.0.tgz"
+  "version" "4.2.0"
+  dependencies:
+    "escape-string-regexp" "5.0.0"
 
 "cliui@^7.0.2":
   "integrity" "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08="
@@ -587,13 +564,6 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decamelize/-/decamelize-4.0.0.tgz"
   "version" "4.0.0"
 
-"decompress-response@^3.3.0":
-  "integrity" "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-3.3.0.tgz"
-  "version" "3.3.0"
-  dependencies:
-    "mimic-response" "^1.0.0"
-
 "decompress-response@^6.0.0":
   "integrity" "sha1-yjh2Et234QS9FthaqwDV7PCcZvw="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz"
@@ -607,11 +577,6 @@
   "version" "3.0.1"
   dependencies:
     "type-detect" "^4.0.0"
-
-"defer-to-connect@^1.0.1":
-  "integrity" "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/defer-to-connect/-/defer-to-connect-1.1.3.tgz"
-  "version" "1.1.3"
 
 "defer-to-connect@^2.0.0", "defer-to-connect@^2.0.1":
   "integrity" "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc="
@@ -671,11 +636,6 @@
   "version" "0.1.4"
   dependencies:
     "readable-stream" "^2.0.2"
-
-"duplexer3@^0.1.4":
-  "integrity" "sha1-C15Ne61d6JAepEQGJMjh0gCZIX4="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/duplexer3/-/duplexer3-0.1.5.tgz"
-  "version" "0.1.5"
 
 "emoji-regex@^8.0.0":
   "integrity" "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
@@ -747,6 +707,11 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   "version" "4.0.0"
 
+"escape-string-regexp@5.0.0":
+  "integrity" "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz"
+  "version" "5.0.0"
+
 "esprima@^4.0.0":
   "integrity" "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz"
@@ -778,9 +743,9 @@
   "version" "5.0.2"
 
 "follow-redirects@^1.15.4":
-  "integrity" "sha1-VNTW0GLA+n2dF/6wCEYVUOO6gCA="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.5.tgz"
-  "version" "1.15.5"
+  "integrity" "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz"
+  "version" "1.15.6"
 
 "form-data-encoder@^2.1.2":
   "integrity" "sha1-Jh6jXSpw1I0w7HqWAxMPpVFenNU="
@@ -857,13 +822,6 @@
   dependencies:
     "npm-conf" "~1.1.3"
 
-"get-stream@^4.1.0":
-  "integrity" "sha1-wbJVV189wh1Zv8ec09K0axw6VLU="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-4.1.0.tgz"
-  "version" "4.1.0"
-  dependencies:
-    "pump" "^3.0.0"
-
 "get-stream@^5.1.0":
   "integrity" "sha1-SWaheV7lrOZecGxLe+txJX1uItM="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-stream/-/get-stream-5.2.0.tgz"
@@ -915,23 +873,6 @@
     "once" "^1.3.0"
     "path-is-absolute" "^1.0.0"
 
-"got@^11.8.0", "got@11.8.5":
-  "integrity" "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz"
-  "version" "11.8.5"
-  dependencies:
-    "@sindresorhus/is" "^4.0.0"
-    "@szmarczak/http-timer" "^4.0.5"
-    "@types/cacheable-request" "^6.0.1"
-    "@types/responselike" "^1.0.0"
-    "cacheable-lookup" "^5.0.3"
-    "cacheable-request" "^7.0.2"
-    "decompress-response" "^6.0.0"
-    "http2-wrapper" "^1.0.0-beta.5.2"
-    "lowercase-keys" "^2.0.0"
-    "p-cancelable" "^2.0.0"
-    "responselike" "^2.0.0"
-
 "got@^12.0.0":
   "integrity" "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz"
@@ -949,22 +890,39 @@
     "p-cancelable" "^3.0.0"
     "responselike" "^3.0.0"
 
-"got@^9.6.0":
-  "integrity" "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-9.6.0.tgz"
-  "version" "9.6.0"
+"got@^12.1.0":
+  "integrity" "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz"
+  "version" "12.6.1"
   dependencies:
-    "@sindresorhus/is" "^0.14.0"
-    "@szmarczak/http-timer" "^1.1.2"
-    "cacheable-request" "^6.0.0"
-    "decompress-response" "^3.3.0"
-    "duplexer3" "^0.1.4"
-    "get-stream" "^4.1.0"
-    "lowercase-keys" "^1.0.1"
-    "mimic-response" "^1.0.1"
-    "p-cancelable" "^1.0.0"
-    "to-readable-stream" "^1.0.0"
-    "url-parse-lax" "^3.0.0"
+    "@sindresorhus/is" "^5.2.0"
+    "@szmarczak/http-timer" "^5.0.1"
+    "cacheable-lookup" "^7.0.0"
+    "cacheable-request" "^10.2.8"
+    "decompress-response" "^6.0.0"
+    "form-data-encoder" "^2.1.2"
+    "get-stream" "^6.0.1"
+    "http2-wrapper" "^2.1.10"
+    "lowercase-keys" "^3.0.0"
+    "p-cancelable" "^3.0.0"
+    "responselike" "^3.0.0"
+
+"got@11.8.5":
+  "integrity" "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz"
+  "version" "11.8.5"
+  dependencies:
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    "cacheable-lookup" "^5.0.3"
+    "cacheable-request" "^7.0.2"
+    "decompress-response" "^6.0.0"
+    "http2-wrapper" "^1.0.0-beta.5.2"
+    "lowercase-keys" "^2.0.0"
+    "p-cancelable" "^2.0.0"
+    "responselike" "^2.0.0"
 
 "graceful-fs@^4.1.2", "graceful-fs@^4.2.2", "graceful-fs@^4.2.4":
   "integrity" "sha1-FH06AG2kyjzhRyjHrvwofDZ9emw="
@@ -1045,9 +1003,9 @@
     "resolve-alpn" "^1.0.0"
 
 "http2-wrapper@^2.1.10":
-  "integrity" "sha1-uArRmdIWt9NoAZUHe9e5Bg+p1/M="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.0.tgz"
-  "version" "2.2.0"
+  "integrity" "sha1-MQloFT3N7bFg2LchFDY+9fzh9ko="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.1.tgz"
+  "version" "2.2.1"
   dependencies:
     "quick-lru" "^5.1.1"
     "resolve-alpn" "^1.2.0"
@@ -1068,10 +1026,10 @@
     "agent-base" "^7.0.2"
     "debug" "4"
 
-"indent-string@^4.0.0":
-  "integrity" "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-4.0.0.tgz"
-  "version" "4.0.0"
+"indent-string@^5.0.0":
+  "integrity" "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz"
+  "version" "5.0.0"
 
 "inflight@^1.0.4":
   "integrity" "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
@@ -1197,15 +1155,15 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz"
   "version" "7.0.0"
 
-"is-online@9.0.1":
-  "integrity" "sha1-caNCAvqCa65vP/i+pCDFZXNEil8="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-9.0.1.tgz"
-  "version" "9.0.1"
+"is-online@^10.0.0":
+  "integrity" "sha1-XgLO6fgi/ZwZsGDw7L3HmNNylaM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-10.0.0.tgz"
+  "version" "10.0.0"
   dependencies:
-    "got" "^11.8.0"
-    "p-any" "^3.0.0"
-    "p-timeout" "^3.2.0"
-    "public-ip" "^4.0.4"
+    "got" "^12.1.0"
+    "p-any" "^4.0.0"
+    "p-timeout" "^5.1.0"
+    "public-ip" "^5.0.0"
 
 "is-plain-obj@^2.1.0":
   "integrity" "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc="
@@ -1295,22 +1253,10 @@
   dependencies:
     "argparse" "^2.0.1"
 
-"json-buffer@3.0.0":
-  "integrity" "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.0.tgz"
-  "version" "3.0.0"
-
 "json-buffer@3.0.1":
   "integrity" "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz"
   "version" "3.0.1"
-
-"keyv@^3.0.0":
-  "integrity" "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-3.1.0.tgz"
-  "version" "3.1.0"
-  dependencies:
-    "json-buffer" "3.0.0"
 
 "keyv@^4.0.0", "keyv@^4.5.3":
   "integrity" "sha1-AIc9KwRt9zeWMVe9BPKUyoGMnCU="
@@ -1346,16 +1292,6 @@
   dependencies:
     "get-func-name" "^2.0.0"
 
-"lowercase-keys@^1.0.0":
-  "integrity" "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz"
-  "version" "1.0.1"
-
-"lowercase-keys@^1.0.1":
-  "integrity" "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz"
-  "version" "1.0.1"
-
 "lowercase-keys@^2.0.0":
   "integrity" "sha1-JgPni3tLAAbLyi+8yKMgJVislHk="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lowercase-keys/-/lowercase-keys-2.0.0.tgz"
@@ -1378,7 +1314,7 @@
   dependencies:
     "mime-db" "1.52.0"
 
-"mimic-response@^1.0.0", "mimic-response@^1.0.1":
+"mimic-response@^1.0.0":
   "integrity" "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-1.0.1.tgz"
   "version" "1.0.1"
@@ -1469,20 +1405,15 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz"
   "version" "3.0.0"
 
-"normalize-url@^4.1.0":
-  "integrity" "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-4.5.1.tgz"
-  "version" "4.5.1"
-
 "normalize-url@^6.0.1":
   "integrity" "sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-6.1.0.tgz"
   "version" "6.1.0"
 
 "normalize-url@^8.0.0":
-  "integrity" "sha1-WT29KE90Po3Pal3fj63/FJyCcBo="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.0.tgz"
-  "version" "8.0.0"
+  "integrity" "sha1-m32Wr5g2V3xY9Yg+k5Nl+hViOko="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.1.tgz"
+  "version" "8.0.1"
 
 "npm-conf@~1.1.3":
   "integrity" "sha1-JWzEe9DiGMJZxOlVC/QTvCGSr/k="
@@ -1533,18 +1464,13 @@
     "is-docker" "^2.1.1"
     "is-wsl" "^2.2.0"
 
-"p-any@^3.0.0":
-  "integrity" "sha1-eYR67tcLXToQ6mJSlsDD0ukKh7k="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-3.0.0.tgz"
-  "version" "3.0.0"
+"p-any@^4.0.0":
+  "integrity" "sha1-DpyLD6PljMeeahxscVqpMmtqREc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-4.0.0.tgz"
+  "version" "4.0.0"
   dependencies:
-    "p-cancelable" "^2.0.0"
-    "p-some" "^5.0.0"
-
-"p-cancelable@^1.0.0":
-  "integrity" "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-1.1.0.tgz"
-  "version" "1.1.0"
+    "p-cancelable" "^3.0.0"
+    "p-some" "^6.0.0"
 
 "p-cancelable@^2.0.0":
   "integrity" "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8="
@@ -1555,11 +1481,6 @@
   "integrity" "sha1-Y4JmlLVNYcocIOvLbT7PXhTNgFA="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-3.0.0.tgz"
   "version" "3.0.0"
-
-"p-finally@^1.0.0":
-  "integrity" "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz"
-  "version" "1.0.0"
 
 "p-limit@^3.0.2":
   "integrity" "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs="
@@ -1583,20 +1504,18 @@
     "@types/retry" "^0.12.0"
     "retry" "^0.13.1"
 
-"p-some@^5.0.0":
-  "integrity" "sha1-i3MMdLT+UWnXJkokCtAQtuvGhqQ="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-5.0.0.tgz"
-  "version" "5.0.0"
+"p-some@^6.0.0":
+  "integrity" "sha1-RhOoIgOKvhJeQhUuqfdwWnlnUm8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    "aggregate-error" "^3.0.0"
-    "p-cancelable" "^2.0.0"
+    "aggregate-error" "^4.0.0"
+    "p-cancelable" "^3.0.0"
 
-"p-timeout@^3.2.0":
-  "integrity" "sha1-x+F6vJcdKnli74NiazXWNazyPf4="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz"
-  "version" "3.2.0"
-  dependencies:
-    "p-finally" "^1.0.0"
+"p-timeout@^5.1.0":
+  "integrity" "sha1-s8aRz0QVE4zi2c/gcduhHw/uCFs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-5.1.0.tgz"
+  "version" "5.1.0"
 
 "path-exists@^4.0.0":
   "integrity" "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="
@@ -1628,11 +1547,6 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pify/-/pify-3.0.0.tgz"
   "version" "3.0.0"
 
-"prepend-http@^2.0.0":
-  "integrity" "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prepend-http/-/prepend-http-2.0.0.tgz"
-  "version" "2.0.0"
-
 "process-nextick-args@~2.0.0":
   "integrity" "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
@@ -1656,15 +1570,6 @@
   "integrity" "sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
   "version" "1.1.0"
-
-"public-ip@^4.0.4":
-  "integrity" "sha1-s3hKWh/xuB0BW5oYRQvmX/2SnrM="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/public-ip/-/public-ip-4.0.4.tgz"
-  "version" "4.0.4"
-  dependencies:
-    "dns-socket" "^4.2.2"
-    "got" "^9.6.0"
-    "is-ip" "^3.1.0"
 
 "public-ip@^5.0.0":
   "integrity" "sha1-s5L8yIVSw7NpM6KGBolIgWUV+So="
@@ -1754,13 +1659,6 @@
     "is-core-module" "^2.9.0"
     "path-parse" "^1.0.7"
     "supports-preserve-symlinks-flag" "^1.0.0"
-
-"responselike@^1.0.2":
-  "integrity" "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/responselike/-/responselike-1.0.2.tgz"
-  "version" "1.0.2"
-  dependencies:
-    "lowercase-keys" "^1.0.0"
 
 "responselike@^2.0.0":
   "integrity" "sha1-mgvI/cJS8/scymiwFlkQWboUIrw="
@@ -1937,11 +1835,6 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   "version" "1.0.0"
 
-"to-readable-stream@^1.0.0":
-  "integrity" "sha1-zgqgwvPfat+FLvtASng+d8BHV3E="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-readable-stream/-/to-readable-stream-1.0.0.tgz"
-  "version" "1.0.0"
-
 "to-regex-range@^5.0.1":
   "integrity" "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz"
@@ -2020,13 +1913,6 @@
     "listenercount" "~1.0.1"
     "readable-stream" "~2.3.6"
     "setimmediate" "~1.0.4"
-
-"url-parse-lax@^3.0.0":
-  "integrity" "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-parse-lax/-/url-parse-lax-3.0.0.tgz"
-  "version" "3.0.0"
-  dependencies:
-    "prepend-http" "^2.0.0"
 
 "util-deprecate@~1.0.1":
   "integrity" "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="

--- a/vscode-dotnet-runtime-library/yarn.lock
+++ b/vscode-dotnet-runtime-library/yarn.lock
@@ -94,7 +94,7 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/http-cache-semantics@*", "@types/http-cache-semantics@^4.0.1", "@types/http-cache-semantics@^4.0.2":
+"@types/http-cache-semantics@*", "@types/http-cache-semantics@^4.0.1":
   "integrity" "sha1-uXnrrTkZeZyXmxfHJiHAvAoxxsQ="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz"
   "version" "4.0.4"
@@ -189,14 +189,6 @@
   "version" "6.0.2"
   dependencies:
     "debug" "4"
-
-"aggregate-error@^4.0.0":
-  "integrity" "sha1-JQkf4Vc7ngvokq7aFcfGalRfdY4="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/aggregate-error/-/aggregate-error-4.0.1.tgz"
-  "version" "4.0.1"
-  dependencies:
-    "clean-stack" "^4.0.0"
-    "indent-string" "^5.0.0"
 
 "ansi-colors@4.1.1":
   "integrity" "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g="
@@ -357,11 +349,11 @@
   "version" "7.0.0"
 
 "cacheable-request@^10.2.8":
-  "integrity" "sha1-65FbZl/aQbeWUngt8/VTRJxAa50="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.14.tgz"
-  "version" "10.2.14"
+  "integrity" "sha1-twErtKKs2xjLVNLf91HXZrNQCEI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-10.2.13.tgz"
+  "version" "10.2.13"
   dependencies:
-    "@types/http-cache-semantics" "^4.0.2"
+    "@types/http-cache-semantics" "^4.0.1"
     "get-stream" "^6.0.1"
     "http-cache-semantics" "^4.1.1"
     "keyv" "^4.5.3"
@@ -467,13 +459,6 @@
     "readdirp" "~3.6.0"
   optionalDependencies:
     "fsevents" "~2.3.2"
-
-"clean-stack@^4.0.0":
-  "integrity" "sha1-xGTkzeSseJ9OBzXF11vrSdezCzE="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/clean-stack/-/clean-stack-4.2.0.tgz"
-  "version" "4.2.0"
-  dependencies:
-    "escape-string-regexp" "5.0.0"
 
 "cliui@^7.0.2":
   "integrity" "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08="
@@ -707,11 +692,6 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   "version" "4.0.0"
 
-"escape-string-regexp@5.0.0":
-  "integrity" "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz"
-  "version" "5.0.0"
-
 "esprima@^4.0.0":
   "integrity" "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz"
@@ -890,23 +870,6 @@
     "p-cancelable" "^3.0.0"
     "responselike" "^3.0.0"
 
-"got@^12.1.0":
-  "integrity" "sha1-iGlWDRODNTIEtalDX3gt+cCR9Uk="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-12.6.1.tgz"
-  "version" "12.6.1"
-  dependencies:
-    "@sindresorhus/is" "^5.2.0"
-    "@szmarczak/http-timer" "^5.0.1"
-    "cacheable-lookup" "^7.0.0"
-    "cacheable-request" "^10.2.8"
-    "decompress-response" "^6.0.0"
-    "form-data-encoder" "^2.1.2"
-    "get-stream" "^6.0.1"
-    "http2-wrapper" "^2.1.10"
-    "lowercase-keys" "^3.0.0"
-    "p-cancelable" "^3.0.0"
-    "responselike" "^3.0.0"
-
 "got@11.8.5":
   "integrity" "sha1-znfQRRNt5W6PAkvruC6jSbxzAEY="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/got/-/got-11.8.5.tgz"
@@ -1003,9 +966,9 @@
     "resolve-alpn" "^1.0.0"
 
 "http2-wrapper@^2.1.10":
-  "integrity" "sha1-MQloFT3N7bFg2LchFDY+9fzh9ko="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.1.tgz"
-  "version" "2.2.1"
+  "integrity" "sha1-uArRmdIWt9NoAZUHe9e5Bg+p1/M="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http2-wrapper/-/http2-wrapper-2.2.0.tgz"
+  "version" "2.2.0"
   dependencies:
     "quick-lru" "^5.1.1"
     "resolve-alpn" "^1.2.0"
@@ -1025,11 +988,6 @@
   dependencies:
     "agent-base" "^7.0.2"
     "debug" "4"
-
-"indent-string@^5.0.0":
-  "integrity" "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz"
-  "version" "5.0.0"
 
 "inflight@^1.0.4":
   "integrity" "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
@@ -1154,16 +1112,6 @@
   "integrity" "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz"
   "version" "7.0.0"
-
-"is-online@^10.0.0":
-  "integrity" "sha1-XgLO6fgi/ZwZsGDw7L3HmNNylaM="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-online/-/is-online-10.0.0.tgz"
-  "version" "10.0.0"
-  dependencies:
-    "got" "^12.1.0"
-    "p-any" "^4.0.0"
-    "p-timeout" "^5.1.0"
-    "public-ip" "^5.0.0"
 
 "is-plain-obj@^2.1.0":
   "integrity" "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc="
@@ -1411,9 +1359,9 @@
   "version" "6.1.0"
 
 "normalize-url@^8.0.0":
-  "integrity" "sha1-m32Wr5g2V3xY9Yg+k5Nl+hViOko="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.1.tgz"
-  "version" "8.0.1"
+  "integrity" "sha1-WT29KE90Po3Pal3fj63/FJyCcBo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/normalize-url/-/normalize-url-8.0.0.tgz"
+  "version" "8.0.0"
 
 "npm-conf@~1.1.3":
   "integrity" "sha1-JWzEe9DiGMJZxOlVC/QTvCGSr/k="
@@ -1464,14 +1412,6 @@
     "is-docker" "^2.1.1"
     "is-wsl" "^2.2.0"
 
-"p-any@^4.0.0":
-  "integrity" "sha1-DpyLD6PljMeeahxscVqpMmtqREc="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-any/-/p-any-4.0.0.tgz"
-  "version" "4.0.0"
-  dependencies:
-    "p-cancelable" "^3.0.0"
-    "p-some" "^6.0.0"
-
 "p-cancelable@^2.0.0":
   "integrity" "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz"
@@ -1503,19 +1443,6 @@
   dependencies:
     "@types/retry" "^0.12.0"
     "retry" "^0.13.1"
-
-"p-some@^6.0.0":
-  "integrity" "sha1-RhOoIgOKvhJeQhUuqfdwWnlnUm8="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-some/-/p-some-6.0.0.tgz"
-  "version" "6.0.0"
-  dependencies:
-    "aggregate-error" "^4.0.0"
-    "p-cancelable" "^3.0.0"
-
-"p-timeout@^5.1.0":
-  "integrity" "sha1-s8aRz0QVE4zi2c/gcduhHw/uCFs="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-timeout/-/p-timeout-5.1.0.tgz"
-  "version" "5.1.0"
 
 "path-exists@^4.0.0":
   "integrity" "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,978 +3,995 @@
 
 
 "@isaacs/cliui@^8.0.2":
-  version "8.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz"
-  integrity sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=
+  "integrity" "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz"
+  "version" "8.0.2"
   dependencies:
-    string-width "^5.1.2"
-    string-width-cjs "npm:string-width@^4.2.0"
-    strip-ansi "^7.0.1"
-    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
-    wrap-ansi "^8.1.0"
-    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+    "string-width" "^5.1.2"
+    "string-width-cjs" "npm:string-width@^4.2.0"
+    "strip-ansi" "^7.0.1"
+    "strip-ansi-cjs" "npm:strip-ansi@^6.0.1"
+    "wrap-ansi" "^8.1.0"
+    "wrap-ansi-cjs" "npm:wrap-ansi@^7.0.0"
 
 "@pkgjs/parseargs@^0.11.0":
-  version "0.11.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
-  integrity sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=
+  "integrity" "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
+  "version" "0.11.0"
 
-ansi-regex@^5.0.1:
-  version "5.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz"
-  integrity sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=
-
-ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-6.0.1.tgz"
-  integrity sha1-MYPjj66aZdfLXlOUXNWJfQJgoGo=
 "@types/source-map-support@^0.5.6":
-  version "0.5.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/source-map-support/-/source-map-support-0.5.6.tgz"
-  integrity sha1-qkqMmOxzofHzCoE1c6myFUpus5o=
+  "integrity" "sha1-qkqMmOxzofHzCoE1c6myFUpus5o="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/source-map-support/-/source-map-support-0.5.6.tgz"
+  "version" "0.5.6"
   dependencies:
-    source-map "^0.6.0"
+    "source-map" "^0.6.0"
 
-ansi-styles@^3.2.1:
-  version "3.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz"
-  integrity sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=
+"ansi-regex@^5.0.1":
+  "integrity" "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz"
+  "version" "5.0.1"
+
+"ansi-regex@^6.0.1":
+  "integrity" "sha1-MYPjj66aZdfLXlOUXNWJfQJgoGo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-6.0.1.tgz"
+  "version" "6.0.1"
+
+"ansi-styles@^3.2.1":
+  "integrity" "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz"
+  "version" "3.2.1"
   dependencies:
-    color-convert "^1.9.0"
+    "color-convert" "^1.9.0"
 
-ansi-styles@^4.0.0:
-  version "4.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz"
-  integrity sha1-7dgDYornHATIWuegkG7a00tkiTc=
+"ansi-styles@^4.0.0":
+  "integrity" "sha1-7dgDYornHATIWuegkG7a00tkiTc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz"
+  "version" "4.3.0"
   dependencies:
-    color-convert "^2.0.1"
+    "color-convert" "^2.0.1"
 
-ansi-styles@^6.1.0:
-  version "6.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-6.2.1.tgz"
-  integrity sha1-DmIyDPmcIa//OzASGSVGqsv7BcU=
+"ansi-styles@^6.1.0":
+  "integrity" "sha1-DmIyDPmcIa//OzASGSVGqsv7BcU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-6.2.1.tgz"
+  "version" "6.2.1"
 
-argparse@^2.0.1:
-  version "2.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz"
-  integrity sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=
+"argparse@^2.0.1":
+  "integrity" "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz"
+  "version" "2.0.1"
 
-azure-devops-node-api@^11.0.1:
-  version "11.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz"
-  integrity sha1-vwTtvvYDExF6BQdBXu1HkKQgrWs=
+"azure-devops-node-api@^11.0.1":
+  "integrity" "sha1-vwTtvvYDExF6BQdBXu1HkKQgrWs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz"
+  "version" "11.2.0"
   dependencies:
-    tunnel "0.0.6"
-    typed-rest-client "^1.8.4"
+    "tunnel" "0.0.6"
+    "typed-rest-client" "^1.8.4"
 
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz"
-  integrity sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=
+"balanced-match@^1.0.0":
+  "integrity" "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz"
+  "version" "1.0.2"
 
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/base64-js/-/base64-js-1.5.1.tgz"
-  integrity sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=
+"base64-js@^1.3.1":
+  "integrity" "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/base64-js/-/base64-js-1.5.1.tgz"
+  "version" "1.5.1"
 
-bl@^4.0.3:
-  version "4.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bl/-/bl-4.1.0.tgz"
-  integrity sha1-RRU1JkGCvsL7vIOmKrmM8R2fezo=
+"bl@^4.0.3":
+  "integrity" "sha1-RRU1JkGCvsL7vIOmKrmM8R2fezo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bl/-/bl-4.1.0.tgz"
+  "version" "4.1.0"
   dependencies:
-    buffer "^5.5.0"
-    inherits "^2.0.4"
-    readable-stream "^3.4.0"
+    "buffer" "^5.5.0"
+    "inherits" "^2.0.4"
+    "readable-stream" "^3.4.0"
 
-boolbase@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/boolbase/-/boolbase-1.0.0.tgz"
-  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+"boolbase@^1.0.0":
+  "integrity" "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/boolbase/-/boolbase-1.0.0.tgz"
+  "version" "1.0.0"
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz"
-  integrity sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=
+"brace-expansion@^1.1.7":
+  "integrity" "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz"
+  "version" "1.1.11"
   dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
+    "balanced-match" "^1.0.0"
+    "concat-map" "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz"
-  integrity sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=
+"brace-expansion@^2.0.1":
+  "integrity" "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz"
+  "version" "2.0.1"
   dependencies:
-    balanced-match "^1.0.0"
+    "balanced-match" "^1.0.0"
 
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
-  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+"buffer-crc32@~0.2.3":
+  "integrity" "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
+  "version" "0.2.13"
 
-buffer@^5.5.0:
-  version "5.7.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer/-/buffer-5.7.1.tgz"
-  integrity sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=
+"buffer@^5.5.0":
+  "integrity" "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer/-/buffer-5.7.1.tgz"
+  "version" "5.7.1"
   dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.1.13"
+    "base64-js" "^1.3.1"
+    "ieee754" "^1.1.13"
 
-call-bind@^1.0.0:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind/-/call-bind-1.0.2.tgz"
-  integrity sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=
+"call-bind@^1.0.0":
+  "integrity" "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind/-/call-bind-1.0.2.tgz"
+  "version" "1.0.2"
   dependencies:
-    function-bind "^1.1.1"
-    get-intrinsic "^1.0.2"
+    "function-bind" "^1.1.1"
+    "get-intrinsic" "^1.0.2"
 
-chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz"
-  integrity sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=
+"chalk@^2.4.2":
+  "integrity" "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz"
+  "version" "2.4.2"
   dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
+    "ansi-styles" "^3.2.1"
+    "escape-string-regexp" "^1.0.5"
+    "supports-color" "^5.3.0"
 
-cheerio-select@^2.1.0:
-  version "2.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cheerio-select/-/cheerio-select-2.1.0.tgz"
-  integrity sha1-TYZzKGuBJsoqjkJ0DV48SISuIbQ=
+"cheerio-select@^2.1.0":
+  "integrity" "sha1-TYZzKGuBJsoqjkJ0DV48SISuIbQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cheerio-select/-/cheerio-select-2.1.0.tgz"
+  "version" "2.1.0"
   dependencies:
-    boolbase "^1.0.0"
-    css-select "^5.1.0"
-    css-what "^6.1.0"
-    domelementtype "^2.3.0"
-    domhandler "^5.0.3"
-    domutils "^3.0.1"
+    "boolbase" "^1.0.0"
+    "css-select" "^5.1.0"
+    "css-what" "^6.1.0"
+    "domelementtype" "^2.3.0"
+    "domhandler" "^5.0.3"
+    "domutils" "^3.0.1"
 
-cheerio@^1.0.0-rc.9:
-  version "1.0.0-rc.12"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cheerio/-/cheerio-1.0.0-rc.12.tgz"
-  integrity sha1-eIv3RmUGsca/X65R0kosTWLkdoM=
+"cheerio@^1.0.0-rc.9":
+  "integrity" "sha1-eIv3RmUGsca/X65R0kosTWLkdoM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cheerio/-/cheerio-1.0.0-rc.12.tgz"
+  "version" "1.0.0-rc.12"
   dependencies:
-    cheerio-select "^2.1.0"
-    dom-serializer "^2.0.0"
-    domhandler "^5.0.3"
-    domutils "^3.0.1"
-    htmlparser2 "^8.0.1"
-    parse5 "^7.0.0"
-    parse5-htmlparser2-tree-adapter "^7.0.0"
+    "cheerio-select" "^2.1.0"
+    "dom-serializer" "^2.0.0"
+    "domhandler" "^5.0.3"
+    "domutils" "^3.0.1"
+    "htmlparser2" "^8.0.1"
+    "parse5" "^7.0.0"
+    "parse5-htmlparser2-tree-adapter" "^7.0.0"
 
-chownr@^1.1.1:
-  version "1.1.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chownr/-/chownr-1.1.4.tgz"
-  integrity sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=
+"chownr@^1.1.1":
+  "integrity" "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chownr/-/chownr-1.1.4.tgz"
+  "version" "1.1.4"
 
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz"
-  integrity sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=
+"color-convert@^1.9.0":
+  "integrity" "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz"
+  "version" "1.9.3"
   dependencies:
-    color-name "1.1.3"
+    "color-name" "1.1.3"
 
-color-convert@^2.0.1:
-  version "2.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz"
-  integrity sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=
+"color-convert@^2.0.1":
+  "integrity" "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz"
+  "version" "2.0.1"
   dependencies:
-    color-name "~1.1.4"
+    "color-name" "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+"color-name@~1.1.4":
+  "integrity" "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.4.tgz"
+  "version" "1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.4.tgz"
-  integrity sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=
+"color-name@1.1.3":
+  "integrity" "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz"
+  "version" "1.1.3"
 
-commander@^6.1.0:
-  version "6.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-6.2.1.tgz"
-  integrity sha1-B5LraC37wyWZm7K4T93duhEKxzw=
+"commander@^6.1.0":
+  "integrity" "sha1-B5LraC37wyWZm7K4T93duhEKxzw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-6.2.1.tgz"
+  "version" "6.2.1"
 
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+"concat-map@0.0.1":
+  "integrity" "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz"
+  "version" "0.0.1"
 
-cross-spawn@^7.0.0:
-  version "7.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.3.tgz"
-  integrity sha1-9zqFudXUHQRVUcF34ogtSshXKKY=
+"cross-spawn@^7.0.0":
+  "integrity" "sha1-9zqFudXUHQRVUcF34ogtSshXKKY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.3.tgz"
+  "version" "7.0.3"
   dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
+    "path-key" "^3.1.0"
+    "shebang-command" "^2.0.0"
+    "which" "^2.0.1"
 
-css-select@^5.1.0:
-  version "5.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-select/-/css-select-5.1.0.tgz"
-  integrity sha1-uOvWVUw2N8zHZoiAStP2pv2uqKY=
+"css-select@^5.1.0":
+  "integrity" "sha1-uOvWVUw2N8zHZoiAStP2pv2uqKY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-select/-/css-select-5.1.0.tgz"
+  "version" "5.1.0"
   dependencies:
-    boolbase "^1.0.0"
-    css-what "^6.1.0"
-    domhandler "^5.0.2"
-    domutils "^3.0.1"
-    nth-check "^2.0.1"
+    "boolbase" "^1.0.0"
+    "css-what" "^6.1.0"
+    "domhandler" "^5.0.2"
+    "domutils" "^3.0.1"
+    "nth-check" "^2.0.1"
 
-css-what@^6.1.0:
-  version "6.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-what/-/css-what-6.1.0.tgz"
-  integrity sha1-+17/z3bx3eosgb36pN5E55uscPQ=
+"css-what@^6.1.0":
+  "integrity" "sha1-+17/z3bx3eosgb36pN5E55uscPQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-what/-/css-what-6.1.0.tgz"
+  "version" "6.1.0"
 
-decompress-response@^6.0.0:
-  version "6.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz"
-  integrity sha1-yjh2Et234QS9FthaqwDV7PCcZvw=
+"decompress-response@^6.0.0":
+  "integrity" "sha1-yjh2Et234QS9FthaqwDV7PCcZvw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    mimic-response "^3.1.0"
+    "mimic-response" "^3.1.0"
 
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-extend/-/deep-extend-0.6.0.tgz"
-  integrity sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=
+"deep-extend@^0.6.0":
+  "integrity" "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-extend/-/deep-extend-0.6.0.tgz"
+  "version" "0.6.0"
 
-detect-libc@^2.0.0:
-  version "2.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.0.1.tgz"
-  integrity sha1-4Yl6qI+mrRl4YpN/vARB7zUu4M0=
+"detect-libc@^2.0.0":
+  "integrity" "sha1-8M1QO0D5k5uJRpfRmtUIleMM9wA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.0.3.tgz"
+  "version" "2.0.3"
 
-dom-serializer@^2.0.0:
-  version "2.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dom-serializer/-/dom-serializer-2.0.0.tgz"
-  integrity sha1-5BuALh7t+fbK4YPOXmIteJ19jlM=
+"dom-serializer@^2.0.0":
+  "integrity" "sha1-5BuALh7t+fbK4YPOXmIteJ19jlM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dom-serializer/-/dom-serializer-2.0.0.tgz"
+  "version" "2.0.0"
   dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.2"
-    entities "^4.2.0"
+    "domelementtype" "^2.3.0"
+    "domhandler" "^5.0.2"
+    "entities" "^4.2.0"
 
-domelementtype@^2.3.0:
-  version "2.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domelementtype/-/domelementtype-2.3.0.tgz"
-  integrity sha1-XEXo6GmVJiYzHXqrMm0B2vZdWJ0=
+"domelementtype@^2.3.0":
+  "integrity" "sha1-XEXo6GmVJiYzHXqrMm0B2vZdWJ0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domelementtype/-/domelementtype-2.3.0.tgz"
+  "version" "2.3.0"
 
-domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
-  version "5.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domhandler/-/domhandler-5.0.3.tgz"
-  integrity sha1-zDhff3UfHR/GUMITdIBCVFOMfTE=
+"domhandler@^5.0.1", "domhandler@^5.0.2", "domhandler@^5.0.3":
+  "integrity" "sha1-zDhff3UfHR/GUMITdIBCVFOMfTE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domhandler/-/domhandler-5.0.3.tgz"
+  "version" "5.0.3"
   dependencies:
-    domelementtype "^2.3.0"
+    "domelementtype" "^2.3.0"
 
-domutils@^3.0.1:
-  version "3.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domutils/-/domutils-3.0.1.tgz"
-  integrity sha1-aWs4dSODOMsYa2wGEr1JAciaTxw=
+"domutils@^3.0.1":
+  "integrity" "sha1-aWs4dSODOMsYa2wGEr1JAciaTxw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domutils/-/domutils-3.0.1.tgz"
+  "version" "3.0.1"
   dependencies:
-    dom-serializer "^2.0.0"
-    domelementtype "^2.3.0"
-    domhandler "^5.0.1"
+    "dom-serializer" "^2.0.0"
+    "domelementtype" "^2.3.0"
+    "domhandler" "^5.0.1"
 
-eastasianwidth@^0.2.0:
-  version "0.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
-  integrity sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=
+"eastasianwidth@^0.2.0":
+  "integrity" "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
+  "version" "0.2.0"
 
-emoji-regex@^8.0.0:
-  version "8.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz"
-  integrity sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=
+"emoji-regex@^8.0.0":
+  "integrity" "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz"
+  "version" "8.0.0"
 
-emoji-regex@^9.2.2:
-  version "9.2.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz"
-  integrity sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=
+"emoji-regex@^9.2.2":
+  "integrity" "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz"
+  "version" "9.2.2"
 
-end-of-stream@^1.1.0, end-of-stream@^1.4.1:
-  version "1.4.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz"
-  integrity sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=
+"end-of-stream@^1.1.0", "end-of-stream@^1.4.1":
+  "integrity" "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz"
+  "version" "1.4.4"
   dependencies:
-    once "^1.4.0"
+    "once" "^1.4.0"
 
-entities@^4.2.0, entities@^4.3.0, entities@^4.4.0:
-  version "4.4.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-4.4.0.tgz"
-  integrity sha1-l72roXAzlEZJXmU8/S23iWKQAXQ=
+"entities@^4.2.0", "entities@^4.3.0", "entities@^4.4.0":
+  "integrity" "sha1-l72roXAzlEZJXmU8/S23iWKQAXQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-4.4.0.tgz"
+  "version" "4.4.0"
 
-entities@~2.1.0:
-  version "2.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-2.1.0.tgz"
-  integrity sha1-mS0xKc999ocLlsV4WMJJoSD4uLU=
+"entities@~2.1.0":
+  "integrity" "sha1-mS0xKc999ocLlsV4WMJJoSD4uLU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-2.1.0.tgz"
+  "version" "2.1.0"
 
-escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+"escape-string-regexp@^1.0.5":
+  "integrity" "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+  "version" "1.0.5"
 
-expand-template@^2.0.3:
-  version "2.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/expand-template/-/expand-template-2.0.3.tgz"
-  integrity sha1-bhSz/O4POmNA7LV9LokYaSBSpHw=
+"expand-template@^2.0.3":
+  "integrity" "sha1-bhSz/O4POmNA7LV9LokYaSBSpHw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/expand-template/-/expand-template-2.0.3.tgz"
+  "version" "2.0.3"
 
-fd-slicer@~1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fd-slicer/-/fd-slicer-1.1.0.tgz"
-  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+"fd-slicer@~1.1.0":
+  "integrity" "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fd-slicer/-/fd-slicer-1.1.0.tgz"
+  "version" "1.1.0"
   dependencies:
-    pend "~1.2.0"
+    "pend" "~1.2.0"
 
-foreground-child@^3.1.0:
-  version "3.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/foreground-child/-/foreground-child-3.1.1.tgz"
-  integrity sha1-HRc+d2110ncv7Qjv5KDeHqGxLQ0=
+"foreground-child@^3.1.0":
+  "integrity" "sha1-HRc+d2110ncv7Qjv5KDeHqGxLQ0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/foreground-child/-/foreground-child-3.1.1.tgz"
+  "version" "3.1.1"
   dependencies:
-    cross-spawn "^7.0.0"
-    signal-exit "^4.0.1"
+    "cross-spawn" "^7.0.0"
+    "signal-exit" "^4.0.1"
 
-fs-constants@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz"
-  integrity sha1-a+Dem+mYzhavivwkSXue6bfM2a0=
+"fs-constants@^1.0.0":
+  "integrity" "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz"
+  "version" "1.0.0"
 
-fs.realpath@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz"
-  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+"fs.realpath@^1.0.0":
+  "integrity" "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz"
+  "version" "1.0.0"
 
-function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz"
-  integrity sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=
+"function-bind@^1.1.1":
+  "integrity" "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz"
+  "version" "1.1.1"
 
-get-intrinsic@^1.0.2:
-  version "1.1.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.1.3.tgz"
-  integrity sha1-BjyEMprZPoOJPH9PJD72P/o1E4U=
+"get-intrinsic@^1.0.2":
+  "integrity" "sha1-BjyEMprZPoOJPH9PJD72P/o1E4U="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.1.3.tgz"
+  "version" "1.1.3"
   dependencies:
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-symbols "^1.0.3"
+    "function-bind" "^1.1.1"
+    "has" "^1.0.3"
+    "has-symbols" "^1.0.3"
 
-github-from-package@0.0.0:
-  version "0.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/github-from-package/-/github-from-package-0.0.0.tgz"
-  integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
+"github-from-package@0.0.0":
+  "integrity" "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/github-from-package/-/github-from-package-0.0.0.tgz"
+  "version" "0.0.0"
 
-glob@^10.2.5:
-  version "10.3.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-10.3.3.tgz"
-  integrity sha1-g2Ck/91u2Q34SqjVLyH0UuhqEjs=
+"glob@^10.2.5":
+  "integrity" "sha1-g2Ck/91u2Q34SqjVLyH0UuhqEjs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-10.3.3.tgz"
+  "version" "10.3.3"
   dependencies:
-    foreground-child "^3.1.0"
-    jackspeak "^2.0.3"
-    minimatch "^9.0.1"
-    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
-    path-scurry "^1.10.1"
+    "foreground-child" "^3.1.0"
+    "jackspeak" "^2.0.3"
+    "minimatch" "^9.0.1"
+    "minipass" "^5.0.0 || ^6.0.2 || ^7.0.0"
+    "path-scurry" "^1.10.1"
 
-glob@^7.0.6, glob@^7.1.3:
-  version "7.2.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.3.tgz"
-  integrity sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=
+"glob@^7.0.6", "glob@^7.1.3":
+  "integrity" "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.3.tgz"
+  "version" "7.2.3"
   dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.1.1"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
+    "fs.realpath" "^1.0.0"
+    "inflight" "^1.0.4"
+    "inherits" "2"
+    "minimatch" "^3.1.1"
+    "once" "^1.3.0"
+    "path-is-absolute" "^1.0.0"
 
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+"has-flag@^3.0.0":
+  "integrity" "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz"
+  "version" "3.0.0"
 
-has-symbols@^1.0.3:
-  version "1.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz"
-  integrity sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg=
+"has-symbols@^1.0.3":
+  "integrity" "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz"
+  "version" "1.0.3"
 
-has@^1.0.3:
-  version "1.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has/-/has-1.0.3.tgz"
-  integrity sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=
+"has@^1.0.3":
+  "integrity" "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has/-/has-1.0.3.tgz"
+  "version" "1.0.3"
   dependencies:
-    function-bind "^1.1.1"
+    "function-bind" "^1.1.1"
 
-hosted-git-info@^4.0.2:
-  version "4.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hosted-git-info/-/hosted-git-info-4.1.0.tgz"
-  integrity sha1-gnuChn6f8cjQxNnVOIA5fSyG0iQ=
+"hosted-git-info@^4.0.2":
+  "integrity" "sha1-gnuChn6f8cjQxNnVOIA5fSyG0iQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hosted-git-info/-/hosted-git-info-4.1.0.tgz"
+  "version" "4.1.0"
   dependencies:
-    lru-cache "^6.0.0"
+    "lru-cache" "^6.0.0"
 
-htmlparser2@^8.0.1:
-  version "8.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/htmlparser2/-/htmlparser2-8.0.1.tgz"
-  integrity sha1-q6qYVHT87+JpvHYad5tUTXGW0BA=
+"htmlparser2@^8.0.1":
+  "integrity" "sha1-q6qYVHT87+JpvHYad5tUTXGW0BA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/htmlparser2/-/htmlparser2-8.0.1.tgz"
+  "version" "8.0.1"
   dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.2"
-    domutils "^3.0.1"
-    entities "^4.3.0"
+    "domelementtype" "^2.3.0"
+    "domhandler" "^5.0.2"
+    "domutils" "^3.0.1"
+    "entities" "^4.3.0"
 
-ieee754@^1.1.13:
-  version "1.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ieee754/-/ieee754-1.2.1.tgz"
-  integrity sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=
+"ieee754@^1.1.13":
+  "integrity" "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ieee754/-/ieee754-1.2.1.tgz"
+  "version" "1.2.1"
 
-inflight@^1.0.4:
-  version "1.0.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz"
-  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+"inflight@^1.0.4":
+  "integrity" "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz"
+  "version" "1.0.6"
   dependencies:
-    once "^1.3.0"
-    wrappy "1"
+    "once" "^1.3.0"
+    "wrappy" "1"
 
-inherits@^2.0.3, inherits@^2.0.4, inherits@2:
-  version "2.0.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inherits/-/inherits-2.0.4.tgz"
-  integrity sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=
+"inherits@^2.0.3", "inherits@^2.0.4", "inherits@2":
+  "integrity" "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inherits/-/inherits-2.0.4.tgz"
+  "version" "2.0.4"
 
-ini@~1.3.0:
-  version "1.3.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ini/-/ini-1.3.8.tgz"
-  integrity sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw=
+"ini@~1.3.0":
+  "integrity" "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ini/-/ini-1.3.8.tgz"
+  "version" "1.3.8"
 
-is-fullwidth-code-point@^3.0.0:
-  version "3.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
-  integrity sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=
+"is-fullwidth-code-point@^3.0.0":
+  "integrity" "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
+  "version" "3.0.0"
 
-isexe@^2.0.0:
-  version "2.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz"
-  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+"isexe@^2.0.0":
+  "integrity" "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz"
+  "version" "2.0.0"
 
-jackspeak@^2.0.3:
-  version "2.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jackspeak/-/jackspeak-2.2.1.tgz"
-  integrity sha1-ZV6M8CXYcsnAPT62Po8MAk/vFqY=
+"jackspeak@^2.0.3":
+  "integrity" "sha1-ZV6M8CXYcsnAPT62Po8MAk/vFqY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jackspeak/-/jackspeak-2.2.1.tgz"
+  "version" "2.2.1"
   dependencies:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
-keytar@^7.7.0:
-  version "7.9.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keytar/-/keytar-7.9.0.tgz"
-  integrity sha1-TGIlcI9RtQy/d8Wq6BchlkwpGMs=
+"keytar@^7.7.0":
+  "integrity" "sha1-TGIlcI9RtQy/d8Wq6BchlkwpGMs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keytar/-/keytar-7.9.0.tgz"
+  "version" "7.9.0"
   dependencies:
-    node-addon-api "^4.3.0"
-    prebuild-install "^7.0.1"
+    "node-addon-api" "^4.3.0"
+    "prebuild-install" "^7.0.1"
 
-leven@^3.1.0:
-  version "3.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/leven/-/leven-3.1.0.tgz"
-  integrity sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=
+"leven@^3.1.0":
+  "integrity" "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/leven/-/leven-3.1.0.tgz"
+  "version" "3.1.0"
 
-linkify-it@^3.0.1:
-  version "3.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/linkify-it/-/linkify-it-3.0.3.tgz"
-  integrity sha1-qYuvRM5FpVDvtNScdp0HUkzC+i4=
+"linkify-it@^3.0.1":
+  "integrity" "sha1-qYuvRM5FpVDvtNScdp0HUkzC+i4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/linkify-it/-/linkify-it-3.0.3.tgz"
+  "version" "3.0.3"
   dependencies:
-    uc.micro "^1.0.1"
+    "uc.micro" "^1.0.1"
 
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz"
-  integrity sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=
+"lru-cache@^6.0.0":
+  "integrity" "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    yallist "^4.0.0"
+    "yallist" "^4.0.0"
 
 "lru-cache@^9.1.1 || ^10.0.0":
-  version "10.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-10.0.0.tgz"
-  integrity sha1-ueKmpyoSnYGrMXIC2Tx2kd9yfmE=
+  "integrity" "sha1-ueKmpyoSnYGrMXIC2Tx2kd9yfmE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-10.0.0.tgz"
+  "version" "10.0.0"
 
-markdown-it@^12.3.2:
-  version "12.3.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/markdown-it/-/markdown-it-12.3.2.tgz"
-  integrity sha1-v5Kskig/6YP+Tej/ir+1rXLNDJA=
+"markdown-it@^12.3.2":
+  "integrity" "sha1-v5Kskig/6YP+Tej/ir+1rXLNDJA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/markdown-it/-/markdown-it-12.3.2.tgz"
+  "version" "12.3.2"
   dependencies:
-    argparse "^2.0.1"
-    entities "~2.1.0"
-    linkify-it "^3.0.1"
-    mdurl "^1.0.1"
-    uc.micro "^1.0.5"
+    "argparse" "^2.0.1"
+    "entities" "~2.1.0"
+    "linkify-it" "^3.0.1"
+    "mdurl" "^1.0.1"
+    "uc.micro" "^1.0.5"
 
-mdurl@^1.0.1:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mdurl/-/mdurl-1.0.1.tgz"
-  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
+"mdurl@^1.0.1":
+  "integrity" "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mdurl/-/mdurl-1.0.1.tgz"
+  "version" "1.0.1"
 
-mime@^1.3.4:
-  version "1.6.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime/-/mime-1.6.0.tgz"
-  integrity sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=
+"mime@^1.3.4":
+  "integrity" "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime/-/mime-1.6.0.tgz"
+  "version" "1.6.0"
 
-mimic-response@^3.1.0:
-  version "3.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz"
-  integrity sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k=
+"mimic-response@^3.1.0":
+  "integrity" "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz"
+  "version" "3.1.0"
 
-minimatch@^3.0.3, minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz"
-  integrity sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=
+"minimatch@^3.0.3", "minimatch@^3.1.1":
+  "integrity" "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz"
+  "version" "3.1.2"
   dependencies:
-    brace-expansion "^1.1.7"
+    "brace-expansion" "^1.1.7"
 
-minimatch@^9.0.1:
-  version "9.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-9.0.3.tgz"
-  integrity sha1-puAMPeRMOlQr+q5wq/wiQgptqCU=
+"minimatch@^9.0.1":
+  "integrity" "sha1-puAMPeRMOlQr+q5wq/wiQgptqCU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-9.0.3.tgz"
+  "version" "9.0.3"
   dependencies:
-    brace-expansion "^2.0.1"
+    "brace-expansion" "^2.0.1"
 
-minimist@^1.2.0, minimist@^1.2.3:
-  version "1.2.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.6.tgz"
-  integrity sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q=
+"minimist@^1.2.0", "minimist@^1.2.3":
+  "integrity" "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.8.tgz"
+  "version" "1.2.8"
 
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
-  version "7.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minipass/-/minipass-7.0.2.tgz"
-  integrity sha1-WKgrfYHHAQ2lvUssDIWsS07FEx4=
+  "integrity" "sha1-WKgrfYHHAQ2lvUssDIWsS07FEx4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minipass/-/minipass-7.0.2.tgz"
+  "version" "7.0.2"
 
-mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
-  version "0.5.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz"
-  integrity sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM=
+"mkdirp-classic@^0.5.2", "mkdirp-classic@^0.5.3":
+  "integrity" "sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz"
+  "version" "0.5.3"
 
-mute-stream@~0.0.4:
-  version "0.0.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mute-stream/-/mute-stream-0.0.8.tgz"
-  integrity sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=
+"mute-stream@~0.0.4":
+  "integrity" "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mute-stream/-/mute-stream-0.0.8.tgz"
+  "version" "0.0.8"
 
-napi-build-utils@^1.0.1:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/napi-build-utils/-/napi-build-utils-1.0.2.tgz"
-  integrity sha1-sf3cCyxG44Cgt6dvmE3UfEGhOAY=
+"napi-build-utils@^1.0.1":
+  "integrity" "sha1-sf3cCyxG44Cgt6dvmE3UfEGhOAY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/napi-build-utils/-/napi-build-utils-1.0.2.tgz"
+  "version" "1.0.2"
 
-node-abi@^3.3.0:
-  version "3.24.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.24.0.tgz"
-  integrity sha1-udAzk6SfLH4UfQyZ8YDmgMJ8FZk=
+"node-abi@^3.3.0":
+  "integrity" "sha1-13LLiZI2wKpGd40NJSVpF88V6xU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.57.0.tgz"
+  "version" "3.57.0"
   dependencies:
-    semver "^7.3.5"
+    "semver" "^7.3.5"
 
-node-addon-api@^4.3.0:
-  version "4.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-addon-api/-/node-addon-api-4.3.0.tgz"
-  integrity sha1-UqGgtHUZPgko6Y4EJqDRJUeCt38=
+"node-addon-api@^4.3.0":
+  "integrity" "sha1-UqGgtHUZPgko6Y4EJqDRJUeCt38="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-addon-api/-/node-addon-api-4.3.0.tgz"
+  "version" "4.3.0"
 
-nth-check@^2.0.1:
-  version "2.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nth-check/-/nth-check-2.1.1.tgz"
-  integrity sha1-yeq0KO/842zWuSySS9sADvHx7R0=
+"nth-check@^2.0.1":
+  "integrity" "sha1-yeq0KO/842zWuSySS9sADvHx7R0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nth-check/-/nth-check-2.1.1.tgz"
+  "version" "2.1.1"
   dependencies:
-    boolbase "^1.0.0"
+    "boolbase" "^1.0.0"
 
-object-inspect@^1.9.0:
-  version "1.12.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-inspect/-/object-inspect-1.12.2.tgz"
-  integrity sha1-wGQfJjlFMvKKuNeWq5VOQ8AJqOo=
+"object-inspect@^1.9.0":
+  "integrity" "sha1-wGQfJjlFMvKKuNeWq5VOQ8AJqOo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-inspect/-/object-inspect-1.12.2.tgz"
+  "version" "1.12.2"
 
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
-  version "1.4.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/once/-/once-1.4.0.tgz"
-  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+"once@^1.3.0", "once@^1.3.1", "once@^1.4.0":
+  "integrity" "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/once/-/once-1.4.0.tgz"
+  "version" "1.4.0"
   dependencies:
-    wrappy "1"
+    "wrappy" "1"
 
-parse-semver@^1.1.1:
-  version "1.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse-semver/-/parse-semver-1.1.1.tgz"
-  integrity sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=
+"parse-semver@^1.1.1":
+  "integrity" "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse-semver/-/parse-semver-1.1.1.tgz"
+  "version" "1.1.1"
   dependencies:
-    semver "^5.1.0"
+    "semver" "^5.1.0"
 
-parse5-htmlparser2-tree-adapter@^7.0.0:
-  version "7.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz"
-  integrity sha1-I8LMIzvPCbt766i4pp1GsIxiwvE=
+"parse5-htmlparser2-tree-adapter@^7.0.0":
+  "integrity" "sha1-I8LMIzvPCbt766i4pp1GsIxiwvE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz"
+  "version" "7.0.0"
   dependencies:
-    domhandler "^5.0.2"
-    parse5 "^7.0.0"
+    "domhandler" "^5.0.2"
+    "parse5" "^7.0.0"
 
-parse5@^7.0.0:
-  version "7.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse5/-/parse5-7.1.1.tgz"
-  integrity sha1-Rkn5QMz7ldh1Tzf3MHjqIK/gx0Y=
+"parse5@^7.0.0":
+  "integrity" "sha1-Rkn5QMz7ldh1Tzf3MHjqIK/gx0Y="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse5/-/parse5-7.1.1.tgz"
+  "version" "7.1.1"
   dependencies:
-    entities "^4.4.0"
+    "entities" "^4.4.0"
 
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+"path-is-absolute@^1.0.0":
+  "integrity" "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+  "version" "1.0.1"
 
-path-key@^3.1.0:
-  version "3.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz"
-  integrity sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=
+"path-key@^3.1.0":
+  "integrity" "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz"
+  "version" "3.1.1"
 
-path-scurry@^1.10.1:
-  version "1.10.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-scurry/-/path-scurry-1.10.1.tgz"
-  integrity sha1-m6a/WqhQD+n9Z99PDZSDsrC/xpg=
+"path-scurry@^1.10.1":
+  "integrity" "sha1-m6a/WqhQD+n9Z99PDZSDsrC/xpg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-scurry/-/path-scurry-1.10.1.tgz"
+  "version" "1.10.1"
   dependencies:
-    lru-cache "^9.1.1 || ^10.0.0"
-    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+    "lru-cache" "^9.1.1 || ^10.0.0"
+    "minipass" "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pend/-/pend-1.2.0.tgz"
-  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+"pend@~1.2.0":
+  "integrity" "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pend/-/pend-1.2.0.tgz"
+  "version" "1.2.0"
 
-prebuild-install@^7.0.1:
-  version "7.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prebuild-install/-/prebuild-install-7.1.1.tgz"
-  integrity sha1-3pfVs0pwoMgTNP0kZB8qFwI1LkU=
+"prebuild-install@^7.0.1":
+  "integrity" "sha1-pf2ZhvWmJR+8R+Hlxl3nHmjAoFY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prebuild-install/-/prebuild-install-7.1.2.tgz"
+  "version" "7.1.2"
   dependencies:
-    detect-libc "^2.0.0"
-    expand-template "^2.0.3"
-    github-from-package "0.0.0"
-    minimist "^1.2.3"
-    mkdirp-classic "^0.5.3"
-    napi-build-utils "^1.0.1"
-    node-abi "^3.3.0"
-    pump "^3.0.0"
-    rc "^1.2.7"
-    simple-get "^4.0.0"
-    tar-fs "^2.0.0"
-    tunnel-agent "^0.6.0"
+    "detect-libc" "^2.0.0"
+    "expand-template" "^2.0.3"
+    "github-from-package" "0.0.0"
+    "minimist" "^1.2.3"
+    "mkdirp-classic" "^0.5.3"
+    "napi-build-utils" "^1.0.1"
+    "node-abi" "^3.3.0"
+    "pump" "^3.0.0"
+    "rc" "^1.2.7"
+    "simple-get" "^4.0.0"
+    "tar-fs" "^2.0.0"
+    "tunnel-agent" "^0.6.0"
 
-pump@^3.0.0:
-  version "3.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pump/-/pump-3.0.0.tgz"
-  integrity sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=
+"pump@^3.0.0":
+  "integrity" "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pump/-/pump-3.0.0.tgz"
+  "version" "3.0.0"
   dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
+    "end-of-stream" "^1.1.0"
+    "once" "^1.3.1"
 
-qs@^6.9.1:
-  version "6.11.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/qs/-/qs-6.11.0.tgz"
-  integrity sha1-/Q2WNEb3pl4TZ+AavYVClFPww3o=
+"qs@^6.9.1":
+  "integrity" "sha1-/Q2WNEb3pl4TZ+AavYVClFPww3o="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/qs/-/qs-6.11.0.tgz"
+  "version" "6.11.0"
   dependencies:
-    side-channel "^1.0.4"
+    "side-channel" "^1.0.4"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rc/-/rc-1.2.8.tgz"
-  integrity sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=
+"rc@^1.2.7":
+  "integrity" "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rc/-/rc-1.2.8.tgz"
+  "version" "1.2.8"
   dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
+    "deep-extend" "^0.6.0"
+    "ini" "~1.3.0"
+    "minimist" "^1.2.0"
+    "strip-json-comments" "~2.0.1"
 
-read@^1.0.7:
-  version "1.0.7"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/read/-/read-1.0.7.tgz"
-  integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
+"read@^1.0.7":
+  "integrity" "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/read/-/read-1.0.7.tgz"
+  "version" "1.0.7"
   dependencies:
-    mute-stream "~0.0.4"
+    "mute-stream" "~0.0.4"
 
-readable-stream@^3.1.1, readable-stream@^3.4.0:
-  version "3.6.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-3.6.0.tgz"
-  integrity sha1-M3u9o63AcGvT4CRCaihtS0sskZg=
+"readable-stream@^3.1.1", "readable-stream@^3.4.0":
+  "integrity" "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz"
+  "version" "3.6.2"
   dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
+    "inherits" "^2.0.3"
+    "string_decoder" "^1.1.1"
+    "util-deprecate" "^1.0.1"
 
-rimraf@^3.0.0:
-  version "3.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz"
-  integrity sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=
+"rimraf@^3.0.0":
+  "integrity" "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz"
+  "version" "3.0.2"
   dependencies:
-    glob "^7.1.3"
+    "glob" "^7.1.3"
 
-rimraf@^5.0.1:
-  version "5.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-5.0.1.tgz#0881323ab94ad45fec7c0221f27ea1a142f3f0d0"
-  integrity sha1-CIEyOrlK1F/sfAIh8n6hoULz8NA=
+"rimraf@^5.0.1":
+  "integrity" "sha1-CIEyOrlK1F/sfAIh8n6hoULz8NA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-5.0.1.tgz"
+  "version" "5.0.1"
   dependencies:
-    glob "^10.2.5"
+    "glob" "^10.2.5"
 
-safe-buffer@^5.0.1, safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz"
-  integrity sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=
+"safe-buffer@^5.0.1", "safe-buffer@~5.2.0":
+  "integrity" "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz"
+  "version" "5.2.1"
 
-sax@>=0.6.0:
-  version "1.2.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sax/-/sax-1.2.4.tgz"
-  integrity sha1-KBYjTiN4vdxOU1T6tcqold9xANk=
+"sax@>=0.6.0":
+  "integrity" "sha1-pdvnfbO+BcnR7neF29PqneUVk9A="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sax/-/sax-1.3.0.tgz"
+  "version" "1.3.0"
 
-semver@^5.1.0:
-  version "5.7.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.1.tgz"
-  integrity sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=
+"semver@^5.1.0":
+  "integrity" "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.2.tgz"
+  "version" "5.7.2"
 
-semver@^7.3.5:
-  version "7.3.7"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.3.7.tgz"
-  integrity sha1-EsW2Sa/b+QSXB3luIqQCiBTOUj8=
+"semver@^7.3.5":
+  "integrity" "sha1-Gkak20v/zM2Xt0O1AFyDJfI9Ti0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.0.tgz"
+  "version" "7.6.0"
   dependencies:
-    lru-cache "^6.0.0"
+    "lru-cache" "^6.0.0"
 
-shebang-command@^2.0.0:
-  version "2.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz"
-  integrity sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=
+"shebang-command@^2.0.0":
+  "integrity" "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz"
+  "version" "2.0.0"
   dependencies:
-    shebang-regex "^3.0.0"
+    "shebang-regex" "^3.0.0"
 
-shebang-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz"
-  integrity sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=
+"shebang-regex@^3.0.0":
+  "integrity" "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz"
+  "version" "3.0.0"
 
-side-channel@^1.0.4:
-  version "1.0.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/side-channel/-/side-channel-1.0.4.tgz"
-  integrity sha1-785cj9wQTudRslxY1CkAEfpeos8=
+"side-channel@^1.0.4":
+  "integrity" "sha1-785cj9wQTudRslxY1CkAEfpeos8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/side-channel/-/side-channel-1.0.4.tgz"
+  "version" "1.0.4"
   dependencies:
-    call-bind "^1.0.0"
-    get-intrinsic "^1.0.2"
-    object-inspect "^1.9.0"
+    "call-bind" "^1.0.0"
+    "get-intrinsic" "^1.0.2"
+    "object-inspect" "^1.9.0"
 
-signal-exit@^4.0.1:
-  version "4.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/signal-exit/-/signal-exit-4.0.2.tgz"
-  integrity sha1-/1W7HZ/yEUwTtABoj6VErGPDaWc=
+"signal-exit@^4.0.1":
+  "integrity" "sha1-/1W7HZ/yEUwTtABoj6VErGPDaWc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/signal-exit/-/signal-exit-4.0.2.tgz"
+  "version" "4.0.2"
 
-simple-concat@^1.0.0:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/simple-concat/-/simple-concat-1.0.1.tgz"
-  integrity sha1-9Gl2CCujXCJj8cirXt/ibEHJVS8=
+"simple-concat@^1.0.0":
+  "integrity" "sha1-9Gl2CCujXCJj8cirXt/ibEHJVS8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/simple-concat/-/simple-concat-1.0.1.tgz"
+  "version" "1.0.1"
 
-simple-get@^4.0.0:
-  version "4.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/simple-get/-/simple-get-4.0.1.tgz"
-  integrity sha1-SjnbVJKHyXnTUhEvoD/Zn9a8NUM=
+"simple-get@^4.0.0":
+  "integrity" "sha1-SjnbVJKHyXnTUhEvoD/Zn9a8NUM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/simple-get/-/simple-get-4.0.1.tgz"
+  "version" "4.0.1"
   dependencies:
-    decompress-response "^6.0.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
+    "decompress-response" "^6.0.0"
+    "once" "^1.3.1"
+    "simple-concat" "^1.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  version "4.2.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-4.2.3.tgz"
-  integrity sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=
+"source-map@^0.6.0":
+  "integrity" "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map/-/source-map-0.6.1.tgz"
+  "version" "0.6.1"
+
+"string_decoder@^1.1.1":
+  "integrity" "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz"
+  "version" "1.3.0"
   dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
+    "safe-buffer" "~5.2.0"
 
-string-width@^5.0.1, string-width@^5.1.2:
-  version "5.1.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-5.1.2.tgz"
-  integrity sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=
+"string-width-cjs@npm:string-width@^4.2.0":
+  "integrity" "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-4.2.3.tgz"
+  "version" "4.2.3"
   dependencies:
-    eastasianwidth "^0.2.0"
-    emoji-regex "^9.2.2"
-    strip-ansi "^7.0.1"
+    "emoji-regex" "^8.0.0"
+    "is-fullwidth-code-point" "^3.0.0"
+    "strip-ansi" "^6.0.1"
 
-source-map@^0.6.0:
-  version "0.6.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map/-/source-map-0.6.1.tgz"
-  integrity sha1-dHIq8y6WFOnCh6jQu95IteLxomM=
-
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=
+"string-width@^4.1.0":
+  "integrity" "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-4.2.3.tgz"
+  "version" "4.2.3"
   dependencies:
-    safe-buffer "~5.2.0"
+    "emoji-regex" "^8.0.0"
+    "is-fullwidth-code-point" "^3.0.0"
+    "strip-ansi" "^6.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=
+"string-width@^5.0.1", "string-width@^5.1.2":
+  "integrity" "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-5.1.2.tgz"
+  "version" "5.1.2"
   dependencies:
-    ansi-regex "^5.0.1"
+    "eastasianwidth" "^0.2.0"
+    "emoji-regex" "^9.2.2"
+    "strip-ansi" "^7.0.1"
 
-strip-ansi@^7.0.1:
-  version "7.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-7.1.0.tgz"
-  integrity sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U=
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  "integrity" "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  "version" "6.0.1"
   dependencies:
-    ansi-regex "^6.0.1"
+    "ansi-regex" "^5.0.1"
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
-supports-color@^5.3.0:
-  version "5.5.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz"
-  integrity sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=
+"strip-ansi@^6.0.0", "strip-ansi@^6.0.1":
+  "integrity" "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  "version" "6.0.1"
   dependencies:
-    has-flag "^3.0.0"
+    "ansi-regex" "^5.0.1"
 
-tar-fs@^2.0.0:
-  version "2.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar-fs/-/tar-fs-2.1.1.tgz"
-  integrity sha1-SJoVq4Xx8L76uzcLfeT561y+h4Q=
+"strip-ansi@^7.0.1":
+  "integrity" "sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-7.1.0.tgz"
+  "version" "7.1.0"
   dependencies:
-    chownr "^1.1.1"
-    mkdirp-classic "^0.5.2"
-    pump "^3.0.0"
-    tar-stream "^2.1.4"
+    "ansi-regex" "^6.0.1"
 
-tar-stream@^2.1.4:
-  version "2.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar-stream/-/tar-stream-2.2.0.tgz"
-  integrity sha1-rK2EwoQTawYNw/qmRHSqmuvXcoc=
+"strip-json-comments@~2.0.1":
+  "integrity" "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+  "version" "2.0.1"
+
+"supports-color@^5.3.0":
+  "integrity" "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz"
+  "version" "5.5.0"
   dependencies:
-    bl "^4.0.3"
-    end-of-stream "^1.4.1"
-    fs-constants "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^3.1.1"
+    "has-flag" "^3.0.0"
 
-tmp@^0.2.1:
-  version "0.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tmp/-/tmp-0.2.1.tgz"
-  integrity sha1-hFf8MDfc9HGcJRNnoa9lAO4czxQ=
+"tar-fs@^2.0.0":
+  "integrity" "sha1-SJoVq4Xx8L76uzcLfeT561y+h4Q="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar-fs/-/tar-fs-2.1.1.tgz"
+  "version" "2.1.1"
   dependencies:
-    rimraf "^3.0.0"
+    "chownr" "^1.1.1"
+    "mkdirp-classic" "^0.5.2"
+    "pump" "^3.0.0"
+    "tar-stream" "^2.1.4"
 
-tunnel-agent@^0.6.0:
-  version "0.6.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-  integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
+"tar-stream@^2.1.4":
+  "integrity" "sha1-rK2EwoQTawYNw/qmRHSqmuvXcoc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar-stream/-/tar-stream-2.2.0.tgz"
+  "version" "2.2.0"
   dependencies:
-    safe-buffer "^5.0.1"
+    "bl" "^4.0.3"
+    "end-of-stream" "^1.4.1"
+    "fs-constants" "^1.0.0"
+    "inherits" "^2.0.3"
+    "readable-stream" "^3.1.1"
 
-tunnel@0.0.6:
-  version "0.0.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel/-/tunnel-0.0.6.tgz"
-  integrity sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=
-
-typed-rest-client@^1.8.4:
-  version "1.8.9"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-rest-client/-/typed-rest-client-1.8.9.tgz"
-  integrity sha1-5WAia8rf5xsPtcQWtYf42juPktg=
+"tmp@^0.2.1":
+  "integrity" "sha1-hFf8MDfc9HGcJRNnoa9lAO4czxQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tmp/-/tmp-0.2.1.tgz"
+  "version" "0.2.1"
   dependencies:
-    qs "^6.9.1"
-    tunnel "0.0.6"
-    underscore "^1.12.1"
+    "rimraf" "^3.0.0"
 
-uc.micro@^1.0.1, uc.micro@^1.0.5:
-  version "1.0.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uc.micro/-/uc.micro-1.0.6.tgz"
-  integrity sha1-nEEagCpAmpH8bPdAgbq6NLJEmaw=
-
-underscore@^1.12.1:
-  version "1.13.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/underscore/-/underscore-1.13.4.tgz"
-  integrity sha1-eIa0a73wf3aOAFLxgo4dyrQMDe4=
-
-url-join@^4.0.1:
-  version "4.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-join/-/url-join-4.0.1.tgz"
-  integrity sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec=
-
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz"
-  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
-
-vsce@2.11.0:
-  version "2.11.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vsce/-/vsce-2.11.0.tgz"
-  integrity sha1-5gqsWOz8OuxuQAJOE+qMjSl2Su8=
+"tunnel-agent@^0.6.0":
+  "integrity" "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+  "version" "0.6.0"
   dependencies:
-    azure-devops-node-api "^11.0.1"
-    chalk "^2.4.2"
-    cheerio "^1.0.0-rc.9"
-    commander "^6.1.0"
-    glob "^7.0.6"
-    hosted-git-info "^4.0.2"
-    keytar "^7.7.0"
-    leven "^3.1.0"
-    markdown-it "^12.3.2"
-    mime "^1.3.4"
-    minimatch "^3.0.3"
-    parse-semver "^1.1.1"
-    read "^1.0.7"
-    semver "^5.1.0"
-    tmp "^0.2.1"
-    typed-rest-client "^1.8.4"
-    url-join "^4.0.1"
-    xml2js "^0.4.23"
-    yauzl "^2.3.1"
-    yazl "^2.2.2"
+    "safe-buffer" "^5.0.1"
 
-which@^2.0.1:
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz"
-  integrity sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=
+"tunnel@0.0.6":
+  "integrity" "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel/-/tunnel-0.0.6.tgz"
+  "version" "0.0.6"
+
+"typed-rest-client@^1.8.4":
+  "integrity" "sha1-5WAia8rf5xsPtcQWtYf42juPktg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-rest-client/-/typed-rest-client-1.8.9.tgz"
+  "version" "1.8.9"
   dependencies:
-    isexe "^2.0.0"
+    "qs" "^6.9.1"
+    "tunnel" "0.0.6"
+    "underscore" "^1.12.1"
+
+"uc.micro@^1.0.1", "uc.micro@^1.0.5":
+  "integrity" "sha1-nEEagCpAmpH8bPdAgbq6NLJEmaw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uc.micro/-/uc.micro-1.0.6.tgz"
+  "version" "1.0.6"
+
+"underscore@^1.12.1":
+  "integrity" "sha1-eIa0a73wf3aOAFLxgo4dyrQMDe4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/underscore/-/underscore-1.13.4.tgz"
+  "version" "1.13.4"
+
+"url-join@^4.0.1":
+  "integrity" "sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-join/-/url-join-4.0.1.tgz"
+  "version" "4.0.1"
+
+"util-deprecate@^1.0.1":
+  "integrity" "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz"
+  "version" "1.0.2"
+
+"vsce@^2.15.0":
+  "integrity" "sha1-SpkueFMgkqNKdVFDxrbCyry31yk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vsce/-/vsce-2.15.0.tgz"
+  "version" "2.15.0"
+  dependencies:
+    "azure-devops-node-api" "^11.0.1"
+    "chalk" "^2.4.2"
+    "cheerio" "^1.0.0-rc.9"
+    "commander" "^6.1.0"
+    "glob" "^7.0.6"
+    "hosted-git-info" "^4.0.2"
+    "keytar" "^7.7.0"
+    "leven" "^3.1.0"
+    "markdown-it" "^12.3.2"
+    "mime" "^1.3.4"
+    "minimatch" "^3.0.3"
+    "parse-semver" "^1.1.1"
+    "read" "^1.0.7"
+    "semver" "^5.1.0"
+    "tmp" "^0.2.1"
+    "typed-rest-client" "^1.8.4"
+    "url-join" "^4.0.1"
+    "xml2js" "^0.4.23"
+    "yauzl" "^2.3.1"
+    "yazl" "^2.2.2"
+
+"which@^2.0.1":
+  "integrity" "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz"
+  "version" "2.0.2"
+  dependencies:
+    "isexe" "^2.0.0"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=
+  "integrity" "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  "version" "7.0.0"
   dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
+    "ansi-styles" "^4.0.0"
+    "string-width" "^4.1.0"
+    "strip-ansi" "^6.0.0"
 
-wrap-ansi@^8.1.0:
-  version "8.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz"
-  integrity sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=
+"wrap-ansi@^8.1.0":
+  "integrity" "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz"
+  "version" "8.1.0"
   dependencies:
-    ansi-styles "^6.1.0"
-    string-width "^5.0.1"
-    strip-ansi "^7.0.1"
+    "ansi-styles" "^6.1.0"
+    "string-width" "^5.0.1"
+    "strip-ansi" "^7.0.1"
 
-wrappy@1:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+"wrappy@1":
+  "integrity" "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz"
+  "version" "1.0.2"
 
-xml2js@^0.4.23:
-  version "0.4.23"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xml2js/-/xml2js-0.4.23.tgz"
-  integrity sha1-oMaVFnUkIesqx1juTUzPWIQ+rGY=
+"xml2js@^0.4.23":
+  "integrity" "sha1-oMaVFnUkIesqx1juTUzPWIQ+rGY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xml2js/-/xml2js-0.4.23.tgz"
+  "version" "0.4.23"
   dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
+    "sax" ">=0.6.0"
+    "xmlbuilder" "~11.0.0"
 
-xmlbuilder@~11.0.0:
-  version "11.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xmlbuilder/-/xmlbuilder-11.0.1.tgz"
-  integrity sha1-vpuuHIoEbnazESdyY0fQrXACvrM=
+"xmlbuilder@~11.0.0":
+  "integrity" "sha1-vpuuHIoEbnazESdyY0fQrXACvrM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xmlbuilder/-/xmlbuilder-11.0.1.tgz"
+  "version" "11.0.1"
 
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yallist/-/yallist-4.0.0.tgz"
-  integrity sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=
+"yallist@^4.0.0":
+  "integrity" "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yallist/-/yallist-4.0.0.tgz"
+  "version" "4.0.0"
 
-yauzl@^2.3.1:
-  version "2.10.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yauzl/-/yauzl-2.10.0.tgz"
-  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+"yauzl@^2.3.1":
+  "integrity" "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yauzl/-/yauzl-2.10.0.tgz"
+  "version" "2.10.0"
   dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"
+    "buffer-crc32" "~0.2.3"
+    "fd-slicer" "~1.1.0"
 
-yazl@^2.2.2:
-  version "2.5.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yazl/-/yazl-2.5.1.tgz"
-  integrity sha1-o9ZdPdZZpbCTeFDoYJ8i//orXDU=
+"yazl@^2.2.2":
+  "integrity" "sha1-o9ZdPdZZpbCTeFDoYJ8i//orXDU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yazl/-/yazl-2.5.1.tgz"
+  "version" "2.5.1"
   dependencies:
-    buffer-crc32 "~0.2.3"
+    "buffer-crc32" "~0.2.3"


### PR DESCRIPTION
We rely on a library is-online that has not been managed in about 2 years. The check that it does seems to rely on apples hotspot website which is kind of rudimentary https://github.com/sindresorhus/is-online/blob/main/index.js. We can instead try to rely on 8.8.8.8 or the google dns server, which is one of the highest up time servers. Note that we are partially doing this to update the dependencies, and is-online has a breaking change which also makes it not ideal.

This is a crude check but it only happens when we've already timed out and is simply there to improve error diagnosability. I did test pulling the plug on the internet a few times with this one.