### PR TITLE
Improve the error message for failing to install the .NET SDK.

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
@@ -82,7 +82,7 @@ export abstract class IDistroDotnetSDKProvider {
         if(!distroVersion || !this.distroJson || !((this.distroJson as any)[this.distroVersion.distro]))
         {
             const error = new DotnetAcquisitionDistroUnknownError(new Error(`Automated installation for the distro ${this.distroVersion.distro} is not yet supported.
-Please install the .NET SDK manually: dotnet.microsoft.com/download.`),
+Please install the .NET SDK manually: https://dotnet.microsoft.com/download`),
                 getInstallKeyFromContext(this.context.acquisitionContext));
             throw error.error;
         }

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
@@ -81,7 +81,8 @@ export abstract class IDistroDotnetSDKProvider {
         this.distroJson = JSON.parse(fs.readFileSync(distroDataFile, 'utf8'));
         if(!distroVersion || !this.distroJson || !((this.distroJson as any)[this.distroVersion.distro]))
         {
-            const error = new DotnetAcquisitionDistroUnknownError(new Error('We are unable to detect the distro or version of your machine'),
+            const error = new DotnetAcquisitionDistroUnknownError(new Error(`Automated installation for the distro ${this.distroVersion.distro} is not yet supported.
+Please install the .NET SDK manually: dotnet.microsoft.com/download.`),
                 getInstallKeyFromContext(this.context.acquisitionContext));
             throw error.error;
         }


### PR DESCRIPTION
This error message is misleading. We could detect the distro, it just wasn't supported yet in our list of supported distros. We should give the user more action here.