### PR TITLE
Always collect install script stdout and stderr.

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -87,17 +87,16 @@ You will need to restart VS Code after these changes. If PowerShell is still not
                         { cwd: process.cwd(), maxBuffer: 500 * 1024, timeout: 1000 * installContext.timeoutSeconds, killSignal: 'SIGKILL' },
                         async (error, stdout, stderr) =>
                 {
+                    if (stdout)
+                    {
+                            this.eventStream.post(new DotnetAcquisitionScriptOutput(installKey, TelemetryUtilities.HashAllPaths(stdout)));
+                    }
+                    if (stderr)
+                    {
+                            this.eventStream.post(new DotnetAcquisitionScriptOutput(installKey, `STDERR: ${TelemetryUtilities.HashAllPaths(stderr)}`));
+                    }
                     if (error)
                     {
-                        if (stdout)
-                        {
-                            this.eventStream.post(new DotnetAcquisitionScriptOutput(installKey, TelemetryUtilities.HashAllPaths(stdout)));
-                        }
-                        if (stderr)
-                        {
-                            this.eventStream.post(new DotnetAcquisitionScriptOutput(installKey, `STDERR: ${TelemetryUtilities.HashAllPaths(stderr)}`));
-                        }
-
                         if (!(await this.isOnline(installContext)))
                         {
                             const offlineError = new Error('No internet connection detected: Cannot install .NET');
@@ -117,7 +116,6 @@ You will need to restart VS Code after these changes. If PowerShell is still not
                     }
                     else if (stderr && stderr.length > 0)
                     {
-                        this.eventStream.post(new DotnetAcquisitionScriptOutput(installKey, `STDERR: ${TelemetryUtilities.HashAllPaths(stderr)}`));
                         this.eventStream.post(new DotnetAcquisitionCompleted(installKey, installContext.dotnetPath, installContext.version));
                         resolve();
                     }


### PR DESCRIPTION
Per our discussion at https://github.com/dotnet/vscode-dotnet-runtime/issues/1741#issuecomment-2051238090, it would be useful to have stdout even if we dont error, because the error condition is only if:

When running the install script:
The process could not be spawned.
The process could not be killed.
Sending a message to the child process failed.
The child process was aborted via the signal option.