### PR TITLE
Update Axios Cache Interceptor Bundle for Runtime Error Change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,219 @@
 			"name": "vscode-dotnet-runtime",
 			"license": "MIT",
 			"dependencies": {
-				"rimraf": "^5.0.1",
-				"vsce": "^2.15.0"
+				"@vscode/vsce": "^2.26.1",
+				"rimraf": "^5.0.1"
 			},
 			"devDependencies": {
 				"@types/source-map-support": "^0.5.6"
+			}
+		},
+		"node_modules/@azure/abort-controller": {
+			"version": "1.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+			"integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@azure/core-auth": {
+			"version": "1.7.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-auth/-/core-auth-1.7.2.tgz",
+			"integrity": "sha1-VYt8t90SsAvuwHrl31kH103x69k=",
+			"license": "MIT",
+			"dependencies": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-util": "^1.1.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
+			"version": "2.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+			"integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-client": {
+			"version": "1.9.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-client/-/core-client-1.9.2.tgz",
+			"integrity": "sha1-b8ac7igWiDq2xc3WU+5PL/l3T3Q=",
+			"license": "MIT",
+			"dependencies": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-auth": "^1.4.0",
+				"@azure/core-rest-pipeline": "^1.9.1",
+				"@azure/core-tracing": "^1.0.0",
+				"@azure/core-util": "^1.6.1",
+				"@azure/logger": "^1.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-client/node_modules/@azure/abort-controller": {
+			"version": "2.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+			"integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-rest-pipeline": {
+			"version": "1.16.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.0.tgz",
+			"integrity": "sha1-YxFy4v4DRs9EENHI4BrZjYSXOOI=",
+			"license": "MIT",
+			"dependencies": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-auth": "^1.4.0",
+				"@azure/core-tracing": "^1.0.1",
+				"@azure/core-util": "^1.9.0",
+				"@azure/logger": "^1.0.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
+			"version": "2.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+			"integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-tracing": {
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
+			"integrity": "sha1-Bl2rTgk/thiZmIoc28gn2a2QtO4=",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-util": {
+			"version": "1.9.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-util/-/core-util-1.9.0.tgz",
+			"integrity": "sha1-Rpr9fmRS1TiLGJ+Q0z93VrCyENE=",
+			"license": "MIT",
+			"dependencies": {
+				"@azure/abort-controller": "^2.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+			"version": "2.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+			"integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/identity": {
+			"version": "4.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/identity/-/identity-4.2.0.tgz",
+			"integrity": "sha1-rK7i9QeFzId3jsfu3MINbnLB2iM=",
+			"license": "MIT",
+			"dependencies": {
+				"@azure/abort-controller": "^1.0.0",
+				"@azure/core-auth": "^1.5.0",
+				"@azure/core-client": "^1.4.0",
+				"@azure/core-rest-pipeline": "^1.1.0",
+				"@azure/core-tracing": "^1.0.0",
+				"@azure/core-util": "^1.3.0",
+				"@azure/logger": "^1.0.0",
+				"@azure/msal-browser": "^3.11.1",
+				"@azure/msal-node": "^2.6.6",
+				"events": "^3.0.0",
+				"jws": "^4.0.0",
+				"open": "^8.0.0",
+				"stoppable": "^1.1.0",
+				"tslib": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/logger": {
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/logger/-/logger-1.1.2.tgz",
+			"integrity": "sha1-P0uHbO+tMo3BSv+LhQ1jthHiSdw=",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/msal-browser": {
+			"version": "3.14.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-browser/-/msal-browser-3.14.0.tgz",
+			"integrity": "sha1-HLXKtDiplDISqlDEA9Efd1x4eyE=",
+			"license": "MIT",
+			"dependencies": {
+				"@azure/msal-common": "14.10.0"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@azure/msal-common": {
+			"version": "14.10.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-common/-/msal-common-14.10.0.tgz",
+			"integrity": "sha1-IVRJcmcXtT1UmVPbd1YsrWy4Qhw=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@azure/msal-node": {
+			"version": "2.8.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-node/-/msal-node-2.8.1.tgz",
+			"integrity": "sha1-re0o037qLnJ4yb1E8gFmRzkPI5w=",
+			"license": "MIT",
+			"dependencies": {
+				"@azure/msal-common": "14.10.0",
+				"jsonwebtoken": "^9.0.0",
+				"uuid": "^8.3.0"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/@isaacs/cliui": {
@@ -51,6 +259,126 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"node_modules/@vscode/vsce": {
+			"version": "2.26.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce/-/vsce-2.26.1.tgz",
+			"integrity": "sha1-xPE7BCJeXNFtCoDrW7mLlkUc5DE=",
+			"license": "MIT",
+			"dependencies": {
+				"@azure/identity": "^4.1.0",
+				"azure-devops-node-api": "^12.5.0",
+				"chalk": "^2.4.2",
+				"cheerio": "^1.0.0-rc.9",
+				"cockatiel": "^3.1.2",
+				"commander": "^6.2.1",
+				"form-data": "^4.0.0",
+				"glob": "^7.0.6",
+				"hosted-git-info": "^4.0.2",
+				"jsonc-parser": "^3.2.0",
+				"leven": "^3.1.0",
+				"markdown-it": "^12.3.2",
+				"mime": "^1.3.4",
+				"minimatch": "^3.0.3",
+				"parse-semver": "^1.1.1",
+				"read": "^1.0.7",
+				"semver": "^7.5.2",
+				"tmp": "^0.2.1",
+				"typed-rest-client": "^1.8.4",
+				"url-join": "^4.0.1",
+				"xml2js": "^0.5.0",
+				"yauzl": "^2.3.1",
+				"yazl": "^2.2.2"
+			},
+			"bin": {
+				"vsce": "vsce"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"optionalDependencies": {
+				"keytar": "^7.7.0"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
+			"license": "Python-2.0"
+		},
+		"node_modules/@vscode/vsce/node_modules/azure-devops-node-api": {
+			"version": "12.5.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+			"integrity": "sha1-OLnv18WsdDVP5Ojb5CaX2wuOhaU=",
+			"license": "MIT",
+			"dependencies": {
+				"tunnel": "0.0.6",
+				"typed-rest-client": "^1.8.4"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/entities": {
+			"version": "2.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha1-mS0xKc999ocLlsV4WMJJoSD4uLU=",
+			"license": "BSD-2-Clause",
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/linkify-it": {
+			"version": "3.0.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/linkify-it/-/linkify-it-3.0.3.tgz",
+			"integrity": "sha1-qYuvRM5FpVDvtNScdp0HUkzC+i4=",
+			"license": "MIT",
+			"dependencies": {
+				"uc.micro": "^1.0.1"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/markdown-it": {
+			"version": "12.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/markdown-it/-/markdown-it-12.3.2.tgz",
+			"integrity": "sha1-v5Kskig/6YP+Tej/ir+1rXLNDJA=",
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "~2.1.0",
+				"linkify-it": "^3.0.1",
+				"mdurl": "^1.0.1",
+				"uc.micro": "^1.0.5"
+			},
+			"bin": {
+				"markdown-it": "bin/markdown-it.js"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/semver": {
+			"version": "7.6.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/url-join": {
+			"version": "4.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-join/-/url-join-4.0.1.tgz",
+			"integrity": "sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec=",
+			"license": "MIT"
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha1-vb3tffsJa3UaKgh+7rlmRyWy4xc=",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/ansi-regex": {
 			"version": "6.0.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -75,21 +403,11 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
-			"license": "Python-2.0"
-		},
-		"node_modules/azure-devops-node-api": {
-			"version": "11.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz",
-			"integrity": "sha1-vwTtvvYDExF6BQdBXu1HkKQgrWs=",
-			"license": "MIT",
-			"dependencies": {
-				"tunnel": "0.0.6",
-				"typed-rest-client": "^1.8.4"
-			}
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"license": "MIT"
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -115,13 +433,15 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/bl": {
 			"version": "4.1.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bl/-/bl-4.1.0.tgz",
 			"integrity": "sha1-RRU1JkGCvsL7vIOmKrmM8R2fezo=",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"buffer": "^5.5.0",
 				"inherits": "^2.0.4",
@@ -163,6 +483,7 @@
 				}
 			],
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
@@ -176,6 +497,12 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/call-bind": {
 			"version": "1.0.2",
@@ -246,7 +573,17 @@
 			"version": "1.1.4",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chownr/-/chownr-1.1.4.tgz",
 			"integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=",
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true
+		},
+		"node_modules/cockatiel": {
+			"version": "3.1.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cockatiel/-/cockatiel-3.1.3.tgz",
+			"integrity": "sha1-uxd0pJihfnOd2ZTVZhDcZTiwKFg=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			}
 		},
 		"node_modules/color-convert": {
 			"version": "1.9.3",
@@ -262,6 +599,18 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"license": "MIT"
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/commander": {
 			"version": "6.2.1",
@@ -320,11 +669,29 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
+		"node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/decompress-response": {
 			"version": "6.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz",
 			"integrity": "sha1-yjh2Et234QS9FthaqwDV7PCcZvw=",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"mimic-response": "^3.1.0"
 			},
@@ -340,8 +707,27 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-extend/-/deep-extend-0.6.0.tgz",
 			"integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/define-lazy-prop": {
+			"version": "2.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/detect-libc": {
@@ -349,6 +735,7 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.0.3.tgz",
 			"integrity": "sha1-8M1QO0D5k5uJRpfRmtUIleMM9wA=",
 			"license": "Apache-2.0",
+			"optional": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -414,6 +801,15 @@
 			"integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
 			"license": "MIT"
 		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"node_modules/emoji-regex": {
 			"version": "9.2.2",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -425,6 +821,7 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"once": "^1.4.0"
 			}
@@ -450,11 +847,21 @@
 				"node": ">=0.8.0"
 			}
 		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/events/-/events-3.3.0.tgz",
+			"integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
 		"node_modules/expand-template": {
 			"version": "2.0.3",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/expand-template/-/expand-template-2.0.3.tgz",
 			"integrity": "sha1-bhSz/O4POmNA7LV9LokYaSBSpHw=",
 			"license": "(MIT OR WTFPL)",
+			"optional": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -484,11 +891,26 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha1-k5Gdrq82HuUpWEubMWZNwSyfpFI=",
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz",
 			"integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
@@ -520,7 +942,8 @@
 			"version": "0.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/github-from-package/-/github-from-package-0.0.0.tgz",
 			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/glob": {
 			"version": "7.2.3",
@@ -606,6 +1029,32 @@
 				"entities": "^4.3.0"
 			}
 		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+			"integrity": "sha1-jpe4QaAprY3chzHyZZW62GjLQWg=",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.0.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ieee754/-/ieee754-1.2.1.tgz",
@@ -624,7 +1073,8 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
@@ -646,13 +1096,41 @@
 			"version": "1.3.8",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw=",
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true
+		},
+		"node_modules/is-docker": {
+			"version": "2.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=",
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
 			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
 			"engines": {
 				"node": ">=8"
 			}
@@ -681,12 +1159,95 @@
 				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
+		"node_modules/jsonc-parser": {
+			"version": "3.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+			"integrity": "sha1-AxkEVxzPkp12cO6MVHVFCByzfxo=",
+			"license": "MIT"
+		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+			"integrity": "sha1-Zf+R9KvvF4RpfUCVK7GZjFBMqvM=",
+			"license": "MIT",
+			"dependencies": {
+				"jws": "^3.2.2",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/jwa": {
+			"version": "1.4.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jwa/-/jwa-1.4.1.tgz",
+			"integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/jws": {
+			"version": "3.2.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jws/-/jws-3.2.2.tgz",
+			"integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^1.4.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/semver": {
+			"version": "7.6.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/jwa": {
+			"version": "2.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jwa/-/jwa-2.0.0.tgz",
+			"integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jws/-/jws-4.0.0.tgz",
+			"integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.0",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"node_modules/keytar": {
 			"version": "7.9.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keytar/-/keytar-7.9.0.tgz",
 			"integrity": "sha1-TGIlcI9RtQy/d8Wq6BchlkwpGMs=",
 			"hasInstallScript": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"node-addon-api": "^4.3.0",
 				"prebuild-install": "^7.0.1"
@@ -701,14 +1262,47 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/linkify-it": {
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isboolean": {
 			"version": "3.0.3",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/linkify-it/-/linkify-it-3.0.3.tgz",
-			"integrity": "sha1-qYuvRM5FpVDvtNScdp0HUkzC+i4=",
-			"license": "MIT",
-			"dependencies": {
-				"uc.micro": "^1.0.1"
-			}
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+			"license": "MIT"
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+			"license": "MIT"
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
@@ -720,31 +1314,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/markdown-it": {
-			"version": "12.3.2",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/markdown-it/-/markdown-it-12.3.2.tgz",
-			"integrity": "sha1-v5Kskig/6YP+Tej/ir+1rXLNDJA=",
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1",
-				"entities": "~2.1.0",
-				"linkify-it": "^3.0.1",
-				"mdurl": "^1.0.1",
-				"uc.micro": "^1.0.5"
-			},
-			"bin": {
-				"markdown-it": "bin/markdown-it.js"
-			}
-		},
-		"node_modules/markdown-it/node_modules/entities": {
-			"version": "2.1.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-2.1.0.tgz",
-			"integrity": "sha1-mS0xKc999ocLlsV4WMJJoSD4uLU=",
-			"license": "BSD-2-Clause",
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/mdurl": {
@@ -765,11 +1334,33 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/mimic-response": {
 			"version": "3.1.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz",
 			"integrity": "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k=",
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -794,6 +1385,7 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
 			"license": "MIT",
+			"optional": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -811,6 +1403,13 @@
 			"version": "0.5.3",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
 			"integrity": "sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM=",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
 			"license": "MIT"
 		},
 		"node_modules/mute-stream": {
@@ -823,13 +1422,15 @@
 			"version": "1.0.2",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
 			"integrity": "sha1-sf3cCyxG44Cgt6dvmE3UfEGhOAY=",
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/node-abi": {
-			"version": "3.57.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.57.0.tgz",
-			"integrity": "sha1-13LLiZI2wKpGd40NJSVpF88V6xU=",
+			"version": "3.62.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.62.0.tgz",
+			"integrity": "sha1-AXlY7RIPiaOhSnJT2oEPXXJOPzY=",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"semver": "^7.3.5"
 			},
@@ -838,13 +1439,11 @@
 			}
 		},
 		"node_modules/node-abi/node_modules/semver": {
-			"version": "7.6.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.0.tgz",
-			"integrity": "sha1-Gkak20v/zM2Xt0O1AFyDJfI9Ti0=",
+			"version": "7.6.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
 			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"optional": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -856,7 +1455,8 @@
 			"version": "4.3.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-addon-api/-/node-addon-api-4.3.0.tgz",
 			"integrity": "sha1-UqGgtHUZPgko6Y4EJqDRJUeCt38=",
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/nth-check": {
 			"version": "2.1.1",
@@ -886,6 +1486,23 @@
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/open": {
+			"version": "8.4.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-8.4.2.tgz",
+			"integrity": "sha1-W1/+Ko95Pc0qrXPlUMuHtZywhPk=",
+			"license": "MIT",
+			"dependencies": {
+				"define-lazy-prop": "^2.0.0",
+				"is-docker": "^2.1.1",
+				"is-wsl": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/parse-semver": {
@@ -976,6 +1593,7 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prebuild-install/-/prebuild-install-7.1.2.tgz",
 			"integrity": "sha1-pf2ZhvWmJR+8R+Hlxl3nHmjAoFY=",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"detect-libc": "^2.0.0",
 				"expand-template": "^2.0.3",
@@ -1002,6 +1620,7 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -1027,6 +1646,7 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
 			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+			"optional": true,
 			"dependencies": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -1054,6 +1674,7 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -1227,7 +1848,8 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/simple-get": {
 			"version": "4.0.1",
@@ -1248,6 +1870,7 @@
 				}
 			],
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"decompress-response": "^6.0.0",
 				"once": "^1.3.1",
@@ -1264,11 +1887,22 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/stoppable": {
+			"version": "1.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stoppable/-/stoppable-1.1.0.tgz",
+			"integrity": "sha1-MtpWjoPqSIsI5NfqLDvMnXUBXVs=",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4",
+				"npm": ">=6"
+			}
+		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -1374,6 +2008,7 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1395,6 +2030,7 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar-fs/-/tar-fs-2.1.1.tgz",
 			"integrity": "sha1-SJoVq4Xx8L76uzcLfeT561y+h4Q=",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"chownr": "^1.1.1",
 				"mkdirp-classic": "^0.5.2",
@@ -1407,6 +2043,7 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar-stream/-/tar-stream-2.2.0.tgz",
 			"integrity": "sha1-rK2EwoQTawYNw/qmRHSqmuvXcoc=",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"bl": "^4.0.3",
 				"end-of-stream": "^1.4.1",
@@ -1445,6 +2082,12 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha1-cDrClCXns3zW/UVukkBNRtHz5K4=",
+			"license": "0BSD"
+		},
 		"node_modules/tunnel": {
 			"version": "0.0.6",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
@@ -1459,6 +2102,7 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"license": "Apache-2.0",
+			"optional": true,
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
 			},
@@ -1489,50 +2133,20 @@
 			"integrity": "sha1-eIa0a73wf3aOAFLxgo4dyrQMDe4=",
 			"license": "MIT"
 		},
-		"node_modules/url-join": {
-			"version": "4.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-join/-/url-join-4.0.1.tgz",
-			"integrity": "sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec=",
-			"license": "MIT"
-		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"license": "MIT"
-		},
-		"node_modules/vsce": {
-			"version": "2.15.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vsce/-/vsce-2.15.0.tgz",
-			"integrity": "sha1-SpkueFMgkqNKdVFDxrbCyry31yk=",
 			"license": "MIT",
-			"dependencies": {
-				"azure-devops-node-api": "^11.0.1",
-				"chalk": "^2.4.2",
-				"cheerio": "^1.0.0-rc.9",
-				"commander": "^6.1.0",
-				"glob": "^7.0.6",
-				"hosted-git-info": "^4.0.2",
-				"keytar": "^7.7.0",
-				"leven": "^3.1.0",
-				"markdown-it": "^12.3.2",
-				"mime": "^1.3.4",
-				"minimatch": "^3.0.3",
-				"parse-semver": "^1.1.1",
-				"read": "^1.0.7",
-				"semver": "^5.1.0",
-				"tmp": "^0.2.1",
-				"typed-rest-client": "^1.8.4",
-				"url-join": "^4.0.1",
-				"xml2js": "^0.4.23",
-				"yauzl": "^2.3.1",
-				"yazl": "^2.2.2"
-			},
+			"optional": true
+		},
+		"node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+			"license": "MIT",
 			"bin": {
-				"vsce": "vsce"
-			},
-			"engines": {
-				"node": ">= 14"
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/which": {
@@ -1678,9 +2292,9 @@
 			"license": "ISC"
 		},
 		"node_modules/xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha1-oMaVFnUkIesqx1juTUzPWIQ+rGY=",
+			"version": "0.5.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xml2js/-/xml2js-0.5.0.tgz",
+			"integrity": "sha1-2UQGMfuy7YACA/rRBvJyT2LEk7c=",
 			"license": "MIT",
 			"dependencies": {
 				"sax": ">=0.6.0",
@@ -1726,6 +2340,162 @@
 		}
 	},
 	"dependencies": {
+		"@azure/abort-controller": {
+			"version": "1.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+			"integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
+			"requires": {
+				"tslib": "^2.2.0"
+			}
+		},
+		"@azure/core-auth": {
+			"version": "1.7.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-auth/-/core-auth-1.7.2.tgz",
+			"integrity": "sha1-VYt8t90SsAvuwHrl31kH103x69k=",
+			"requires": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-util": "^1.1.0",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@azure/abort-controller": {
+					"version": "2.1.2",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+					"integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				}
+			}
+		},
+		"@azure/core-client": {
+			"version": "1.9.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-client/-/core-client-1.9.2.tgz",
+			"integrity": "sha1-b8ac7igWiDq2xc3WU+5PL/l3T3Q=",
+			"requires": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-auth": "^1.4.0",
+				"@azure/core-rest-pipeline": "^1.9.1",
+				"@azure/core-tracing": "^1.0.0",
+				"@azure/core-util": "^1.6.1",
+				"@azure/logger": "^1.0.0",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@azure/abort-controller": {
+					"version": "2.1.2",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+					"integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				}
+			}
+		},
+		"@azure/core-rest-pipeline": {
+			"version": "1.16.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.0.tgz",
+			"integrity": "sha1-YxFy4v4DRs9EENHI4BrZjYSXOOI=",
+			"requires": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-auth": "^1.4.0",
+				"@azure/core-tracing": "^1.0.1",
+				"@azure/core-util": "^1.9.0",
+				"@azure/logger": "^1.0.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@azure/abort-controller": {
+					"version": "2.1.2",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+					"integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				}
+			}
+		},
+		"@azure/core-tracing": {
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
+			"integrity": "sha1-Bl2rTgk/thiZmIoc28gn2a2QtO4=",
+			"requires": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"@azure/core-util": {
+			"version": "1.9.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-util/-/core-util-1.9.0.tgz",
+			"integrity": "sha1-Rpr9fmRS1TiLGJ+Q0z93VrCyENE=",
+			"requires": {
+				"@azure/abort-controller": "^2.0.0",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@azure/abort-controller": {
+					"version": "2.1.2",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+					"integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				}
+			}
+		},
+		"@azure/identity": {
+			"version": "4.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/identity/-/identity-4.2.0.tgz",
+			"integrity": "sha1-rK7i9QeFzId3jsfu3MINbnLB2iM=",
+			"requires": {
+				"@azure/abort-controller": "^1.0.0",
+				"@azure/core-auth": "^1.5.0",
+				"@azure/core-client": "^1.4.0",
+				"@azure/core-rest-pipeline": "^1.1.0",
+				"@azure/core-tracing": "^1.0.0",
+				"@azure/core-util": "^1.3.0",
+				"@azure/logger": "^1.0.0",
+				"@azure/msal-browser": "^3.11.1",
+				"@azure/msal-node": "^2.6.6",
+				"events": "^3.0.0",
+				"jws": "^4.0.0",
+				"open": "^8.0.0",
+				"stoppable": "^1.1.0",
+				"tslib": "^2.2.0"
+			}
+		},
+		"@azure/logger": {
+			"version": "1.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/logger/-/logger-1.1.2.tgz",
+			"integrity": "sha1-P0uHbO+tMo3BSv+LhQ1jthHiSdw=",
+			"requires": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"@azure/msal-browser": {
+			"version": "3.14.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-browser/-/msal-browser-3.14.0.tgz",
+			"integrity": "sha1-HLXKtDiplDISqlDEA9Efd1x4eyE=",
+			"requires": {
+				"@azure/msal-common": "14.10.0"
+			}
+		},
+		"@azure/msal-common": {
+			"version": "14.10.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-common/-/msal-common-14.10.0.tgz",
+			"integrity": "sha1-IVRJcmcXtT1UmVPbd1YsrWy4Qhw="
+		},
+		"@azure/msal-node": {
+			"version": "2.8.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-node/-/msal-node-2.8.1.tgz",
+			"integrity": "sha1-re0o037qLnJ4yb1E8gFmRzkPI5w=",
+			"requires": {
+				"@azure/msal-common": "14.10.0",
+				"jsonwebtoken": "^9.0.0",
+				"uuid": "^8.3.0"
+			}
+		},
 		"@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1754,6 +2524,96 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"@vscode/vsce": {
+			"version": "2.26.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce/-/vsce-2.26.1.tgz",
+			"integrity": "sha1-xPE7BCJeXNFtCoDrW7mLlkUc5DE=",
+			"requires": {
+				"@azure/identity": "^4.1.0",
+				"azure-devops-node-api": "^12.5.0",
+				"chalk": "^2.4.2",
+				"cheerio": "^1.0.0-rc.9",
+				"cockatiel": "^3.1.2",
+				"commander": "^6.2.1",
+				"form-data": "^4.0.0",
+				"glob": "^7.0.6",
+				"hosted-git-info": "^4.0.2",
+				"jsonc-parser": "^3.2.0",
+				"keytar": "^7.7.0",
+				"leven": "^3.1.0",
+				"markdown-it": "^12.3.2",
+				"mime": "^1.3.4",
+				"minimatch": "^3.0.3",
+				"parse-semver": "^1.1.1",
+				"read": "^1.0.7",
+				"semver": "^7.5.2",
+				"tmp": "^0.2.1",
+				"typed-rest-client": "^1.8.4",
+				"url-join": "^4.0.1",
+				"xml2js": "^0.5.0",
+				"yauzl": "^2.3.1",
+				"yazl": "^2.2.2"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg="
+				},
+				"azure-devops-node-api": {
+					"version": "12.5.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+					"integrity": "sha1-OLnv18WsdDVP5Ojb5CaX2wuOhaU=",
+					"requires": {
+						"tunnel": "0.0.6",
+						"typed-rest-client": "^1.8.4"
+					}
+				},
+				"entities": {
+					"version": "2.1.0",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-2.1.0.tgz",
+					"integrity": "sha1-mS0xKc999ocLlsV4WMJJoSD4uLU="
+				},
+				"linkify-it": {
+					"version": "3.0.3",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/linkify-it/-/linkify-it-3.0.3.tgz",
+					"integrity": "sha1-qYuvRM5FpVDvtNScdp0HUkzC+i4=",
+					"requires": {
+						"uc.micro": "^1.0.1"
+					}
+				},
+				"markdown-it": {
+					"version": "12.3.2",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/markdown-it/-/markdown-it-12.3.2.tgz",
+					"integrity": "sha1-v5Kskig/6YP+Tej/ir+1rXLNDJA=",
+					"requires": {
+						"argparse": "^2.0.1",
+						"entities": "~2.1.0",
+						"linkify-it": "^3.0.1",
+						"mdurl": "^1.0.1",
+						"uc.micro": "^1.0.5"
+					}
+				},
+				"semver": {
+					"version": "7.6.2",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM="
+				},
+				"url-join": {
+					"version": "4.0.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-join/-/url-join-4.0.1.tgz",
+					"integrity": "sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec="
+				}
+			}
+		},
+		"agent-base": {
+			"version": "7.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha1-vb3tffsJa3UaKgh+7rlmRyWy4xc=",
+			"requires": {
+				"debug": "^4.3.4"
+			}
+		},
 		"ansi-regex": {
 			"version": "6.0.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -1767,19 +2627,10 @@
 				"color-convert": "^1.9.0"
 			}
 		},
-		"argparse": {
-			"version": "2.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg="
-		},
-		"azure-devops-node-api": {
-			"version": "11.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz",
-			"integrity": "sha1-vwTtvvYDExF6BQdBXu1HkKQgrWs=",
-			"requires": {
-				"tunnel": "0.0.6",
-				"typed-rest-client": "^1.8.4"
-			}
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"balanced-match": {
 			"version": "1.0.2",
@@ -1789,12 +2640,14 @@
 		"base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo="
+			"integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
+			"optional": true
 		},
 		"bl": {
 			"version": "4.1.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bl/-/bl-4.1.0.tgz",
 			"integrity": "sha1-RRU1JkGCvsL7vIOmKrmM8R2fezo=",
+			"optional": true,
 			"requires": {
 				"buffer": "^5.5.0",
 				"inherits": "^2.0.4",
@@ -1819,6 +2672,7 @@
 			"version": "5.7.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer/-/buffer-5.7.1.tgz",
 			"integrity": "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=",
+			"optional": true,
 			"requires": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
@@ -1828,6 +2682,11 @@
 			"version": "0.2.13",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+		},
+		"buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
 		},
 		"call-bind": {
 			"version": "1.0.2",
@@ -1878,7 +2737,13 @@
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs="
+			"integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=",
+			"optional": true
+		},
+		"cockatiel": {
+			"version": "3.1.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cockatiel/-/cockatiel-3.1.3.tgz",
+			"integrity": "sha1-uxd0pJihfnOd2ZTVZhDcZTiwKFg="
 		},
 		"color-convert": {
 			"version": "1.9.3",
@@ -1892,6 +2757,14 @@
 			"version": "1.1.3",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
 		},
 		"commander": {
 			"version": "6.2.1",
@@ -1930,10 +2803,19 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-what/-/css-what-6.1.0.tgz",
 			"integrity": "sha1-+17/z3bx3eosgb36pN5E55uscPQ="
 		},
+		"debug": {
+			"version": "4.3.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=",
+			"requires": {
+				"ms": "2.1.2"
+			}
+		},
 		"decompress-response": {
 			"version": "6.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz",
 			"integrity": "sha1-yjh2Et234QS9FthaqwDV7PCcZvw=",
+			"optional": true,
 			"requires": {
 				"mimic-response": "^3.1.0"
 			}
@@ -1941,12 +2823,24 @@
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
+			"integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
+			"optional": true
+		},
+		"define-lazy-prop": {
+			"version": "2.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8="
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"detect-libc": {
 			"version": "2.0.3",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.0.3.tgz",
-			"integrity": "sha1-8M1QO0D5k5uJRpfRmtUIleMM9wA="
+			"integrity": "sha1-8M1QO0D5k5uJRpfRmtUIleMM9wA=",
+			"optional": true
 		},
 		"dom-serializer": {
 			"version": "2.0.0",
@@ -1986,6 +2880,14 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s="
 		},
+		"ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"emoji-regex": {
 			"version": "9.2.2",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -1995,6 +2897,7 @@
 			"version": "1.4.4",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+			"optional": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -2009,10 +2912,16 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
+		"events": {
+			"version": "3.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/events/-/events-3.3.0.tgz",
+			"integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA="
+		},
 		"expand-template": {
 			"version": "2.0.3",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha1-bhSz/O4POmNA7LV9LokYaSBSpHw="
+			"integrity": "sha1-bhSz/O4POmNA7LV9LokYaSBSpHw=",
+			"optional": true
 		},
 		"fd-slicer": {
 			"version": "1.1.0",
@@ -2031,10 +2940,21 @@
 				"signal-exit": "^4.0.1"
 			}
 		},
+		"form-data": {
+			"version": "4.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha1-k5Gdrq82HuUpWEubMWZNwSyfpFI=",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			}
+		},
 		"fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
+			"integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
+			"optional": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -2059,7 +2979,8 @@
 		"github-from-package": {
 			"version": "0.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+			"optional": true
 		},
 		"glob": {
 			"version": "7.2.3",
@@ -2111,10 +3032,29 @@
 				"entities": "^4.3.0"
 			}
 		},
+		"http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
+			"requires": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			}
+		},
+		"https-proxy-agent": {
+			"version": "7.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+			"integrity": "sha1-jpe4QaAprY3chzHyZZW62GjLQWg=",
+			"requires": {
+				"agent-base": "^7.0.2",
+				"debug": "4"
+			}
+		},
 		"ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I="
+			"integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=",
+			"optional": true
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -2133,12 +3073,26 @@
 		"ini": {
 			"version": "1.3.8",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw="
+			"integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw=",
+			"optional": true
+		},
+		"is-docker": {
+			"version": "2.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao="
 		},
 		"is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
+		},
+		"is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+			"requires": {
+				"is-docker": "^2.0.0"
+			}
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -2154,10 +3108,78 @@
 				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
+		"jsonc-parser": {
+			"version": "3.2.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+			"integrity": "sha1-AxkEVxzPkp12cO6MVHVFCByzfxo="
+		},
+		"jsonwebtoken": {
+			"version": "9.0.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+			"integrity": "sha1-Zf+R9KvvF4RpfUCVK7GZjFBMqvM=",
+			"requires": {
+				"jws": "^3.2.2",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"dependencies": {
+				"jwa": {
+					"version": "1.4.1",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jwa/-/jwa-1.4.1.tgz",
+					"integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
+					"requires": {
+						"buffer-equal-constant-time": "1.0.1",
+						"ecdsa-sig-formatter": "1.0.11",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"jws": {
+					"version": "3.2.2",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jws/-/jws-3.2.2.tgz",
+					"integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+					"requires": {
+						"jwa": "^1.4.1",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"semver": {
+					"version": "7.6.2",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM="
+				}
+			}
+		},
+		"jwa": {
+			"version": "2.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jwa/-/jwa-2.0.0.tgz",
+			"integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
+			"requires": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"jws": {
+			"version": "4.0.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jws/-/jws-4.0.0.tgz",
+			"integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
+			"requires": {
+				"jwa": "^2.0.0",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"keytar": {
 			"version": "7.9.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keytar/-/keytar-7.9.0.tgz",
 			"integrity": "sha1-TGIlcI9RtQy/d8Wq6BchlkwpGMs=",
+			"optional": true,
 			"requires": {
 				"node-addon-api": "^4.3.0",
 				"prebuild-install": "^7.0.1"
@@ -2168,13 +3190,40 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/leven/-/leven-3.1.0.tgz",
 			"integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I="
 		},
-		"linkify-it": {
+		"lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+		},
+		"lodash.isboolean": {
 			"version": "3.0.3",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/linkify-it/-/linkify-it-3.0.3.tgz",
-			"integrity": "sha1-qYuvRM5FpVDvtNScdp0HUkzC+i4=",
-			"requires": {
-				"uc.micro": "^1.0.1"
-			}
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+		},
+		"lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+		},
+		"lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+		},
+		"lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+		},
+		"lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
 		},
 		"lru-cache": {
 			"version": "6.0.0",
@@ -2182,25 +3231,6 @@
 			"integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
 			"requires": {
 				"yallist": "^4.0.0"
-			}
-		},
-		"markdown-it": {
-			"version": "12.3.2",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/markdown-it/-/markdown-it-12.3.2.tgz",
-			"integrity": "sha1-v5Kskig/6YP+Tej/ir+1rXLNDJA=",
-			"requires": {
-				"argparse": "^2.0.1",
-				"entities": "~2.1.0",
-				"linkify-it": "^3.0.1",
-				"mdurl": "^1.0.1",
-				"uc.micro": "^1.0.5"
-			},
-			"dependencies": {
-				"entities": {
-					"version": "2.1.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-2.1.0.tgz",
-					"integrity": "sha1-mS0xKc999ocLlsV4WMJJoSD4uLU="
-				}
 			}
 		},
 		"mdurl": {
@@ -2213,10 +3243,24 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime/-/mime-1.6.0.tgz",
 			"integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
 		},
+		"mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A="
+		},
+		"mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
+			"requires": {
+				"mime-db": "1.52.0"
+			}
+		},
 		"mimic-response": {
 			"version": "3.1.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k="
+			"integrity": "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k=",
+			"optional": true
 		},
 		"minimatch": {
 			"version": "3.1.2",
@@ -2229,7 +3273,8 @@
 		"minimist": {
 			"version": "1.2.8",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw="
+			"integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
+			"optional": true
 		},
 		"minipass": {
 			"version": "7.0.2",
@@ -2239,7 +3284,13 @@
 		"mkdirp-classic": {
 			"version": "0.5.3",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-			"integrity": "sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM="
+			"integrity": "sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM=",
+			"optional": true
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
 		},
 		"mute-stream": {
 			"version": "0.0.8",
@@ -2249,30 +3300,31 @@
 		"napi-build-utils": {
 			"version": "1.0.2",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-			"integrity": "sha1-sf3cCyxG44Cgt6dvmE3UfEGhOAY="
+			"integrity": "sha1-sf3cCyxG44Cgt6dvmE3UfEGhOAY=",
+			"optional": true
 		},
 		"node-abi": {
-			"version": "3.57.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.57.0.tgz",
-			"integrity": "sha1-13LLiZI2wKpGd40NJSVpF88V6xU=",
+			"version": "3.62.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.62.0.tgz",
+			"integrity": "sha1-AXlY7RIPiaOhSnJT2oEPXXJOPzY=",
+			"optional": true,
 			"requires": {
 				"semver": "^7.3.5"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.6.0",
-					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.0.tgz",
-					"integrity": "sha1-Gkak20v/zM2Xt0O1AFyDJfI9Ti0=",
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
+					"version": "7.6.2",
+					"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
+					"optional": true
 				}
 			}
 		},
 		"node-addon-api": {
 			"version": "4.3.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-addon-api/-/node-addon-api-4.3.0.tgz",
-			"integrity": "sha1-UqGgtHUZPgko6Y4EJqDRJUeCt38="
+			"integrity": "sha1-UqGgtHUZPgko6Y4EJqDRJUeCt38=",
+			"optional": true
 		},
 		"nth-check": {
 			"version": "2.1.1",
@@ -2293,6 +3345,16 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"open": {
+			"version": "8.4.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-8.4.2.tgz",
+			"integrity": "sha1-W1/+Ko95Pc0qrXPlUMuHtZywhPk=",
+			"requires": {
+				"define-lazy-prop": "^2.0.0",
+				"is-docker": "^2.1.1",
+				"is-wsl": "^2.2.0"
 			}
 		},
 		"parse-semver": {
@@ -2355,6 +3417,7 @@
 			"version": "7.1.2",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prebuild-install/-/prebuild-install-7.1.2.tgz",
 			"integrity": "sha1-pf2ZhvWmJR+8R+Hlxl3nHmjAoFY=",
+			"optional": true,
 			"requires": {
 				"detect-libc": "^2.0.0",
 				"expand-template": "^2.0.3",
@@ -2374,6 +3437,7 @@
 			"version": "3.0.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+			"optional": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -2391,6 +3455,7 @@
 			"version": "1.2.8",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
+			"optional": true,
 			"requires": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -2410,6 +3475,7 @@
 			"version": "3.6.2",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
+			"optional": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -2500,12 +3566,14 @@
 		"simple-concat": {
 			"version": "1.0.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha1-9Gl2CCujXCJj8cirXt/ibEHJVS8="
+			"integrity": "sha1-9Gl2CCujXCJj8cirXt/ibEHJVS8=",
+			"optional": true
 		},
 		"simple-get": {
 			"version": "4.0.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/simple-get/-/simple-get-4.0.1.tgz",
 			"integrity": "sha1-SjnbVJKHyXnTUhEvoD/Zn9a8NUM=",
+			"optional": true,
 			"requires": {
 				"decompress-response": "^6.0.0",
 				"once": "^1.3.1",
@@ -2518,10 +3586,16 @@
 			"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
 			"dev": true
 		},
+		"stoppable": {
+			"version": "1.1.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stoppable/-/stoppable-1.1.0.tgz",
+			"integrity": "sha1-MtpWjoPqSIsI5NfqLDvMnXUBXVs="
+		},
 		"string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
+			"optional": true,
 			"requires": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -2592,7 +3666,8 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"optional": true
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -2606,6 +3681,7 @@
 			"version": "2.1.1",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar-fs/-/tar-fs-2.1.1.tgz",
 			"integrity": "sha1-SJoVq4Xx8L76uzcLfeT561y+h4Q=",
+			"optional": true,
 			"requires": {
 				"chownr": "^1.1.1",
 				"mkdirp-classic": "^0.5.2",
@@ -2617,6 +3693,7 @@
 			"version": "2.2.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar-stream/-/tar-stream-2.2.0.tgz",
 			"integrity": "sha1-rK2EwoQTawYNw/qmRHSqmuvXcoc=",
+			"optional": true,
 			"requires": {
 				"bl": "^4.0.3",
 				"end-of-stream": "^1.4.1",
@@ -2643,6 +3720,11 @@
 				}
 			}
 		},
+		"tslib": {
+			"version": "2.6.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha1-cDrClCXns3zW/UVukkBNRtHz5K4="
+		},
 		"tunnel": {
 			"version": "0.0.6",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
@@ -2652,6 +3734,7 @@
 			"version": "0.6.0",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"optional": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -2676,42 +3759,16 @@
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/underscore/-/underscore-1.13.4.tgz",
 			"integrity": "sha1-eIa0a73wf3aOAFLxgo4dyrQMDe4="
 		},
-		"url-join": {
-			"version": "4.0.1",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-join/-/url-join-4.0.1.tgz",
-			"integrity": "sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec="
-		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"optional": true
 		},
-		"vsce": {
-			"version": "2.15.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vsce/-/vsce-2.15.0.tgz",
-			"integrity": "sha1-SpkueFMgkqNKdVFDxrbCyry31yk=",
-			"requires": {
-				"azure-devops-node-api": "^11.0.1",
-				"chalk": "^2.4.2",
-				"cheerio": "^1.0.0-rc.9",
-				"commander": "^6.1.0",
-				"glob": "^7.0.6",
-				"hosted-git-info": "^4.0.2",
-				"keytar": "^7.7.0",
-				"leven": "^3.1.0",
-				"markdown-it": "^12.3.2",
-				"mime": "^1.3.4",
-				"minimatch": "^3.0.3",
-				"parse-semver": "^1.1.1",
-				"read": "^1.0.7",
-				"semver": "^5.1.0",
-				"tmp": "^0.2.1",
-				"typed-rest-client": "^1.8.4",
-				"url-join": "^4.0.1",
-				"xml2js": "^0.4.23",
-				"yauzl": "^2.3.1",
-				"yazl": "^2.2.2"
-			}
+		"uuid": {
+			"version": "8.3.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
 		},
 		"which": {
 			"version": "2.0.2",
@@ -2805,9 +3862,9 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha1-oMaVFnUkIesqx1juTUzPWIQ+rGY=",
+			"version": "0.5.0",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xml2js/-/xml2js-0.5.0.tgz",
+			"integrity": "sha1-2UQGMfuy7YACA/rRBvJyT2LEk7c=",
 			"requires": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
 		"lint": "tslint -c tslint.json 'vscode-dotnet-runtime-library/src/**/*.ts' 'vscode-dotnet-runtime-extension/src/**/*.ts' 'vscode-dotnet-sdk-extension/src/**/*.ts'"
 	},
 	"dependencies": {
-		"rimraf": "^5.0.1",
-		"vsce": "^2.15.0"
+		"@vscode/vsce": "^2.26.1",
+		"rimraf": "^5.0.1"
 	},
 	"devDependencies": {
 		"@types/source-map-support": "^0.5.6"

--- a/pipeline-templates/install-node.yaml
+++ b/pipeline-templates/install-node.yaml
@@ -1,5 +1,5 @@
 steps:
-- task: NodeTool@0
+- task:  UseNode@1
   inputs:
-    versionSpec: '16.10.0'
+    version: '18.x'
   displayName: '⚛️ Install Node.js'

--- a/vscode-dotnet-runtime-library/package-lock.json
+++ b/vscode-dotnet-runtime-library/package-lock.json
@@ -17,7 +17,7 @@
 				"@types/shelljs": "0.8.9",
 				"@types/vscode": "1.74.0",
 				"@vscode/sudo-prompt": "^9.3.1",
-				"axios": "^1.3.4",
+				"axios": "^1.7.2",
 				"axios-cache-interceptor": "^1.5.3",
 				"axios-retry": "^3.4.0",
 				"chai": "4.3.4",
@@ -431,12 +431,12 @@
 			"license": "MIT"
 		},
 		"node_modules/axios": {
-			"version": "1.6.7",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/axios/-/axios-1.6.7.tgz",
-			"integrity": "sha1-e0jC4nyW+caKL48x4qsZ9ZsGsKc=",
+			"version": "1.7.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/axios/-/axios-1.7.2.tgz",
+			"integrity": "sha1-tiXbinBR++phw1o8uzodqnucdiE=",
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.4",
+				"follow-redirects": "^1.15.6",
 				"form-data": "^4.0.0",
 				"proxy-from-env": "^1.1.0"
 			}
@@ -3621,11 +3621,11 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"axios": {
-			"version": "1.6.7",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/axios/-/axios-1.6.7.tgz",
-			"integrity": "sha1-e0jC4nyW+caKL48x4qsZ9ZsGsKc=",
+			"version": "1.7.2",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/axios/-/axios-1.7.2.tgz",
+			"integrity": "sha1-tiXbinBR++phw1o8uzodqnucdiE=",
 			"requires": {
-				"follow-redirects": "^1.15.4",
+				"follow-redirects": "^1.15.6",
 				"form-data": "^4.0.0",
 				"proxy-from-env": "^1.1.0"
 			},

--- a/vscode-dotnet-runtime-library/package-lock.json
+++ b/vscode-dotnet-runtime-library/package-lock.json
@@ -18,7 +18,7 @@
 				"@types/vscode": "1.74.0",
 				"@vscode/sudo-prompt": "^9.3.1",
 				"axios": "^1.3.4",
-				"axios-cache-interceptor": "^1.0.1",
+				"axios-cache-interceptor": "^1.5.3",
 				"axios-retry": "^3.4.0",
 				"chai": "4.3.4",
 				"chai-as-promised": "^7.1.1",
@@ -442,14 +442,14 @@
 			}
 		},
 		"node_modules/axios-cache-interceptor": {
-			"version": "1.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/axios-cache-interceptor/-/axios-cache-interceptor-1.2.0.tgz",
-			"integrity": "sha1-xsSK1iMogg2VaycwJwhQVw+zkN0=",
+			"version": "1.5.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/axios-cache-interceptor/-/axios-cache-interceptor-1.5.3.tgz",
+			"integrity": "sha1-IIP8aKrLkVJA437ct5K0/tY1QL4=",
 			"license": "MIT",
 			"dependencies": {
-				"cache-parser": "^1.2.4",
-				"fast-defer": "^1.1.7",
-				"object-code": "^1.2.4"
+				"cache-parser": "1.2.5",
+				"fast-defer": "1.1.8",
+				"object-code": "1.3.3"
 			},
 			"engines": {
 				"node": ">=12"
@@ -580,9 +580,9 @@
 			}
 		},
 		"node_modules/cache-parser": {
-			"version": "1.2.4",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cache-parser/-/cache-parser-1.2.4.tgz",
-			"integrity": "sha1-YJdRNe8jMOah1giVJ51yN6Kps5g=",
+			"version": "1.2.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cache-parser/-/cache-parser-1.2.5.tgz",
+			"integrity": "sha1-8ZECp4iwMFU4lzDrBJPkY+Gzeaw=",
 			"license": "MIT"
 		},
 		"node_modules/cacheable-lookup": {
@@ -1090,9 +1090,9 @@
 			}
 		},
 		"node_modules/fast-defer": {
-			"version": "1.1.7",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-defer/-/fast-defer-1.1.7.tgz",
-			"integrity": "sha1-lDvDx6h21Dc2AxirHh8mminzG6Q=",
+			"version": "1.1.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-defer/-/fast-defer-1.1.8.tgz",
+			"integrity": "sha1-lA75WXsupRxM0I6Z0PKol4+km6I=",
 			"license": "MIT"
 		},
 		"node_modules/fill-range": {
@@ -2202,9 +2202,9 @@
 			}
 		},
 		"node_modules/object-code": {
-			"version": "1.2.4",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-code/-/object-code-1.2.4.tgz",
-			"integrity": "sha1-w1axxSNycuc2o4Q8YIbKCadUsnc=",
+			"version": "1.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-code/-/object-code-1.3.3.tgz",
+			"integrity": "sha1-zyGEPd/szj7HP9FB9mp/FroMuT4=",
 			"license": "MIT"
 		},
 		"node_modules/object-inspect": {
@@ -3643,13 +3643,13 @@
 			}
 		},
 		"axios-cache-interceptor": {
-			"version": "1.2.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/axios-cache-interceptor/-/axios-cache-interceptor-1.2.0.tgz",
-			"integrity": "sha1-xsSK1iMogg2VaycwJwhQVw+zkN0=",
+			"version": "1.5.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/axios-cache-interceptor/-/axios-cache-interceptor-1.5.3.tgz",
+			"integrity": "sha1-IIP8aKrLkVJA437ct5K0/tY1QL4=",
 			"requires": {
-				"cache-parser": "^1.2.4",
-				"fast-defer": "^1.1.7",
-				"object-code": "^1.2.4"
+				"cache-parser": "1.2.5",
+				"fast-defer": "1.1.8",
+				"object-code": "1.3.3"
 			}
 		},
 		"axios-retry": {
@@ -3728,9 +3728,9 @@
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"cache-parser": {
-			"version": "1.2.4",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cache-parser/-/cache-parser-1.2.4.tgz",
-			"integrity": "sha1-YJdRNe8jMOah1giVJ51yN6Kps5g="
+			"version": "1.2.5",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cache-parser/-/cache-parser-1.2.5.tgz",
+			"integrity": "sha1-8ZECp4iwMFU4lzDrBJPkY+Gzeaw="
 		},
 		"cacheable-lookup": {
 			"version": "5.0.4",
@@ -4067,9 +4067,9 @@
 			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
 		},
 		"fast-defer": {
-			"version": "1.1.7",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-defer/-/fast-defer-1.1.7.tgz",
-			"integrity": "sha1-lDvDx6h21Dc2AxirHh8mminzG6Q="
+			"version": "1.1.8",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-defer/-/fast-defer-1.1.8.tgz",
+			"integrity": "sha1-lA75WXsupRxM0I6Z0PKol4+km6I="
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -4766,9 +4766,9 @@
 			}
 		},
 		"object-code": {
-			"version": "1.2.4",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-code/-/object-code-1.2.4.tgz",
-			"integrity": "sha1-w1axxSNycuc2o4Q8YIbKCadUsnc="
+			"version": "1.3.3",
+			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-code/-/object-code-1.3.3.tgz",
+			"integrity": "sha1-zyGEPd/szj7HP9FB9mp/FroMuT4="
 		},
 		"object-inspect": {
 			"version": "1.12.2",

--- a/vscode-dotnet-runtime-library/package.json
+++ b/vscode-dotnet-runtime-library/package.json
@@ -37,7 +37,7 @@
 		"@types/shelljs": "0.8.9",
 		"@types/vscode": "1.74.0",
 		"@vscode/sudo-prompt": "^9.3.1",
-		"axios": "^1.3.4",
+		"axios": "^1.7.2",
 		"axios-cache-interceptor": "^1.5.3",
 		"axios-retry": "^3.4.0",
 		"chai": "4.3.4",

--- a/vscode-dotnet-runtime-library/package.json
+++ b/vscode-dotnet-runtime-library/package.json
@@ -38,7 +38,7 @@
 		"@types/vscode": "1.74.0",
 		"@vscode/sudo-prompt": "^9.3.1",
 		"axios": "^1.3.4",
-		"axios-cache-interceptor": "^1.0.1",
+		"axios-cache-interceptor": "^1.5.3",
 		"axios-retry": "^3.4.0",
 		"chai": "4.3.4",
 		"chai-as-promised": "^7.1.1",

--- a/vscode-dotnet-runtime-library/src/test/unit/LoggingObserver.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LoggingObserver.test.ts
@@ -30,7 +30,7 @@ suite('LoggingObserver Unit Tests', () => {
         // Check if the log file content is same as expected content
         fs.readdirSync(tempPath).forEach(file => {
             const logContent = fs.readFileSync(path.join(tempPath, file)).toString();
-            assert.include(logContent, fakeEvent.eventName, 'The log file does not contain the expected content that should be written to it?');
+            assert.include(logContent, fakeEvent.eventName, 'The log file does not contain the expected content that should be written to it');
         });
 
     }).timeout(4000);

--- a/vscode-dotnet-runtime-library/src/test/unit/LoggingObserver.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LoggingObserver.test.ts
@@ -33,5 +33,5 @@ suite('LoggingObserver Unit Tests', () => {
             assert.include(logContent, fakeEvent.eventName, 'The log file does not contain the expected content that should be written to it?');
         });
 
-    });
+    }).timeout(4000);
 });

--- a/vscode-dotnet-runtime-library/yarn.lock
+++ b/vscode-dotnet-runtime-library/yarn.lock
@@ -244,14 +244,14 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz"
   "version" "0.4.0"
 
-"axios-cache-interceptor@^1.0.1":
-  "integrity" "sha1-xsSK1iMogg2VaycwJwhQVw+zkN0="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/axios-cache-interceptor/-/axios-cache-interceptor-1.2.0.tgz"
-  "version" "1.2.0"
+"axios-cache-interceptor@^1.5.3":
+  "integrity" "sha1-IIP8aKrLkVJA437ct5K0/tY1QL4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/axios-cache-interceptor/-/axios-cache-interceptor-1.5.3.tgz"
+  "version" "1.5.3"
   dependencies:
-    "cache-parser" "^1.2.4"
-    "fast-defer" "^1.1.7"
-    "object-code" "^1.2.4"
+    "cache-parser" "1.2.5"
+    "fast-defer" "1.1.8"
+    "object-code" "1.3.3"
 
 "axios-retry@^3.4.0":
   "integrity" "sha1-9GTb6UCOWqePoxmv04u2m1M9iFQ="
@@ -333,10 +333,10 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz"
   "version" "1.1.1"
 
-"cache-parser@^1.2.4":
-  "integrity" "sha1-YJdRNe8jMOah1giVJ51yN6Kps5g="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cache-parser/-/cache-parser-1.2.4.tgz"
-  "version" "1.2.4"
+"cache-parser@1.2.5":
+  "integrity" "sha1-8ZECp4iwMFU4lzDrBJPkY+Gzeaw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cache-parser/-/cache-parser-1.2.5.tgz"
+  "version" "1.2.5"
 
 "cacheable-lookup@^5.0.3":
   "integrity" "sha1-WmuGWyxENXvj1evCpGewMnGacAU="
@@ -697,10 +697,10 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz"
   "version" "4.0.1"
 
-"fast-defer@^1.1.7":
-  "integrity" "sha1-lDvDx6h21Dc2AxirHh8mminzG6Q="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-defer/-/fast-defer-1.1.7.tgz"
-  "version" "1.1.7"
+"fast-defer@1.1.8":
+  "integrity" "sha1-lA75WXsupRxM0I6Z0PKol4+km6I="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-defer/-/fast-defer-1.1.8.tgz"
+  "version" "1.1.8"
 
 "fill-range@^7.0.1":
   "integrity" "sha1-GRmmp8df44ssfHflGYU12prN2kA="
@@ -1371,10 +1371,10 @@
     "config-chain" "^1.1.11"
     "pify" "^3.0.0"
 
-"object-code@^1.2.4":
-  "integrity" "sha1-w1axxSNycuc2o4Q8YIbKCadUsnc="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-code/-/object-code-1.2.4.tgz"
-  "version" "1.2.4"
+"object-code@1.3.3":
+  "integrity" "sha1-zyGEPd/szj7HP9FB9mp/FroMuT4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-code/-/object-code-1.3.3.tgz"
+  "version" "1.3.3"
 
 "object-inspect@^1.12.0", "object-inspect@^1.9.0":
   "integrity" "sha1-wGQfJjlFMvKKuNeWq5VOQ8AJqOo="

--- a/vscode-dotnet-runtime-library/yarn.lock
+++ b/vscode-dotnet-runtime-library/yarn.lock
@@ -261,12 +261,12 @@
     "@babel/runtime" "^7.15.4"
     "is-retry-allowed" "^2.2.0"
 
-"axios@^1", "axios@^1.3.4":
-  "integrity" "sha1-e0jC4nyW+caKL48x4qsZ9ZsGsKc="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/axios/-/axios-1.6.7.tgz"
-  "version" "1.6.7"
+"axios@^1", "axios@^1.7.2":
+  "integrity" "sha1-tiXbinBR++phw1o8uzodqnucdiE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/axios/-/axios-1.7.2.tgz"
+  "version" "1.7.2"
   dependencies:
-    "follow-redirects" "^1.15.4"
+    "follow-redirects" "^1.15.6"
     "form-data" "^4.0.0"
     "proxy-from-env" "^1.1.0"
 
@@ -722,7 +722,7 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat/-/flat-5.0.2.tgz"
   "version" "5.0.2"
 
-"follow-redirects@^1.15.4":
+"follow-redirects@^1.15.6":
   "integrity" "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz"
   "version" "1.15.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,119 @@
 # yarn lockfile v1
 
 
+"@azure/abort-controller@^1.0.0":
+  "integrity" "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz"
+  "version" "1.1.0"
+  dependencies:
+    "tslib" "^2.2.0"
+
+"@azure/abort-controller@^2.0.0":
+  "integrity" "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz"
+  "version" "2.1.2"
+  dependencies:
+    "tslib" "^2.6.2"
+
+"@azure/core-auth@^1.4.0", "@azure/core-auth@^1.5.0":
+  "integrity" "sha1-VYt8t90SsAvuwHrl31kH103x69k="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-auth/-/core-auth-1.7.2.tgz"
+  "version" "1.7.2"
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    "@azure/core-util" "^1.1.0"
+    "tslib" "^2.6.2"
+
+"@azure/core-client@^1.4.0":
+  "integrity" "sha1-b8ac7igWiDq2xc3WU+5PL/l3T3Q="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-client/-/core-client-1.9.2.tgz"
+  "version" "1.9.2"
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    "@azure/core-auth" "^1.4.0"
+    "@azure/core-rest-pipeline" "^1.9.1"
+    "@azure/core-tracing" "^1.0.0"
+    "@azure/core-util" "^1.6.1"
+    "@azure/logger" "^1.0.0"
+    "tslib" "^2.6.2"
+
+"@azure/core-rest-pipeline@^1.1.0", "@azure/core-rest-pipeline@^1.9.1":
+  "integrity" "sha1-YxFy4v4DRs9EENHI4BrZjYSXOOI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.0.tgz"
+  "version" "1.16.0"
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    "@azure/core-auth" "^1.4.0"
+    "@azure/core-tracing" "^1.0.1"
+    "@azure/core-util" "^1.9.0"
+    "@azure/logger" "^1.0.0"
+    "http-proxy-agent" "^7.0.0"
+    "https-proxy-agent" "^7.0.0"
+    "tslib" "^2.6.2"
+
+"@azure/core-tracing@^1.0.0", "@azure/core-tracing@^1.0.1":
+  "integrity" "sha1-Bl2rTgk/thiZmIoc28gn2a2QtO4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-tracing/-/core-tracing-1.1.2.tgz"
+  "version" "1.1.2"
+  dependencies:
+    "tslib" "^2.6.2"
+
+"@azure/core-util@^1.1.0", "@azure/core-util@^1.3.0", "@azure/core-util@^1.6.1", "@azure/core-util@^1.9.0":
+  "integrity" "sha1-Rpr9fmRS1TiLGJ+Q0z93VrCyENE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-util/-/core-util-1.9.0.tgz"
+  "version" "1.9.0"
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    "tslib" "^2.6.2"
+
+"@azure/identity@^4.1.0":
+  "integrity" "sha1-rK7i9QeFzId3jsfu3MINbnLB2iM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/identity/-/identity-4.2.0.tgz"
+  "version" "4.2.0"
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-auth" "^1.5.0"
+    "@azure/core-client" "^1.4.0"
+    "@azure/core-rest-pipeline" "^1.1.0"
+    "@azure/core-tracing" "^1.0.0"
+    "@azure/core-util" "^1.3.0"
+    "@azure/logger" "^1.0.0"
+    "@azure/msal-browser" "^3.11.1"
+    "@azure/msal-node" "^2.6.6"
+    "events" "^3.0.0"
+    "jws" "^4.0.0"
+    "open" "^8.0.0"
+    "stoppable" "^1.1.0"
+    "tslib" "^2.2.0"
+
+"@azure/logger@^1.0.0":
+  "integrity" "sha1-P0uHbO+tMo3BSv+LhQ1jthHiSdw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/logger/-/logger-1.1.2.tgz"
+  "version" "1.1.2"
+  dependencies:
+    "tslib" "^2.6.2"
+
+"@azure/msal-browser@^3.11.1":
+  "integrity" "sha1-HLXKtDiplDISqlDEA9Efd1x4eyE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-browser/-/msal-browser-3.14.0.tgz"
+  "version" "3.14.0"
+  dependencies:
+    "@azure/msal-common" "14.10.0"
+
+"@azure/msal-common@14.10.0":
+  "integrity" "sha1-IVRJcmcXtT1UmVPbd1YsrWy4Qhw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-common/-/msal-common-14.10.0.tgz"
+  "version" "14.10.0"
+
+"@azure/msal-node@^2.6.6":
+  "integrity" "sha1-re0o037qLnJ4yb1E8gFmRzkPI5w="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-node/-/msal-node-2.8.1.tgz"
+  "version" "2.8.1"
+  dependencies:
+    "@azure/msal-common" "14.10.0"
+    "jsonwebtoken" "^9.0.0"
+    "uuid" "^8.3.0"
+
 "@isaacs/cliui@^8.0.2":
   "integrity" "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz"
@@ -25,6 +138,44 @@
   "version" "0.5.6"
   dependencies:
     "source-map" "^0.6.0"
+
+"@vscode/vsce@^2.26.1":
+  "integrity" "sha1-xPE7BCJeXNFtCoDrW7mLlkUc5DE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce/-/vsce-2.26.1.tgz"
+  "version" "2.26.1"
+  dependencies:
+    "@azure/identity" "^4.1.0"
+    "azure-devops-node-api" "^12.5.0"
+    "chalk" "^2.4.2"
+    "cheerio" "^1.0.0-rc.9"
+    "cockatiel" "^3.1.2"
+    "commander" "^6.2.1"
+    "form-data" "^4.0.0"
+    "glob" "^7.0.6"
+    "hosted-git-info" "^4.0.2"
+    "jsonc-parser" "^3.2.0"
+    "leven" "^3.1.0"
+    "markdown-it" "^12.3.2"
+    "mime" "^1.3.4"
+    "minimatch" "^3.0.3"
+    "parse-semver" "^1.1.1"
+    "read" "^1.0.7"
+    "semver" "^7.5.2"
+    "tmp" "^0.2.1"
+    "typed-rest-client" "^1.8.4"
+    "url-join" "^4.0.1"
+    "xml2js" "^0.5.0"
+    "yauzl" "^2.3.1"
+    "yazl" "^2.2.2"
+  optionalDependencies:
+    "keytar" "^7.7.0"
+
+"agent-base@^7.0.2", "agent-base@^7.1.0":
+  "integrity" "sha1-vb3tffsJa3UaKgh+7rlmRyWy4xc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/agent-base/-/agent-base-7.1.1.tgz"
+  "version" "7.1.1"
+  dependencies:
+    "debug" "^4.3.4"
 
 "ansi-regex@^5.0.1":
   "integrity" "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
@@ -60,10 +211,15 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz"
   "version" "2.0.1"
 
-"azure-devops-node-api@^11.0.1":
-  "integrity" "sha1-vwTtvvYDExF6BQdBXu1HkKQgrWs="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz"
-  "version" "11.2.0"
+"asynckit@^0.4.0":
+  "integrity" "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz"
+  "version" "0.4.0"
+
+"azure-devops-node-api@^12.5.0":
+  "integrity" "sha1-OLnv18WsdDVP5Ojb5CaX2wuOhaU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz"
+  "version" "12.5.0"
   dependencies:
     "tunnel" "0.0.6"
     "typed-rest-client" "^1.8.4"
@@ -111,6 +267,11 @@
   "integrity" "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
   "version" "0.2.13"
+
+"buffer-equal-constant-time@1.0.1":
+  "integrity" "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
+  "version" "1.0.1"
 
 "buffer@^5.5.0":
   "integrity" "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA="
@@ -167,6 +328,11 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chownr/-/chownr-1.1.4.tgz"
   "version" "1.1.4"
 
+"cockatiel@^3.1.2":
+  "integrity" "sha1-uxd0pJihfnOd2ZTVZhDcZTiwKFg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cockatiel/-/cockatiel-3.1.3.tgz"
+  "version" "3.1.3"
+
 "color-convert@^1.9.0":
   "integrity" "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz"
@@ -191,7 +357,14 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz"
   "version" "1.1.3"
 
-"commander@^6.1.0":
+"combined-stream@^1.0.8":
+  "integrity" "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz"
+  "version" "1.0.8"
+  dependencies:
+    "delayed-stream" "~1.0.0"
+
+"commander@^6.2.1":
   "integrity" "sha1-B5LraC37wyWZm7K4T93duhEKxzw="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-6.2.1.tgz"
   "version" "6.2.1"
@@ -226,6 +399,13 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-what/-/css-what-6.1.0.tgz"
   "version" "6.1.0"
 
+"debug@^4.3.4", "debug@4":
+  "integrity" "sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.3.4.tgz"
+  "version" "4.3.4"
+  dependencies:
+    "ms" "2.1.2"
+
 "decompress-response@^6.0.0":
   "integrity" "sha1-yjh2Et234QS9FthaqwDV7PCcZvw="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz"
@@ -237,6 +417,16 @@
   "integrity" "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-extend/-/deep-extend-0.6.0.tgz"
   "version" "0.6.0"
+
+"define-lazy-prop@^2.0.0":
+  "integrity" "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz"
+  "version" "2.0.0"
+
+"delayed-stream@~1.0.0":
+  "integrity" "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz"
+  "version" "1.0.0"
 
 "detect-libc@^2.0.0":
   "integrity" "sha1-8M1QO0D5k5uJRpfRmtUIleMM9wA="
@@ -278,6 +468,13 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
   "version" "0.2.0"
 
+"ecdsa-sig-formatter@1.0.11":
+  "integrity" "sha1-rg8PothQRe8UqBfao86azQSJ5b8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz"
+  "version" "1.0.11"
+  dependencies:
+    "safe-buffer" "^5.0.1"
+
 "emoji-regex@^8.0.0":
   "integrity" "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz"
@@ -310,6 +507,11 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
   "version" "1.0.5"
 
+"events@^3.0.0":
+  "integrity" "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/events/-/events-3.3.0.tgz"
+  "version" "3.3.0"
+
 "expand-template@^2.0.3":
   "integrity" "sha1-bhSz/O4POmNA7LV9LokYaSBSpHw="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/expand-template/-/expand-template-2.0.3.tgz"
@@ -329,6 +531,15 @@
   dependencies:
     "cross-spawn" "^7.0.0"
     "signal-exit" "^4.0.1"
+
+"form-data@^4.0.0":
+  "integrity" "sha1-k5Gdrq82HuUpWEubMWZNwSyfpFI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/form-data/-/form-data-4.0.0.tgz"
+  "version" "4.0.0"
+  dependencies:
+    "asynckit" "^0.4.0"
+    "combined-stream" "^1.0.8"
+    "mime-types" "^2.1.12"
 
 "fs-constants@^1.0.0":
   "integrity" "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
@@ -416,6 +627,22 @@
     "domutils" "^3.0.1"
     "entities" "^4.3.0"
 
+"http-proxy-agent@^7.0.0":
+  "integrity" "sha1-mosfJGhmwChQlIZYX2K48sGMJw4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz"
+  "version" "7.0.2"
+  dependencies:
+    "agent-base" "^7.1.0"
+    "debug" "^4.3.4"
+
+"https-proxy-agent@^7.0.0":
+  "integrity" "sha1-jpe4QaAprY3chzHyZZW62GjLQWg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz"
+  "version" "7.0.4"
+  dependencies:
+    "agent-base" "^7.0.2"
+    "debug" "4"
+
 "ieee754@^1.1.13":
   "integrity" "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ieee754/-/ieee754-1.2.1.tgz"
@@ -439,10 +666,22 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ini/-/ini-1.3.8.tgz"
   "version" "1.3.8"
 
+"is-docker@^2.0.0", "is-docker@^2.1.1":
+  "integrity" "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-2.2.1.tgz"
+  "version" "2.2.1"
+
 "is-fullwidth-code-point@^3.0.0":
   "integrity" "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
   "version" "3.0.0"
+
+"is-wsl@^2.2.0":
+  "integrity" "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz"
+  "version" "2.2.0"
+  dependencies:
+    "is-docker" "^2.0.0"
 
 "isexe@^2.0.0":
   "integrity" "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
@@ -457,6 +696,61 @@
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
+
+"jsonc-parser@^3.2.0":
+  "integrity" "sha1-AxkEVxzPkp12cO6MVHVFCByzfxo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsonc-parser/-/jsonc-parser-3.2.1.tgz"
+  "version" "3.2.1"
+
+"jsonwebtoken@^9.0.0":
+  "integrity" "sha1-Zf+R9KvvF4RpfUCVK7GZjFBMqvM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz"
+  "version" "9.0.2"
+  dependencies:
+    "jws" "^3.2.2"
+    "lodash.includes" "^4.3.0"
+    "lodash.isboolean" "^3.0.3"
+    "lodash.isinteger" "^4.0.4"
+    "lodash.isnumber" "^3.0.3"
+    "lodash.isplainobject" "^4.0.6"
+    "lodash.isstring" "^4.0.1"
+    "lodash.once" "^4.0.0"
+    "ms" "^2.1.1"
+    "semver" "^7.5.4"
+
+"jwa@^1.4.1":
+  "integrity" "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jwa/-/jwa-1.4.1.tgz"
+  "version" "1.4.1"
+  dependencies:
+    "buffer-equal-constant-time" "1.0.1"
+    "ecdsa-sig-formatter" "1.0.11"
+    "safe-buffer" "^5.0.1"
+
+"jwa@^2.0.0":
+  "integrity" "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jwa/-/jwa-2.0.0.tgz"
+  "version" "2.0.0"
+  dependencies:
+    "buffer-equal-constant-time" "1.0.1"
+    "ecdsa-sig-formatter" "1.0.11"
+    "safe-buffer" "^5.0.1"
+
+"jws@^3.2.2":
+  "integrity" "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jws/-/jws-3.2.2.tgz"
+  "version" "3.2.2"
+  dependencies:
+    "jwa" "^1.4.1"
+    "safe-buffer" "^5.0.1"
+
+"jws@^4.0.0":
+  "integrity" "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jws/-/jws-4.0.0.tgz"
+  "version" "4.0.0"
+  dependencies:
+    "jwa" "^2.0.0"
+    "safe-buffer" "^5.0.1"
 
 "keytar@^7.7.0":
   "integrity" "sha1-TGIlcI9RtQy/d8Wq6BchlkwpGMs="
@@ -477,6 +771,41 @@
   "version" "3.0.3"
   dependencies:
     "uc.micro" "^1.0.1"
+
+"lodash.includes@^4.3.0":
+  "integrity" "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz"
+  "version" "4.3.0"
+
+"lodash.isboolean@^3.0.3":
+  "integrity" "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz"
+  "version" "3.0.3"
+
+"lodash.isinteger@^4.0.4":
+  "integrity" "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz"
+  "version" "4.0.4"
+
+"lodash.isnumber@^3.0.3":
+  "integrity" "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz"
+  "version" "3.0.3"
+
+"lodash.isplainobject@^4.0.6":
+  "integrity" "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz"
+  "version" "4.0.6"
+
+"lodash.isstring@^4.0.1":
+  "integrity" "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz"
+  "version" "4.0.1"
+
+"lodash.once@^4.0.0":
+  "integrity" "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz"
+  "version" "4.1.1"
 
 "lru-cache@^6.0.0":
   "integrity" "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ="
@@ -505,6 +834,18 @@
   "integrity" "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mdurl/-/mdurl-1.0.1.tgz"
   "version" "1.0.1"
+
+"mime-db@1.52.0":
+  "integrity" "sha1-u6vNwChZ9JhzAchW4zh85exDv3A="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-db/-/mime-db-1.52.0.tgz"
+  "version" "1.52.0"
+
+"mime-types@^2.1.12":
+  "integrity" "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-types/-/mime-types-2.1.35.tgz"
+  "version" "2.1.35"
+  dependencies:
+    "mime-db" "1.52.0"
 
 "mime@^1.3.4":
   "integrity" "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
@@ -545,6 +886,11 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz"
   "version" "0.5.3"
 
+"ms@^2.1.1", "ms@2.1.2":
+  "integrity" "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz"
+  "version" "2.1.2"
+
 "mute-stream@~0.0.4":
   "integrity" "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mute-stream/-/mute-stream-0.0.8.tgz"
@@ -556,9 +902,9 @@
   "version" "1.0.2"
 
 "node-abi@^3.3.0":
-  "integrity" "sha1-13LLiZI2wKpGd40NJSVpF88V6xU="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.57.0.tgz"
-  "version" "3.57.0"
+  "integrity" "sha1-AXlY7RIPiaOhSnJT2oEPXXJOPzY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.62.0.tgz"
+  "version" "3.62.0"
   dependencies:
     "semver" "^7.3.5"
 
@@ -585,6 +931,15 @@
   "version" "1.4.0"
   dependencies:
     "wrappy" "1"
+
+"open@^8.0.0":
+  "integrity" "sha1-W1/+Ko95Pc0qrXPlUMuHtZywhPk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-8.4.2.tgz"
+  "version" "8.4.2"
+  dependencies:
+    "define-lazy-prop" "^2.0.0"
+    "is-docker" "^2.1.1"
+    "is-wsl" "^2.2.0"
 
 "parse-semver@^1.1.1":
   "integrity" "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg="
@@ -720,11 +1075,19 @@
   "version" "5.7.2"
 
 "semver@^7.3.5":
-  "integrity" "sha1-Gkak20v/zM2Xt0O1AFyDJfI9Ti0="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.0.tgz"
-  "version" "7.6.0"
-  dependencies:
-    "lru-cache" "^6.0.0"
+  "integrity" "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.2.tgz"
+  "version" "7.6.2"
+
+"semver@^7.5.2":
+  "integrity" "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.2.tgz"
+  "version" "7.6.2"
+
+"semver@^7.5.4":
+  "integrity" "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.6.2.tgz"
+  "version" "7.6.2"
 
 "shebang-command@^2.0.0":
   "integrity" "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo="
@@ -770,6 +1133,11 @@
   "integrity" "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map/-/source-map-0.6.1.tgz"
   "version" "0.6.1"
+
+"stoppable@^1.1.0":
+  "integrity" "sha1-MtpWjoPqSIsI5NfqLDvMnXUBXVs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stoppable/-/stoppable-1.1.0.tgz"
+  "version" "1.1.0"
 
 "string_decoder@^1.1.1":
   "integrity" "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4="
@@ -866,6 +1234,11 @@
   dependencies:
     "rimraf" "^3.0.0"
 
+"tslib@^2.2.0", "tslib@^2.6.2":
+  "integrity" "sha1-cDrClCXns3zW/UVukkBNRtHz5K4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.6.2.tgz"
+  "version" "2.6.2"
+
 "tunnel-agent@^0.6.0":
   "integrity" "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
@@ -907,31 +1280,10 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz"
   "version" "1.0.2"
 
-"vsce@^2.15.0":
-  "integrity" "sha1-SpkueFMgkqNKdVFDxrbCyry31yk="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vsce/-/vsce-2.15.0.tgz"
-  "version" "2.15.0"
-  dependencies:
-    "azure-devops-node-api" "^11.0.1"
-    "chalk" "^2.4.2"
-    "cheerio" "^1.0.0-rc.9"
-    "commander" "^6.1.0"
-    "glob" "^7.0.6"
-    "hosted-git-info" "^4.0.2"
-    "keytar" "^7.7.0"
-    "leven" "^3.1.0"
-    "markdown-it" "^12.3.2"
-    "mime" "^1.3.4"
-    "minimatch" "^3.0.3"
-    "parse-semver" "^1.1.1"
-    "read" "^1.0.7"
-    "semver" "^5.1.0"
-    "tmp" "^0.2.1"
-    "typed-rest-client" "^1.8.4"
-    "url-join" "^4.0.1"
-    "xml2js" "^0.4.23"
-    "yauzl" "^2.3.1"
-    "yazl" "^2.2.2"
+"uuid@^8.3.0":
+  "integrity" "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uuid/-/uuid-8.3.2.tgz"
+  "version" "8.3.2"
 
 "which@^2.0.1":
   "integrity" "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE="
@@ -963,10 +1315,10 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz"
   "version" "1.0.2"
 
-"xml2js@^0.4.23":
-  "integrity" "sha1-oMaVFnUkIesqx1juTUzPWIQ+rGY="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xml2js/-/xml2js-0.4.23.tgz"
-  "version" "0.4.23"
+"xml2js@^0.5.0":
+  "integrity" "sha1-2UQGMfuy7YACA/rRBvJyT2LEk7c="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xml2js/-/xml2js-0.5.0.tgz"
+  "version" "0.5.0"
   dependencies:
     "sax" ">=0.6.0"
     "xmlbuilder" "~11.0.0"


### PR DESCRIPTION
Per the issue in https://github.com/arthurfiorette/tinylibs/issues/301, this is one of our highest facing issues. 
Let's see if this update resolves it. 

This is to solve the issue reported in https://github.com/dotnet/vscode-dotnet-runtime/issues/1734 
`Failed: n[r].split is not a function. Abortion. Please ensure that you are online.`

Along the way I also updated axios to make sure the newest version is utilized, and migrated to the newest version of vsce which is how we package our extension. In doing so, I had to migrate from node 16 to node 18.