### PR TITLE
Don't rely on english output for registry lookups

### DIFF
--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -325,6 +325,7 @@ export class MockCommandExecutor extends ICommandExecutor
 {
     private trueExecutor : CommandExecutor;
     public fakeReturnValue = '';
+    public fakeReturnStatus : string | null = null;
     public attemptedCommand = '';
 
     // If you expect several commands to be run and want to specify unique outputs for each, describe them in the same order using the below two arrays.
@@ -342,6 +343,10 @@ export class MockCommandExecutor extends ICommandExecutor
     {
         this.attemptedCommand = CommandExecutor.prettifyCommandExecutorCommand(command);
 
+        if(this.returnStatus && this.fakeReturnStatus)
+        {
+            return this.fakeReturnStatus;
+        }
         if(!command.runUnderSudo && this.fakeReturnValue === '')
         {
             this.trueExecutor.returnStatus = this.returnStatus;

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -356,7 +356,7 @@ export class MockCommandExecutor extends ICommandExecutor
             if(command.commandRoot.includes(commandPatternToLookFor) ||
                 command.commandParts.some((arg) => arg.includes(commandPatternToLookFor)))
             {
-                if(this.shouldReturnStatus() && this.otherCommandsStatusReturnValues)
+                if(this.shouldReturnStatus() && this.otherCommandsStatusReturnValues[i] !== null)
                 {
                         return this.otherCommandsStatusReturnValues[i];
                 }

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -330,7 +330,7 @@ export class MockCommandExecutor extends ICommandExecutor
 
     // If you expect several commands to be run and want to specify unique outputs for each, describe them in the same order using the below two arrays.
     // We will check for an includes match and not an exact match!
-    public otherCommandsToMock : string[] = [];
+    public otherCommandPatternsToMock : string[] = [];
     public otherCommandsReturnValues : string[] = [];
     public otherCommandsStatusReturnValues : string[] = [];
 
@@ -344,24 +344,29 @@ export class MockCommandExecutor extends ICommandExecutor
     {
         this.attemptedCommand = CommandExecutor.prettifyCommandExecutorCommand(command);
 
-        if(!command.runUnderSudo && this.fakeReturnValue === '')
+        if(this.shouldActuallyExecuteCommand(command))
         {
             this.trueExecutor.returnStatus = this.returnStatus;
             return this.trueExecutor.execute(command, options);
         }
-        else if(this.otherCommandsToMock.some(x => x.includes(command.commandRoot) || command.commandParts.some((part) => x.includes(part))))
+
+        for(let i = 0; i < this.otherCommandPatternsToMock.length; ++i)
         {
-            const fakeResultIndex = this.otherCommandsToMock.findIndex(x => x.includes(command.commandRoot));
-            // We don't need to verify the index since this is test code!
-            if(this.returnStatus)
+            const commandPatternToLookFor = this.otherCommandPatternsToMock[i];
+            if(command.commandRoot.includes(commandPatternToLookFor) ||
+                command.commandParts.some((arg) => arg.includes(commandPatternToLookFor)))
             {
-                return this.otherCommandsStatusReturnValues[fakeResultIndex];
+                if(this.shouldReturnStatus() && this.otherCommandsStatusReturnValues)
+                {
+                        return this.otherCommandsStatusReturnValues[i];
+                }
+                return this.otherCommandsReturnValues[i];
             }
-            return this.otherCommandsReturnValues[fakeResultIndex];
         }
-        else if(this.returnStatus && this.fakeReturnStatus)
+
+        if(this.shouldReturnStatus())
         {
-                return this.fakeReturnStatus;
+            return this.fakeReturnStatus!;
         }
         else
         {
@@ -381,6 +386,20 @@ export class MockCommandExecutor extends ICommandExecutor
 
     public async tryFindWorkingCommand(commands: CommandExecutorCommand[]): Promise<CommandExecutorCommand> {
         return commands[0];
+    }
+
+    /**
+     * @remarks For commands which dont edit the global system state or we don't need to mock their data, we can just execute them
+     * with a real command executor to provide better code coverage.
+     */
+    private shouldActuallyExecuteCommand(command : CommandExecutorCommand) : boolean
+    {
+        return !command.runUnderSudo && this.fakeReturnValue === '';
+    }
+
+    private shouldReturnStatus() : boolean
+    {
+        return this.returnStatus && (this.fakeReturnStatus !== null);
     }
 }
 

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -350,7 +350,7 @@ export class MockCommandExecutor extends ICommandExecutor
             this.trueExecutor.returnStatus = this.returnStatus;
             return this.trueExecutor.execute(command, options);
         }
-        else if(this.otherCommandsToMock.some(x => x.includes(command.commandRoot)))
+        else if(this.otherCommandsToMock.some(x => x.includes(command.commandRoot) || command.commandParts.some((part) => x.includes(part))))
         {
             const fakeResultIndex = this.otherCommandsToMock.findIndex(x => x.includes(command.commandRoot));
             // We don't need to verify the index since this is test code!

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -332,6 +332,7 @@ export class MockCommandExecutor extends ICommandExecutor
     // We will check for an includes match and not an exact match!
     public otherCommandsToMock : string[] = [];
     public otherCommandsReturnValues : string[] = [];
+    public otherCommandsStatusReturnValues : string[] = [];
 
     constructor(acquisitionContext : IAcquisitionWorkerContext, utilContext : IUtilityContext)
     {
@@ -343,10 +344,7 @@ export class MockCommandExecutor extends ICommandExecutor
     {
         this.attemptedCommand = CommandExecutor.prettifyCommandExecutorCommand(command);
 
-        if(this.returnStatus && this.fakeReturnStatus)
-        {
-            return this.fakeReturnStatus;
-        }
+
         if(!command.runUnderSudo && this.fakeReturnValue === '')
         {
             this.trueExecutor.returnStatus = this.returnStatus;
@@ -356,7 +354,15 @@ export class MockCommandExecutor extends ICommandExecutor
         {
             const fakeResultIndex = this.otherCommandsToMock.findIndex(x => x.includes(command.commandRoot));
             // We don't need to verify the index since this is test code!
+            if(this.returnStatus)
+            {
+                return this.otherCommandsStatusReturnValues[fakeResultIndex];
+            }
             return this.otherCommandsReturnValues[fakeResultIndex];
+        }
+        else if(this.returnStatus && this.fakeReturnStatus)
+        {
+                return this.fakeReturnStatus;
         }
         else
         {

--- a/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
@@ -50,7 +50,7 @@ suite('Windows & Mac Global Installer Tests', () =>
             mockExecutor.fakeReturnValue = `
             7.0.301    REG_DWORD    0x1
         `;
-            mockExecutor.otherCommandsToMock = ['x86'] // make the 32 bit query error / have no result
+            mockExecutor.otherCommandPatternsToMock = ['x86'] // make the 32 bit query error / have no result
             mockExecutor.otherCommandsReturnValues = [`ERROR: The system was unable to find the specified registry key or value.`];
             mockExecutor.otherCommandsStatusReturnValues = ['1'];
             foundVersions = await installer.getGlobalSdkVersionsInstalledOnMachine();
@@ -58,15 +58,18 @@ suite('Windows & Mac Global Installer Tests', () =>
 
             // no sdks exist
             // Try throwing for  64 bit, and returning empty for 32 bit
+            mockExecutor.fakeReturnStatus = '1';
             mockExecutor.fakeReturnValue = `ERROR: The system was unable to find the specified registry key or value.`;
             mockExecutor.otherCommandsReturnValues = [``];
             mockExecutor.otherCommandsStatusReturnValues = ['1'];
             foundVersions = await installer.getGlobalSdkVersionsInstalledOnMachine();
             assert.deepStrictEqual(foundVersions, []);
-            mockExecutor.fakeReturnValue = ``;
 
-            mockExecutor.otherCommandsToMock = [];
+            mockExecutor.fakeReturnValue = ``;
+            mockExecutor.fakeReturnStatus = '0';
+            mockExecutor.otherCommandPatternsToMock = [];
             mockExecutor.otherCommandsReturnValues = [];
+            mockExecutor.otherCommandsStatusReturnValues = [];
 
             // Assert that it passes when running the command for real
             foundVersions = await installer.getGlobalSdkVersionsInstalledOnMachine();

--- a/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
@@ -22,9 +22,11 @@ suite('Windows & Mac Global Installer Tests', () =>
     const mockUrl = 'https://download.visualstudio.microsoft.com/download/pr/4c0aaf08-3fa1-4fa0-8435-73b85eee4b32/e8264b3530b03b74b04ecfcf1666fe93/dotnet-sdk-7.0.306-win-x64.exe';
     const mockHash = '';
     const mockExecutor = new MockCommandExecutor(getMockAcquisitionContext('sdk', mockVersion), getMockUtilityContext());
+    mockExecutor.fakeReturnStatus = '0';
     const mockFileUtils = new MockFileUtilities();
     const installer : WinMacGlobalInstaller = new WinMacGlobalInstaller(getMockAcquisitionContext('sdk', mockVersion), getMockUtilityContext(), mockVersion, mockUrl, mockHash, mockExecutor);
     installer.file = mockFileUtils;
+
 
     test('It reads SDK registry entries correctly on windows', async () =>
     {

--- a/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
@@ -52,6 +52,7 @@ suite('Windows & Mac Global Installer Tests', () =>
         `;
             mockExecutor.otherCommandsToMock = ['x86'] // make the 32 bit query error / have no result
             mockExecutor.otherCommandsReturnValues = [`ERROR: The system was unable to find the specified registry key or value.`];
+            mockExecutor.otherCommandsStatusReturnValues = ['1'];
             foundVersions = await installer.getGlobalSdkVersionsInstalledOnMachine();
             assert.deepStrictEqual(foundVersions, ['7.0.301']);
 
@@ -59,6 +60,7 @@ suite('Windows & Mac Global Installer Tests', () =>
             // Try throwing for  64 bit, and returning empty for 32 bit
             mockExecutor.fakeReturnValue = `ERROR: The system was unable to find the specified registry key or value.`;
             mockExecutor.otherCommandsReturnValues = [``];
+            mockExecutor.otherCommandsStatusReturnValues = ['1'];
             foundVersions = await installer.getGlobalSdkVersionsInstalledOnMachine();
             assert.deepStrictEqual(foundVersions, []);
             mockExecutor.fakeReturnValue = ``;


### PR DESCRIPTION
⚠️ Problem: We relied on 'ERROR' to determine if an error occurred during a registry lookup. This lookup is to find already existing installs of the .NET SDK on the machine. If the system display language is not english, reg.exe does not return in english. Unfortunately there is no option to standardize output or output language. https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/reg-query

💡 Solution: Read the status code first to check if the query resulted in an error.

❓ Alternative solution: Add registry-js library from GitHub to query registry in a less hacky way. Unfortunately this adds native binaries to our extension and would require us to ship platform specific packages, which is extra work I would prefer not to do.

💥 : Ways this could be improved: 
The `CommandExecutor` only returns a string at the moment. It could be improved to return a result object with stdout, stderr, and status code, so we don't need to run the command twice. This is obviously the better solution in the long term. But it would require updating a lot of code, and I don't think it's a priority to do that right now.

♻️ Testing: I was unable to get reg.exe to output in any language besides english but it does seem to happen. Setting the system locale, preferences, display language, and preferred language did not impact reg.exe after the fact. Will rely on vendors to test on a machine with different OS language.
![image](https://github.com/dotnet/vscode-dotnet-runtime/assets/23152278/88c4b07d-03a6-46fd-a871-812fd6c3a789)

![image](https://github.com/dotnet/vscode-dotnet-runtime/assets/23152278/e9940a68-ff7c-4b92-bc1e-72079d230aba)

Resolves: 
https://github.com/dotnet/vscode-dotnet-runtime/issues/1827
https://github.com/dotnet/vscode-csharp/issues/7158