### PR TITLE
Update distro schema file to account for changes in the file.

### DIFF
--- a/Documentation/json-schema/distro-support-schema.json
+++ b/Documentation/json-schema/distro-support-schema.json
@@ -2,51 +2,127 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "properties": {
-      "DISTRO": {
+        "$schema": {
+            "type": "string"
+        }
+    },
+    "$defs": {
+        "executable_command": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "object",
+            "properties": {
+                "runUnderSudo": {
+                    "type": "boolean",
+                    "description": "true if this command should be executed under sudo on linux"
+                },
+                "commandRoot": {
+                    "type": "string",
+                    "description": "The first word in the command, e.g. if apt-get install foo, it would be the string apt."
+                },
+                "commandParts": {
+                    "type": "array",
+                    "description": "The remaining parts of the command in an array, for apt-get install {0} it would be [install, {0}] as strings"
+                }
+            },
+            "additionalProperties": false
+        },
+        "required_packages": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "object",
+            "properties": {
+                "version": {
+                    "type": "string",
+                    "description": "The version major.minor of dotnet"
+                },
+                "sdk": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "string",
+                            "description": "a collection of all potential package names for this version of the dotnet sdk on this distro"
+                        }
+                    ]
+                },
+                "runtime": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "string",
+                            "description": "a collection of all potential package names for this version of the dotnet runtime on this distro"
+                        }
+                    ]
+                },
+                "aspnetcore": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "string",
+                            "description": "a collection of all potential package names for this version of aspnet on this distro"
+                        }
+                    ]
+                },
+                "required": [
+                    "version",
+                    "sdk",
+                    "runtime",
+                    "aspnetcore"
+                ]
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": {
         "description": "The Distro name as in cat etc/os-release. Multiple distros are added to the same file.",
         "type": "object",
-        "properties":
-        {
+        "additionalProperties": false,
+        "properties": {
             "installCommand": {
                 "type": "array",
-                "typeDefinition" : {
-                    "runUnderSudo":
-                    {
-                        "type": "boolean",
-                        "description": "true if this command should be executed under sudo on linux"
-                    },
-                    "commandRoot":
-                    {
-                        "type": "string",
-                        "description": "The first word in the command, e.g. if apt-get install foo, it would be the string apt."
-                    },
-                    "commandParts":
-                    {
-                        "type": "array",
-                        "description": "The remaining parts of the command in an array, for apt-get install {0} it would be [install, {0}] as strings"
-                    },
-                    "description": "An array of these command objects needed to run in-order"
+                "items": {
+                    "$ref": "#/$defs/executable_command"
                 },
                 "description": "The command(s) needed to install dotnet for this distro. Use {0} for the package to install"
             },
             "uninstallCommand": {
                 "type": "array",
+                "items": {
+                    "$ref": "#/$defs/executable_command"
+                },
                 "description": "The command(s) needed to uninstall dotnet. Use {0} for the package"
             },
             "updateCommand": {
                 "type": "array",
+                "items": {
+                    "$ref": "#/$defs/executable_command"
+                },
                 "description": "The command(s) needed to update dotnet. Use {0} for the package"
             },
             "searchCommand": {
                 "type": "array",
+                "items": {
+                    "$ref": "#/$defs/executable_command"
+                },
                 "description": "The command(s) needed to see if a package is available. Use {0} for the package"
             },
             "isInstalledCommand": {
                 "type": "array",
+                "items": {
+                    "$ref": "#/$defs/executable_command"
+                },
                 "description": "The command(s) needed that will return true if dotnet is installed on the machine"
             },
             "packageLookupCommand": {
                 "type": "array",
+                "items": {
+                    "$ref": "#/$defs/executable_command"
+                },
+                "description": "The command(s) needed that will return true if a given package is installed on the machine"
+            },
+            "readSymLinkCommand": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/$defs/executable_command"
+                },
                 "description": "The command(s) needed that will return true if a given package is installed on the machine"
             },
             "expectedDistroFeedInstallDirectory": {
@@ -59,98 +135,67 @@
             },
             "installedSDKVersionsCommand": {
                 "type": "array",
+                "items": {
+                    "$ref": "#/$defs/executable_command"
+                },
                 "description": "The command needed to get all installed dotnet sdk versions on the machine"
             },
             "installedRuntimeVersionsCommand": {
                 "type": "array",
+                "items": {
+                    "$ref": "#/$defs/executable_command"
+                },
                 "description": "The command needed to get all installed dotnet runtime versions on the machine"
             },
             "currentInstallationVersionCommand": {
                 "type": "array",
+                "items": {
+                    "$ref": "#/$defs/executable_command"
+                },
                 "description": "The command needed to get the version of the installed dotnet on the machine if available"
             },
             "currentInstallPathCommand": {
                 "type": "array",
+                "items": {
+                    "$ref": "#/$defs/executable_command"
+                },
                 "description": "The command needed to get the path of the installed dotnet on the machine if available"
             },
             "packages": {
                 "type": "array",
                 "description": "Lists all of the packages that MAY be supported or found on the system per each version of .NET",
                 "items": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "version": {
-                        "type": "string",
-                        "description": "The version major.minor of dotnet"
-                      },
-                      "sdk": {
-                        "type": "array",
-                        "items": [
-                          {
-                            "type": "string",
-                            "description": "a collection of all potential package names for this version of the dotnet sdk on this distro"
-                          }
-                        ]
-                      },
-                      "runtime": {
-                        "type": "array",
-                        "items": [
-                            {
-                                "type": "string",
-                                "description": "a collection of all potential package names for this version of the dotnet runtime on this distro"
-                            }
-                        ]
-                      },
-                      "aspnetcore": {
-                        "type": "array",
-                        "items": [
-                            {
-                                "type": "string",
-                                "description": "a collection of all potential package names for this version of aspnet on this distro"
-                            }
-                        ]
-                      }
-                    },
-                    "required": [
-                      "version",
-                      "sdk",
-                      "runtime",
-                      "aspnetcore"
-                    ]
-                }]
+                    {
+                        "$ref": "#/$defs/required_packages"
+                    }
+                ]
             },
-            "versions":
-            {
+            "versions": {
                 "type": "array",
                 "description": "The versions of the distro that we support as in etc/os-release or similar. Each one has info on what dotnet versions are supported",
                 "items": [
-                {
-                    "type": "object",
-                    "description": "An object representing a version of the distro and which package names it supports",
-                    "properties": {
-                    "version": {
-                        "type": "string",
-                        "description": "The distro version mapped to this object"
-                    },
-                    "preInstallCommands":
                     {
-                        "type": "array",
-                        "description": "A set of commands needed to install microsoft package feeds if needed",
-                        "items": [
-                        {
-                            "type": "string"
-                        }
+                        "type": "object",
+                        "description": "An object representing a version of the distro and which package names it supports",
+                        "properties": {
+                            "version": {
+                                "type": "string",
+                                "description": "The distro version mapped to this object"
+                            },
+                            "preInstallCommands": {
+                                "type": "array",
+                                "description": "A set of commands needed to install microsoft package feeds if needed",
+                                "items": {
+                                    "$ref": "#/$defs/executable_command"
+                                }
+                            }
+                        },
+                        "required": [
+                            "version"
                         ]
                     }
-                    },
-                    "required": [
-                    "version",
-                    "preInstallCommands"
-                    ]
-                 }]
+                ]
             }
         }
     }
-  }
 }

--- a/Documentation/json-schema/distro-support-schema.json
+++ b/Documentation/json-schema/distro-support-schema.json
@@ -24,6 +24,11 @@
                     "description": "The remaining parts of the command in an array, for apt-get install {0} it would be [install, {0}] as strings"
                 }
             },
+            "required": [
+                "runUnderSudo",
+                "commandRoot",
+                "commandParts"
+            ],
             "additionalProperties": false
         },
         "required_packages": {
@@ -60,16 +65,16 @@
                             "description": "a collection of all potential package names for this version of aspnet on this distro"
                         }
                     ]
-                },
-                "required": [
-                    "version",
-                    "sdk",
-                    "runtime",
-                    "aspnetcore"
-                ]
+                }
             },
-            "additionalProperties": false
-        }
+            "required": [
+                "version",
+                "sdk",
+                "runtime",
+                "aspnetcore"
+            ]
+        },
+        "additionalProperties": false
     },
     "additionalProperties": {
         "description": "The Distro name as in cat etc/os-release. Multiple distros are added to the same file.",

--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -1,395 +1,441 @@
 {
-	"$schema": "../../Documentation/json-schema/distro-support-schema.json",
-	"Ubuntu": {
-		"installCommand":
-		[
-			{
-				"runUnderSudo": true,
-				"commandRoot": "apt-get",
-				"commandParts": ["update"]
-			},
-			{
-				"runUnderSudo": true,
-				"commandRoot": "apt-get",
-				"commandParts": ["install", "-y", "{packageName}"]
-			}
-		],
-		"uninstallCommand":
-		[
-			{
-				"runUnderSudo": true,
-				"commandRoot": "apt-get",
-				"commandParts": ["remove", "{packageName}"]
-			}
-		],
-		"updateCommand":
-		[
-			{
-				"runUnderSudo": true,
-				"commandRoot": "apt-get",
-				"commandParts": ["update"]
-			},
-			{
-				"runUnderSudo": true,
-				"commandRoot": "apt-get",
-				"commandParts": ["upgrade", "-y", "{packageName}"]
-			}
-		],
-		"searchCommand":
-		[
-			{
-				"runUnderSudo": false,
-				"commandRoot": "apt-cache",
-				"commandParts": ["search", "--names-only", "^{packageName}$"]
-			}
-		],
-		"isInstalledCommand":
-		[
-			{
-				"runUnderSudo": true,
-				"commandRoot": "apt",
-				"commandParts": ["list", "--installed", "{packageName}"]
-			}
-		],
-		"packageLookupCommand":
-		[
-			{
-				"runUnderSudo": false,
-				"commandRoot": "dpkg",
-				"commandParts": ["-l", "{packageName}"]
-			}
-		],
-		"readSymLinkCommand":
-		[
-			{
-				"runUnderSudo": false,
-				"commandRoot": "readlink",
-				"commandParts": ["-f", "{path}"]
-			}
-		],
-		"expectedDistroFeedInstallDirectory" : "/usr/lib/dotnet",
-        "expectedMicrosoftFeedInstallDirectory" : "/usr/share/dotnet",
-		"installedSDKVersionsCommand":
-		[
-			{
-				"runUnderSudo": false,
-				"commandRoot": "dotnet",
-				"commandParts": ["--list-sdks"]
-			}
-		],
-		"installedRuntimeVersionsCommand":
-		[
-			{
-				"runUnderSudo": false,
-				"commandRoot": "dotnet",
-				"commandParts": ["--list-runtimes"]
-			}
-		],
-		"currentInstallationVersionCommand":
-		[
-			{
-				"runUnderSudo": false,
-				"commandRoot": "dotnet",
-				"commandParts": ["--version"]
-			}
-		],
-		"currentInstallPathCommand":
-		[
-			{
-				"runUnderSudo": false,
-				"commandRoot": "which",
-				"commandParts": ["dotnet"]
-			}
-		],
-		"packages":
-		[
-			{
-				"version": "6.0",
-				"sdk":
-				[
-					"dotnet-sdk-6.0"
-				],
-				"runtime":
-				[
-					"dotnet-runtime-6.0"
-				],
-				"aspnetcore":
-				[
-					"aspnetcore-runtime-6.0"
-				]
-			},
-			{
-				"version": "7.0",
-				"sdk":
-				[
-					"dotnet-sdk-7.0"
-				],
-				"runtime":
-				[
-					"dotnet-runtime-7.0"
-				],
-				"aspnetcore":
-				[
-					"aspnetcore-runtime-7.0"
-				]
-			},
-			{
-				"version": "8.0",
-				"sdk": [
-					"dotnet-sdk-8.0"
-				],
-				"runtime": [
-					"dotnet-runtime-8.0"
-				],
-				"aspnetcore": [
-					"aspnetcore-runtime-8.0"
-				]
-			},
-			{
-				"version": "9.0",
-				"sdk": [
-					"dotnet-sdk-9.0"
-				],
-				"runtime": [
-					"dotnet-runtime-9.0"
-				],
-				"aspnetcore": [
-					"aspnetcore-runtime-9.0"
-				]
-			}
-		],
-		"versions": [{
-				"version": "18.04",
-				"preInstallCommands":
-				[
-					{
-						"runUnderSudo": true,
-						"commandRoot": "apt-get",
-						"commandParts": ["install", "-y", "wget"]
-					},
-					{
-						"runUnderSudo": true,
-						"commandRoot": "wget",
-						"commandParts": ["https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb", "-O", "packages-microsoft-prod.deb"]
-					},
-					{
-						"runUnderSudo": true,
-						"commandRoot": "dpkg",
-						"commandParts": ["-i", "packages-microsoft-prod.deb"]
-					},
-					{
-						"runUnderSudo": true,
-						"commandRoot": "apt-get",
-						"commandParts": ["update"]
-					}
-				]
-			},
-			{
-				"version": "20.04",
-				"preInstallCommands":
-				[
-					{
-						"runUnderSudo": true,
-						"commandRoot": "apt-get",
-						"commandParts": ["update"]
-					},
-					{
-						"runUnderSudo": true,
-						"commandRoot": "apt-get",
-						"commandParts": ["install", "-y", "wget"]
-					},
-					{
-						"runUnderSudo": true,
-						"commandRoot": "wget",
-						"commandParts": ["https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb", "-O", "packages-microsoft-prod.deb"]
-					},
-					{
-						"runUnderSudo": true,
-						"commandRoot": "dpkg",
-						"commandParts": ["-i", "packages-microsoft-prod.deb"]
-					}
-				]
-			},
-			{
-				"version": "22.04"
-			},
-			{
-				"version": "23.04"
-			}
-		]
-	},
-	"Red Hat Enterprise Linux": {
-		"installCommand": [
-			{
-				"runUnderSudo": true,
-				"commandRoot": "dnf",
-				"commandParts": [
-					"install",
-					"-y",
-					"{packageName}"
-				]
-			}
-		],
-		"uninstallCommand": [
-			{
-				"runUnderSudo": true,
-				"commandRoot": "dnf",
-				"commandParts": [
-					"remove",
-					"-y",
-					"{packageName}"
-				]
-			}
-		],
-		"updateCommand": [
-			{
-				"runUnderSudo": true,
-				"commandRoot": "dnf",
-				"commandParts": [
-					"update",
-					"-y",
-					"{packageName}"
-				]
-			}
-		],
-		"searchCommand": [
-			{
-				"runUnderSudo": false,
-				"commandRoot": "yum",
-				"commandParts": [
-					"search",
-					"{packageName}",
-					"-q"
-				]
-			}
-		],
-		"isInstalledCommand": [
-			{
-				"runUnderSudo": true,
-				"commandRoot": "dnf",
-				"commandParts": [
-					"list",
-					"--installed",
-					"{packageName}",
-					"-q"
-				]
-			}
-		],
-		"packageLookupCommand": [
-			{
-				"runUnderSudo": false,
-				"commandRoot": "yum",
-				"commandParts": [
-					"list",
-					"install",
-					"{packageName}",
-					"-q"
-				]
-			}
-		],
-		"readSymLinkCommand":
-		[
-			{
-				"runUnderSudo": false,
-				"commandRoot": "readlink",
-				"commandParts": ["-f", "{path}"]
-			}
-		],
-		"expectedDistroFeedInstallDirectory": "/usr/lib64/dotnet",
-		"expectedMicrosoftFeedInstallDirectory": "",
-		"installedSDKVersionsCommand": [
-			{
-				"runUnderSudo": false,
-				"commandRoot": "dotnet",
-				"commandParts": [
-					"--list-sdks"
-				]
-			}
-		],
-		"installedRuntimeVersionsCommand": [
-			{
-				"runUnderSudo": false,
-				"commandRoot": "dotnet",
-				"commandParts": [
-					"--list-runtimes"
-				]
-			}
-		],
-		"currentInstallationVersionCommand": [
-			{
-				"runUnderSudo": false,
-				"commandRoot": "dotnet",
-				"commandParts": [
-					"--version"
-				]
-			}
-		],
-		"currentInstallPathCommand": [
-			{
-				"runUnderSudo": false,
-				"commandRoot": "which",
-				"commandParts": [
-					"dotnet"
-				]
-			}
-		],
-		"packages": [
-			{
-				"version": "6.0",
-				"sdk": [
-					"dotnet-sdk-6.0"
-				],
-				"runtime": [
-					"dotnet-runtime-6.0"
-				],
-				"aspnetcore": [
-					"aspnetcore-runtime-6.0"
-				]
-			},
-			{
-				"version": "7.0",
-				"sdk": [
-					"dotnet-sdk-7.0"
-				],
-				"runtime": [
-					"dotnet-runtime-7.0"
-				],
-				"aspnetcore": [
-					"aspnetcore-runtime-7.0"
-				]
-			},
-			{
-				"version": "8.0",
-				"sdk": [
-					"dotnet-sdk-8.0"
-				],
-				"runtime": [
-					"dotnet-runtime-8.0"
-				],
-				"aspnetcore": [
-					"aspnetcore-runtime-8.0"
-				]
-			},
-			{
-				"version": "9.0",
-				"sdk": [
-					"dotnet-sdk-9.0"
-				],
-				"runtime": [
-					"dotnet-runtime-9.0"
-				],
-				"aspnetcore": [
-					"aspnetcore-runtime-9.0"
-				]
-			}
-		],
-		"versions": [
-			{
-				"version": "8.0"
-			},
-			{
-				"version": "9.0"
-			}
-		]
-	}
+    "$schema": "../../Documentation/json-schema/distro-support-schema.json",
+    "Ubuntu": {
+        "installCommand": [
+            {
+                "runUnderSudo": true,
+                "commandRoot": "apt-get",
+                "commandParts": [
+                    "update"
+                ]
+            },
+            {
+                "runUnderSudo": true,
+                "commandRoot": "apt-get",
+                "commandParts": [
+                    "install",
+                    "-y",
+                    "{packageName}"
+                ]
+            }
+        ],
+        "uninstallCommand": [
+            {
+                "runUnderSudo": true,
+                "commandRoot": "apt-get",
+                "commandParts": [
+                    "remove",
+                    "{packageName}"
+                ]
+            }
+        ],
+        "updateCommand": [
+            {
+                "runUnderSudo": true,
+                "commandRoot": "apt-get",
+                "commandParts": [
+                    "update"
+                ]
+            },
+            {
+                "runUnderSudo": true,
+                "commandRoot": "apt-get",
+                "commandParts": [
+                    "upgrade",
+                    "-y",
+                    "{packageName}"
+                ]
+            }
+        ],
+        "searchCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "apt-cache",
+                "commandParts": [
+                    "search",
+                    "--names-only",
+                    "^{packageName}$"
+                ]
+            }
+        ],
+        "isInstalledCommand": [
+            {
+                "runUnderSudo": true,
+                "commandRoot": "apt",
+                "commandParts": [
+                    "list",
+                    "--installed",
+                    "{packageName}"
+                ]
+            }
+        ],
+        "packageLookupCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "dpkg",
+                "commandParts": [
+                    "-l",
+                    "{packageName}"
+                ]
+            }
+        ],
+        "readSymLinkCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "readlink",
+                "commandParts": [
+                    "-f",
+                    "{path}"
+                ]
+            }
+        ],
+        "expectedDistroFeedInstallDirectory": "/usr/lib/dotnet",
+        "expectedMicrosoftFeedInstallDirectory": "/usr/share/dotnet",
+        "installedSDKVersionsCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "dotnet",
+                "commandParts": [
+                    "--list-sdks"
+                ]
+            }
+        ],
+        "installedRuntimeVersionsCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "dotnet",
+                "commandParts": [
+                    "--list-runtimes"
+                ]
+            }
+        ],
+        "currentInstallationVersionCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "dotnet",
+                "commandParts": [
+                    "--version"
+                ]
+            }
+        ],
+        "currentInstallPathCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "which",
+                "commandParts": [
+                    "dotnet"
+                ]
+            }
+        ],
+        "packages": [
+            {
+                "version": "6.0",
+                "sdk": [
+                    "dotnet-sdk-6.0"
+                ],
+                "runtime": [
+                    "dotnet-runtime-6.0"
+                ],
+                "aspnetcore": [
+                    "aspnetcore-runtime-6.0"
+                ]
+            },
+            {
+                "version": "7.0",
+                "sdk": [
+                    "dotnet-sdk-7.0"
+                ],
+                "runtime": [
+                    "dotnet-runtime-7.0"
+                ],
+                "aspnetcore": [
+                    "aspnetcore-runtime-7.0"
+                ]
+            },
+            {
+                "version": "8.0",
+                "sdk": [
+                    "dotnet-sdk-8.0"
+                ],
+                "runtime": [
+                    "dotnet-runtime-8.0"
+                ],
+                "aspnetcore": [
+                    "aspnetcore-runtime-8.0"
+                ]
+            },
+            {
+                "version": "9.0",
+                "sdk": [
+                    "dotnet-sdk-9.0"
+                ],
+                "runtime": [
+                    "dotnet-runtime-9.0"
+                ],
+                "aspnetcore": [
+                    "aspnetcore-runtime-9.0"
+                ]
+            }
+        ],
+        "versions": [
+            {
+                "version": "18.04",
+                "preInstallCommands": [
+                    {
+                        "runUnderSudo": true,
+                        "commandRoot": "apt-get",
+                        "commandParts": [
+                            "install",
+                            "-y",
+                            "wget"
+                        ]
+                    },
+                    {
+                        "runUnderSudo": true,
+                        "commandRoot": "wget",
+                        "commandParts": [
+                            "https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb",
+                            "-O",
+                            "packages-microsoft-prod.deb"
+                        ]
+                    },
+                    {
+                        "runUnderSudo": true,
+                        "commandRoot": "dpkg",
+                        "commandParts": [
+                            "-i",
+                            "packages-microsoft-prod.deb"
+                        ]
+                    },
+                    {
+                        "runUnderSudo": true,
+                        "commandRoot": "apt-get",
+                        "commandParts": [
+                            "update"
+                        ]
+                    }
+                ]
+            },
+            {
+                "version": "20.04",
+                "preInstallCommands": [
+                    {
+                        "runUnderSudo": true,
+                        "commandRoot": "apt-get",
+                        "commandParts": [
+                            "update"
+                        ]
+                    },
+                    {
+                        "runUnderSudo": true,
+                        "commandRoot": "apt-get",
+                        "commandParts": [
+                            "install",
+                            "-y",
+                            "wget"
+                        ]
+                    },
+                    {
+                        "runUnderSudo": true,
+                        "commandRoot": "wget",
+                        "commandParts": [
+                            "https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb",
+                            "-O",
+                            "packages-microsoft-prod.deb"
+                        ]
+                    },
+                    {
+                        "runUnderSudo": true,
+                        "commandRoot": "dpkg",
+                        "commandParts": [
+                            "-i",
+                            "packages-microsoft-prod.deb"
+                        ]
+                    }
+                ]
+            },
+            {
+                "version": "22.04"
+            },
+            {
+                "version": "23.04"
+            }
+        ]
+    },
+    "Red Hat Enterprise Linux": {
+        "installCommand": [
+            {
+                "runUnderSudo": true,
+                "commandRoot": "dnf",
+                "commandParts": [
+                    "install",
+                    "-y",
+                    "{packageName}"
+                ]
+            }
+        ],
+        "uninstallCommand": [
+            {
+                "runUnderSudo": true,
+                "commandRoot": "dnf",
+                "commandParts": [
+                    "remove",
+                    "-y",
+                    "{packageName}"
+                ]
+            }
+        ],
+        "updateCommand": [
+            {
+                "runUnderSudo": true,
+                "commandRoot": "dnf",
+                "commandParts": [
+                    "update",
+                    "-y",
+                    "{packageName}"
+                ]
+            }
+        ],
+        "searchCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "yum",
+                "commandParts": [
+                    "search",
+                    "{packageName}",
+                    "-q"
+                ]
+            }
+        ],
+        "isInstalledCommand": [
+            {
+                "runUnderSudo": true,
+                "commandRoot": "dnf",
+                "commandParts": [
+                    "list",
+                    "--installed",
+                    "{packageName}",
+                    "-q"
+                ]
+            }
+        ],
+        "packageLookupCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "yum",
+                "commandParts": [
+                    "list",
+                    "install",
+                    "{packageName}",
+                    "-q"
+                ]
+            }
+        ],
+        "readSymLinkCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "readlink",
+                "commandParts": [
+                    "-f",
+                    "{path}"
+                ]
+            }
+        ],
+        "expectedDistroFeedInstallDirectory": "/usr/lib64/dotnet",
+        "expectedMicrosoftFeedInstallDirectory": "",
+        "installedSDKVersionsCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "dotnet",
+                "commandParts": [
+                    "--list-sdks"
+                ]
+            }
+        ],
+        "installedRuntimeVersionsCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "dotnet",
+                "commandParts": [
+                    "--list-runtimes"
+                ]
+            }
+        ],
+        "currentInstallationVersionCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "dotnet",
+                "commandParts": [
+                    "--version"
+                ]
+            }
+        ],
+        "currentInstallPathCommand": [
+            {
+                "runUnderSudo": false,
+                "commandRoot": "which",
+                "commandParts": [
+                    "dotnet"
+                ]
+            }
+        ],
+        "packages": [
+            {
+                "version": "6.0",
+                "sdk": [
+                    "dotnet-sdk-6.0"
+                ],
+                "runtime": [
+                    "dotnet-runtime-6.0"
+                ],
+                "aspnetcore": [
+                    "aspnetcore-runtime-6.0"
+                ]
+            },
+            {
+                "version": "7.0",
+                "sdk": [
+                    "dotnet-sdk-7.0"
+                ],
+                "runtime": [
+                    "dotnet-runtime-7.0"
+                ],
+                "aspnetcore": [
+                    "aspnetcore-runtime-7.0"
+                ]
+            },
+            {
+                "version": "8.0",
+                "sdk": [
+                    "dotnet-sdk-8.0"
+                ],
+                "runtime": [
+                    "dotnet-runtime-8.0"
+                ],
+                "aspnetcore": [
+                    "aspnetcore-runtime-8.0"
+                ]
+            },
+            {
+                "version": "9.0",
+                "sdk": [
+                    "dotnet-sdk-9.0"
+                ],
+                "runtime": [
+                    "dotnet-runtime-9.0"
+                ],
+                "aspnetcore": [
+                    "aspnetcore-runtime-9.0"
+                ]
+            }
+        ],
+        "versions": [
+            {
+                "version": "8.0"
+            },
+            {
+                "version": "9.0"
+            }
+        ]
+    }
 }


### PR DESCRIPTION
I was going to prospectively add support for Arch and found that 

a) the schema file wasn't working for me, and
b) once I got it working, it was out of date with the actual contents of the file due to some enhancements made recently.

So I updated the schema file to account for the primary change, which was making sure the preInstallCommands followed the same command structure as all the other commands.

I also used the ability of JSON Schema to name and reuse definitions to extract out the 2 most common types in use in this file:

* the description of a command
* the description of the package names to use for each component of the SDK/Runtime(s)

This makes it much easier to reuse the content.