### PR TITLE
[1/N] Add ASP.NET Support - Refactor Installation Worker

### DIFF
--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -35,7 +35,7 @@
 		},
 		"../vscode-dotnet-runtime-extension": {
 			"name": "vscode-dotnet-runtime",
-			"version": "2.0.5",
+			"version": "2.0.6",
 			"license": "MIT",
 			"dependencies": {
 				"@types/chai-as-promised": "^7.1.8",

--- a/sample/src/extension.ts
+++ b/sample/src/extension.ts
@@ -166,7 +166,7 @@ ${stderr}`);
         try
         {
             await vscode.commands.executeCommand('dotnet.showAcquisitionLog');
-            let commandContext : IDotnetAcquireContext = { version, requestingExtensionId, installType: 'global' };
+            let commandContext : IDotnetAcquireContext = { version: version, requestingExtensionId: requestingExtensionId, installType: 'global' };
             await vscode.commands.executeCommand('dotnet.acquireGlobalSDK', commandContext);
         }
         catch (error)
@@ -208,7 +208,7 @@ ${stderr}`);
         try
         {
             await vscode.commands.executeCommand('dotnet-sdk.showAcquisitionLog');
-            let commandContext : IDotnetAcquireContext = { version, requestingExtensionId, installType: 'global' };
+            let commandContext : IDotnetAcquireContext = { version: version, requestingExtensionId: requestingExtensionId, installType: 'global' };
             await vscode.commands.executeCommand('dotnet-sdk.acquire', commandContext);
         }
         catch (error)

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -38,7 +38,7 @@ import {
     IIssueContext,
     InstallationValidator,
     registerEventStream,
-    getDirectoryByMode,
+    directoryProviderFactory,
     VersionResolver,
     VSCodeExtensionContext,
     VSCodeEnvironment,
@@ -325,7 +325,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         {
             const mode = 'runtime' as DotnetInstallMode;
             const worker = getAcquisitionWorker();
-            const installDirectoryProvider = getDirectoryByMode(mode, context.globalStoragePath);
+            const installDirectoryProvider = directoryProviderFactory(mode, context.globalStoragePath);
 
             await worker.uninstallAll(globalEventStream, installDirectoryProvider.getStoragePath(), context.globalState);
         },
@@ -455,7 +455,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
             timeoutSeconds: resolvedTimeoutSeconds,
             acquisitionContext: acquiringContext,
             installMode: mode,
-            installDirectoryProvider: getDirectoryByMode(mode, context.globalStoragePath),
+            installDirectoryProvider: directoryProviderFactory(mode, context.globalStoragePath),
             proxyUrl: proxyLink,
             isExtensionTelemetryInitiallyEnabled: isExtensionTelemetryEnabled
         }

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -327,7 +327,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
             const worker = getAcquisitionWorker();
             const installDirectoryProvider = getDirectoryByMode(mode, context.globalStoragePath);
 
-            worker.uninstallAll(globalEventStream, installDirectoryProvider.getStoragePath(), context.globalState);
+            await worker.uninstallAll(globalEventStream, installDirectoryProvider.getStoragePath(), context.globalState);
         },
             getIssueContext(existingPathConfigWorker)(commandContext ? commandContext.errorConfiguration : undefined, 'uninstallAll')
         );

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -138,26 +138,19 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
 
     // Setting up command-shared classes for Runtime & SDK Acquisition
     const existingPathConfigWorker = new ExtensionConfigurationWorker(extensionConfiguration, configKeys.existingPath, configKeys.existingSharedPath);
-
-    const runtimeContext = getAcquisitionWorkerContext('runtime');
-    const runtimeVersionResolver = new VersionResolver(runtimeContext);
-    const runtimeIssueContextFunctor = getIssueContext(existingPathConfigWorker);
-    const runtimeAcquisitionWorker = getAcquisitionWorker(runtimeContext);
-
-    const sdkContext = getAcquisitionWorkerContext('sdk');
-    const sdkIssueContextFunctor = getIssueContext(existingPathConfigWorker);
-    const sdkAcquisitionWorker = getAcquisitionWorker(sdkContext);
-
     checkIfSDKAcquisitionIsSupported();
 
     // Creating API Surfaces
-    const dotnetAcquireRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquire}`, async (commandContext: IDotnetAcquireContext) => {
+    const dotnetAcquireRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquire}`, async (commandContext: IDotnetAcquireContext) =>
+    {
         let fullyResolvedVersion = '';
-        const dotnetPath = await callWithErrorHandling<Promise<IDotnetAcquireResult>>(async () => {
+        const worker = getAcquisitionWorker();
+
+        const dotnetPath = await callWithErrorHandling<Promise<IDotnetAcquireResult>>(async () =>
+        {
             globalEventStream.post(new DotnetRuntimeAcquisitionStarted(commandContext.requestingExtensionId));
             globalEventStream.post(new DotnetAcquisitionRequested(commandContext.version, commandContext.requestingExtensionId));
 
-            runtimeAcquisitionWorker.setAcquisitionContext(commandContext);
             telemetryObserver?.setAcquisitionContext(runtimeContext, commandContext);
 
             if(!commandContext.requestingExtensionId)
@@ -178,19 +171,14 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
                 return existingPath;
             }
 
-            const version = await runtimeVersionResolver.getFullRuntimeVersion(commandContext.version);
-            fullyResolvedVersion = version;
+            commandContext.version = await runtimeVersionResolver.getFullRuntimeVersion(commandContext.version);
 
-            if(commandContext.architecture !== undefined)
-            {
-                runtimeAcquisitionWorker.installingArchitecture = commandContext.architecture;
-            }
-
+            const runtimeContext = getAcquisitionWorkerContext('runtime', commandContext);
             const acquisitionInvoker = new AcquisitionInvoker(runtimeContext, utilContext);
-            return runtimeAcquisitionWorker.acquireRuntime(version, acquisitionInvoker);
-        }, runtimeIssueContextFunctor(commandContext.errorConfiguration, 'acquire', commandContext.version), commandContext.requestingExtensionId, runtimeContext);
+            return worker.acquireRuntime(runtimeContext, acquisitionInvoker);
+        }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, 'acquire', commandContext.version), commandContext.requestingExtensionId, runtimeContext);
 
-        const iKey = runtimeAcquisitionWorker.getInstallKey(fullyResolvedVersion);
+        const iKey = worker.getInstallKey(fullyResolvedVersion);
         const install = {installKey : iKey, version : fullyResolvedVersion, installMode: 'runtime', isGlobal: false,
             architecture: commandContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture()} as DotnetInstall;
         globalEventStream.post(new DotnetRuntimeAcquisitionTotalSuccessEvent(commandContext.version, install, commandContext.requestingExtensionId ?? '', dotnetPath?.dotnetPath ?? ''));
@@ -205,13 +193,14 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         }
 
         let fullyResolvedVersion = '';
+        const sdkContext = getAcquisitionWorkerContext('runtime', commandContext);
+        const worker = getAcquisitionWorker();
 
         const pathResult = await callWithErrorHandling(async () =>
         {
             // Warning: Between now and later in this call-stack, the context 'version' is incomplete as it has not been resolved.
             // Errors between here and the place where it is resolved cannot be routed to one another.
 
-            sdkAcquisitionWorker.setAcquisitionContext(commandContext);
             telemetryObserver?.setAcquisitionContext(sdkContext, commandContext);
 
             if(commandContext.version === '' || !commandContext.version)
@@ -234,17 +223,16 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
 
             // Reset context to point to the fully specified version so it is not possible for someone to access incorrect data during the install process.
             commandContext.version = fullyResolvedVersion;
-            sdkAcquisitionWorker.setAcquisitionContext(commandContext);
             telemetryObserver?.setAcquisitionContext(sdkContext, commandContext);
 
             outputChannel.show(true);
-            const dotnetPath = await sdkAcquisitionWorker.acquireGlobalSDK(globalInstallerResolver);
+            const dotnetPath = await worker.acquireGlobalSDK(sdkContext, globalInstallerResolver);
 
             new CommandExecutor(sdkContext, utilContext).setPathEnvVar(dotnetPath.dotnetPath, moreInfoUrl, displayWorker, vsCodeExtensionContext, true);
             return dotnetPath;
-        }, sdkIssueContextFunctor(commandContext.errorConfiguration, commandKeys.acquireGlobalSDK), commandContext.requestingExtensionId, sdkContext);
+        }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, commandKeys.acquireGlobalSDK), commandContext.requestingExtensionId, sdkContext);
 
-        const iKey = sdkAcquisitionWorker.getInstallKey(fullyResolvedVersion);
+        const iKey = worker.getInstallKey(fullyResolvedVersion);
         const install = {installKey : iKey, version : fullyResolvedVersion, installMode: 'sdk', isGlobal: true,
         architecture: commandContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture()} as DotnetInstall;
 
@@ -313,23 +301,38 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
     });
 
     const dotnetAcquireStatusRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquireStatus}`, async (commandContext: IDotnetAcquireContext) => {
-        const pathResult = callWithErrorHandling(async () => {
+        const pathResult = callWithErrorHandling(async () =>
+        {
+            const mode = 'runtime' as DotnetInstallMode;
+            const worker = getAcquisitionWorker();
+            const workerContext = getAcquisitionWorkerContext(mode, commandContext);
+
             globalEventStream.post(new DotnetAcquisitionStatusRequested(commandContext.version, commandContext.requestingExtensionId));
             const resolvedVersion = await runtimeVersionResolver.getFullRuntimeVersion(commandContext.version);
-            const dotnetPath = await runtimeAcquisitionWorker.acquireStatus(resolvedVersion, 'runtime');
+            const dotnetPath = await worker.acquireStatus(workerContext, resolvedVersion, 'runtime');
             return dotnetPath;
-        }, runtimeIssueContextFunctor(commandContext.errorConfiguration, 'acquireRuntimeStatus'));
+        }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, 'acquireRuntimeStatus'));
         return pathResult;
     });
 
     const dotnetUninstallAllRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.uninstallAll}`, async (commandContext: IDotnetUninstallContext | undefined) => {
-        await callWithErrorHandling(() => runtimeAcquisitionWorker.uninstallAll(), runtimeIssueContextFunctor(commandContext ? commandContext.errorConfiguration : undefined, 'uninstallAll'));
+        await callWithErrorHandling(async () =>
+        {
+            const mode = 'runtime' as DotnetInstallMode;
+            const worker = getAcquisitionWorker();
+            const installDirectoryProvider = getDirectoryByMode(mode, context.globalStoragePath);
+
+            () => worker.uninstallAll(globalEventStream, installDirectoryProvider.getStoragePath())
+        },
+            getIssueContext(existingPathConfigWorker)(commandContext ? commandContext.errorConfiguration : undefined, 'uninstallAll')
+        );
     });
 
     const showOutputChannelRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.showAcquisitionLog}`, () => outputChannel.show(/* preserveFocus */ false));
 
     const ensureDependenciesRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.ensureDotnetDependencies}`, async (commandContext: IDotnetEnsureDependenciesContext) => {
-        await callWithErrorHandling(async () => {
+        await callWithErrorHandling(async () =>
+        {
             if (os.platform() !== 'linux') {
                 // We can't handle installing dependencies for anything other than Linux
                 return;
@@ -341,11 +344,11 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
                 globalEventStream.post(new DotnetAcquisitionMissingLinuxDependencies());
                 await installer.promptLinuxDependencyInstall('Failed to run .NET runtime.');
             }
-        }, runtimeIssueContextFunctor(commandContext.errorConfiguration, 'ensureDependencies'));
+        }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, 'ensureDependencies'));
     });
 
     const reportIssueRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.reportIssue}`, async () => {
-        const [url, issueBody] = formatIssueUrl(undefined, runtimeIssueContextFunctor(AcquireErrorConfiguration.DisableErrorPopups, 'reportIssue'));
+        const [url, issueBody] = formatIssueUrl(undefined, getIssueContext(existingPathConfigWorker)(AcquireErrorConfiguration.DisableErrorPopups, 'reportIssue'));
         await vscode.env.clipboard.writeText(issueBody);
         open(url);
     });
@@ -417,7 +420,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         }
     }
 
-    function getAcquisitionWorkerContext(mode : DotnetInstallMode) : IAcquisitionWorkerContext
+    function getAcquisitionWorkerContext(mode : DotnetInstallMode, acquiringContext : IDotnetAcquireContext) : IAcquisitionWorkerContext
     {
         return {
             storagePath: context.globalStoragePath,
@@ -425,6 +428,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
             eventStream: globalEventStream,
             installationValidator: new InstallationValidator(globalEventStream),
             timeoutSeconds: resolvedTimeoutSeconds,
+            acquisitionContext: acquiringContext,
             installMode: mode,
             installDirectoryProvider: getDirectoryByMode(mode, context.globalStoragePath),
             proxyUrl: proxyLink,
@@ -432,9 +436,9 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         }
     }
 
-    function getAcquisitionWorker(workerContext : IAcquisitionWorkerContext) : DotnetCoreAcquisitionWorker
+    function getAcquisitionWorker() : DotnetCoreAcquisitionWorker
     {
-        return new DotnetCoreAcquisitionWorker(workerContext, utilContext, vsCodeExtensionContext);
+        return new DotnetCoreAcquisitionWorker(utilContext, vsCodeExtensionContext);
     }
 
     function getIssueContext(configResolver : ExtensionConfigurationWorker)

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -328,7 +328,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
             const worker = getAcquisitionWorker();
             const installDirectoryProvider = getDirectoryByMode(mode, context.globalStoragePath);
 
-            () => worker.uninstallAll(globalEventStream, installDirectoryProvider.getStoragePath())
+            () => worker.uninstallAll(globalEventStream, installDirectoryProvider.getStoragePath(), context.globalState)
         },
             getIssueContext(existingPathConfigWorker)(commandContext ? commandContext.errorConfiguration : undefined, 'uninstallAll')
         );

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -181,7 +181,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
             return worker.acquireRuntime(runtimeContext, acquisitionInvoker);
         }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, 'acquire', commandContext.version), commandContext.requestingExtensionId, runtimeContext);
 
-        const iKey = worker.getInstallKey(fullyResolvedVersion);
+        const iKey = DotnetCoreAcquisitionWorker.getInstallKeyCustomArchitecture(commandContext.version, commandContext.architecture, 'local');
         const install = {installKey : iKey, version : fullyResolvedVersion, installMode: 'runtime', isGlobal: false,
             architecture: commandContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture()} as DotnetInstall;
         globalEventStream.post(new DotnetRuntimeAcquisitionTotalSuccessEvent(commandContext.version, install, commandContext.requestingExtensionId ?? '', dotnetPath?.dotnetPath ?? ''));
@@ -236,7 +236,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
             return dotnetPath;
         }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, commandKeys.acquireGlobalSDK), commandContext.requestingExtensionId, sdkContext);
 
-        const iKey = worker.getInstallKey(fullyResolvedVersion);
+        const iKey = DotnetCoreAcquisitionWorker.getInstallKeyCustomArchitecture(commandContext.version, commandContext.architecture, 'global');
         const install = {installKey : iKey, version : fullyResolvedVersion, installMode: 'sdk', isGlobal: true,
         architecture: commandContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture()} as DotnetInstall;
 

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -120,7 +120,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function() {
     assert.isTrue(fs.existsSync(result!.dotnetPath!));
     assert.include(result!.dotnetPath, context.version);
     await vscode.commands.executeCommand<string>('dotnet.uninstallAll', context.version);
-    assert.isFalse(fs.existsSync(result!.dotnetPath));
+    assert.isFalse(fs.existsSync(result!.dotnetPath), 'the dotnet path result does not exist after uninstall');
   }).timeout(standardTimeoutTime);
 
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/DirectoryProviderFactory.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DirectoryProviderFactory.ts
@@ -10,7 +10,7 @@ import { RuntimeInstallationDirectoryProvider } from './RuntimeInstallationDirec
 import { SdkInstallationDirectoryProvider } from './SdkInstallationDirectoryProvider';
 
 
-export function getDirectoryByMode(mode: DotnetInstallMode, storagePath: string) : IInstallationDirectoryProvider
+export function directoryProviderFactory(mode: DotnetInstallMode, storagePath: string) : IInstallationDirectoryProvider
 {
     return mode === 'runtime' ? new RuntimeInstallationDirectoryProvider(storagePath) : new SdkInstallationDirectoryProvider(storagePath);
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -342,11 +342,11 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
     {
         const graveyard = new InstallationGraveyard(context);
         const installsToRemove = await graveyard.get();
-        for(const installKey of installsToRemove)
+        for(const install of installsToRemove)
         {
             context.eventStream.post(new DotnetInstallGraveyardEvent(
-                `Attempting to remove .NET at ${installKey.installKey} again, as it was left in the graveyard.`));
-            await this.uninstallLocalRuntimeOrSDK(context, installKey);
+                `Attempting to remove .NET at ${JSON.stringify(install)} again, as it was left in the graveyard.`));
+            await this.uninstallLocalRuntimeOrSDK(context, install);
         }
     }
 
@@ -504,7 +504,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).untrackInstallingVersion(context, install);
 
             graveyard.remove(install);
-            context.eventStream.post(new DotnetInstallGraveyardEvent(`Success at uninstalling ${install} in path ${dotnetInstallDir}`));
+            context.eventStream.post(new DotnetInstallGraveyardEvent(`Success at uninstalling ${JSON.stringify(install)} in path ${dotnetInstallDir}`));
         }
         catch(error : any)
         {

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -403,9 +403,9 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             return 'fake-sdk';
         }
 
-        context.eventStream.post(new DotnetBeginGlobalInstallerExecution(`Beginning to run installer for ${install} in ${os.platform()}.`))
+        context.eventStream.post(new DotnetBeginGlobalInstallerExecution(`Beginning to run installer for ${JSON.stringify(install)} in ${os.platform()}.`))
         const installerResult = await installer.installSDK(install);
-        context.eventStream.post(new DotnetCompletedGlobalInstallerExecution(`Completed installer for ${install} in ${os.platform()}.`))
+        context.eventStream.post(new DotnetCompletedGlobalInstallerExecution(`Completed installer for ${JSON.stringify(install)} in ${os.platform()}.`))
 
         if(installerResult !== '0')
         {
@@ -426,7 +426,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
 
         await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).reclassifyInstallingVersionToInstalled(context, install);
 
-        context.eventStream.post(new DotnetGlobalAcquisitionCompletionEvent(`The version ${install} completed successfully.`));
+        context.eventStream.post(new DotnetGlobalAcquisitionCompletionEvent(`The version ${JSON.stringify(install)} completed successfully.`));
         return installedSDKPath;
     }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -60,6 +60,7 @@ import { InstallationGraveyard } from './InstallationGraveyard';
 import { InstallTracker } from './InstallTracker';
 import { DotnetInstallMode } from './DotnetInstallMode';
 import { IEventStream } from '../EventStream/EventStream';
+import { strict } from 'assert';
 
 /* tslint:disable:no-any */
 
@@ -88,7 +89,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         eventStream.post(new DotnetUninstallAllStarted());
         await this.installTracker.clearPromises();
 
-        this.removeFolderRecursively(context, context.installDirectoryProvider.getStoragePath());
+        this.removeFolderRecursively(eventStream, storagePath);
 
         await this.installTracker.uninstallAllRecords();
 
@@ -487,7 +488,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             graveyard.add(install, dotnetInstallDir);
             context.eventStream.post(new DotnetInstallGraveyardEvent(`Attempting to remove .NET at ${install} in path ${dotnetInstallDir}`));
 
-            this.removeFolderRecursively(context, dotnetInstallDir);
+            this.removeFolderRecursively(context.eventStream, dotnetInstallDir);
 
             await this.installTracker.untrackInstalledVersion(install);
             // this is the only place where installed and installing could deal with pre existing installing key

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -197,7 +197,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             } as DotnetInstall
         }
 
-        context.eventStream.post(new DotnetInstallKeyCreatedEvent(`The requested version ${version} is now marked under the install key: ${install}.`));
+        context.eventStream.post(new DotnetInstallKeyCreatedEvent(`The requested version ${version} is now marked under the install: ${JSON.stringify(install)}.`));
         const existingAcquisitionPromise = InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getPromise(install);
         if (existingAcquisitionPromise)
         {
@@ -474,7 +474,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             // Assumption: .NET versions so far did not include ~ in them, but we do for our non-legacy keys.
             if(!install.dotnetInstall.installKey.includes('~'))
             {
-                context.eventStream.post(new DotnetLegacyInstallDetectedEvent(`A legacy install was detected -- ${install}.`));
+                context.eventStream.post(new DotnetLegacyInstallDetectedEvent(`A legacy install was detected -- ${JSON.stringify(install)}.`));
                 legacyInstalls = legacyInstalls.concat(install);
             }
         }

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -129,7 +129,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
     {
         const version = context.acquisitionContext.version!;
         const install = GetDotnetInstallInfo(version, installMode, 'local',
-            architecture ? architecture : context.installingArchitecture ?? this.getDefaultInternalArchitecture(context.installingArchitecture))
+            architecture ? architecture : context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture))
 
         const existingAcquisitionPromise = InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getPromise(install);
         if (existingAcquisitionPromise)
@@ -183,7 +183,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         }
         const version = context.acquisitionContext.version;
         let install = GetDotnetInstallInfo(version, mode, globalInstallerResolver !== null ? 'global' : 'local',
-            context.installingArchitecture ?? this.getDefaultInternalArchitecture(context.installingArchitecture));
+            context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture));
 
         // Allow for the architecture to be null, which is a legacy behavior.
         if(context.acquisitionContext.architecture === null && context.acquisitionContext.architecture !== undefined)
@@ -304,7 +304,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             installRuntime : mode === 'runtime',
             installMode : mode,
             installType : context.acquisitionContext.installType ?? 'local', // Before this API param existed, all calls were for local types.
-            architecture: context.installingArchitecture ?? this.getDefaultInternalArchitecture(context.installingArchitecture),
+            architecture: context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture),
         } as IDotnetInstallationContext;
         context.eventStream.post(new DotnetAcquisitionStarted(install, version, context.acquisitionContext.requestingExtensionId));
         await acquisitionInvoker.installDotnet(installContext, install).catch((reason) =>
@@ -414,7 +414,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             throw err;
         }
 
-        const installedSDKPath : string = await installer.getExpectedGlobalSDKPath(installingVersion, context.installingArchitecture ?? this.getDefaultInternalArchitecture(context.installingArchitecture));
+        const installedSDKPath : string = await installer.getExpectedGlobalSDKPath(installingVersion, context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture));
 
         TelemetryUtilities.setDotnetSDKTelemetryToMatch(context.isExtensionTelemetryInitiallyEnabled, this.extensionContext, context, this.utilityContext);
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -152,7 +152,8 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         else if(installedVersions.length === 0 && fs.existsSync(dotnetPath) && installMode === 'sdk')
         {
             // The education bundle already laid down a local install, add it to our managed installs
-            const preinstalledVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).checkForUnrecordedLocalSDKSuccessfulInstall(context, dotnetInstallDir, installedVersions);
+            const preinstalledVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).checkForUnrecordedLocalSDKSuccessfulInstall(
+                context, dotnetInstallDir, installedVersions);
             if (preinstalledVersions.some(x => IsEquivalentInstallationFile(x.dotnetInstall, install)) &&
                 (fs.existsSync(dotnetPath) || this.usingNoInstallInvoker ))
             {
@@ -414,7 +415,8 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             throw err;
         }
 
-        const installedSDKPath : string = await installer.getExpectedGlobalSDKPath(installingVersion, context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture));
+        const installedSDKPath : string = await installer.getExpectedGlobalSDKPath(installingVersion,
+            context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture));
 
         TelemetryUtilities.setDotnetSDKTelemetryToMatch(context.isExtensionTelemetryInitiallyEnabled, this.extensionContext, context, this.utilityContext);
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
@@ -68,7 +68,8 @@ export function looksLikeRuntimeVersion(version: string): boolean {
     return !band || band.length <= 2; // assumption : there exists no runtime version at this point over 99 sub versions
 }
 
-export function GetDotnetInstallInfo(installVersion: string, installationMode: DotnetInstallMode, installType: DotnetInstallType, installArchitecture: string): DotnetInstall {
+export function GetDotnetInstallInfo(installVersion: string, installationMode: DotnetInstallMode, installType: DotnetInstallType, installArchitecture: string): DotnetInstall
+{
     return {
         installKey: DotnetCoreAcquisitionWorker.getInstallKeyCustomArchitecture(installVersion, installArchitecture, installType),
         version: installVersion,

--- a/vscode-dotnet-runtime-library/src/Acquisition/IAcquisitionWorkerContext.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IAcquisitionWorkerContext.ts
@@ -17,7 +17,7 @@ export interface IAcquisitionWorkerContext
     installationValidator: IInstallationValidator;
     timeoutSeconds: number;
     installDirectoryProvider: IInstallationDirectoryProvider;
-    acquisitionContext? : IDotnetAcquireContext | null;
+    acquisitionContext : IDotnetAcquireContext;
     installMode: DotnetInstallMode;
     installingArchitecture? : string | undefined | null;
     proxyUrl? : string | undefined;

--- a/vscode-dotnet-runtime-library/src/Acquisition/IAcquisitionWorkerContext.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IAcquisitionWorkerContext.ts
@@ -19,7 +19,6 @@ export interface IAcquisitionWorkerContext
     installDirectoryProvider: IInstallationDirectoryProvider;
     acquisitionContext : IDotnetAcquireContext;
     installMode: DotnetInstallMode;
-    installingArchitecture? : string | undefined | null;
     proxyUrl? : string | undefined;
     isExtensionTelemetryInitiallyEnabled : boolean;
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDotnetCoreAcquisitionWorker.ts
@@ -6,14 +6,15 @@
 import { IDotnetAcquireResult } from '../IDotnetAcquireResult';
 import { GlobalInstallerResolver } from './GlobalInstallerResolver';
 import { IAcquisitionInvoker } from './IAcquisitionInvoker';
+import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 
 export interface IDotnetCoreAcquisitionWorker
 {
-    uninstallAll(): void;
+    uninstallAll(eventStream : IEventStream, storagePath : string): void;
 
-    acquireRuntime(version: string, invoker : IAcquisitionInvoker): Promise<IDotnetAcquireResult>;
+    acquireRuntime(context: IAcquisitionWorkerContext, invoker : IAcquisitionInvoker): Promise<IDotnetAcquireResult>;
 
-    acquireSDK(version: string, invoker : IAcquisitionInvoker): Promise<IDotnetAcquireResult>;
+    acquireSDK(context: IAcquisitionWorkerContext, invoker : IAcquisitionInvoker): Promise<IDotnetAcquireResult>;
 
-    acquireGlobalSDK(installerResolver: GlobalInstallerResolver): Promise<IDotnetAcquireResult>;
+    acquireGlobalSDK(context: IAcquisitionWorkerContext, installerResolver: GlobalInstallerResolver): Promise<IDotnetAcquireResult>;
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDotnetCoreAcquisitionWorker.ts
@@ -3,14 +3,16 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
 
+import { IEventStream } from '../EventStream/EventStream';
 import { IDotnetAcquireResult } from '../IDotnetAcquireResult';
+import { IExtensionState } from '../IExtensionState';
 import { GlobalInstallerResolver } from './GlobalInstallerResolver';
 import { IAcquisitionInvoker } from './IAcquisitionInvoker';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 
 export interface IDotnetCoreAcquisitionWorker
 {
-    uninstallAll(eventStream : IEventStream, storagePath : string): void;
+    uninstallAll(eventStream : IEventStream, storagePath : string, extensionState : IExtensionState): void;
 
     acquireRuntime(context: IAcquisitionWorkerContext, invoker : IAcquisitionInvoker): Promise<IDotnetAcquireResult>;
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
@@ -40,15 +40,27 @@ interface InProgressInstall
 }
 
 
-export class InstallTracker
+export class InstallTrackerSingleton
 {
+    private static instance: InstallTrackerSingleton;
+
     protected inProgressInstalls: Set<InProgressInstall> = new Set<InProgressInstall>();
     private readonly installingVersionsKey = 'installing';
     private readonly installedVersionsKey = 'installed';
 
-    public constructor(protected readonly eventStream : IEventStream, protected readonly extensionState : IExtensionState)
+    protected constructor(protected readonly eventStream : IEventStream, protected extensionState : IExtensionState)
     {
 
+    }
+
+    public static getInstance(eventStream : IEventStream, extensionState : IExtensionState) : InstallTrackerSingleton
+    {
+        if(!InstallTrackerSingleton.instance)
+            {
+                InstallTrackerSingleton.instance = new InstallTrackerSingleton(eventStream, extensionState);
+            }
+
+        return InstallTrackerSingleton.instance;
     }
 
     protected executeWithLock = async <A extends any[], R>(alreadyHoldingLock : boolean, f: (...args: A) => R, ...args: A): Promise<R> =>

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
@@ -257,7 +257,7 @@ Installs: ${[...this.inProgressInstalls].map(x => x.dotnetInstall.installKey).jo
                 else
                 {
                     // There are still other extensions that depend on this install, so merely remove this requesting extension from the list of owners.
-                    this.eventStream.post(new RemovingOwnerFromList(`The owner ${context.acquisitionContext?.requestingExtensionId} removed ${installKey} itself from the list, but ${owners?.join(", ")} remain.`));
+                    this.eventStream.post(new RemovingOwnerFromList(`The owner ${context.acquisitionContext?.requestingExtensionId} removed ${installKey} itself from the list, but ${owners?.join(', ')} remain.`));
                     await this.extensionState.update(key, existingInstalls.map(x => IsEquivalentInstallation(x.dotnetInstall, installKey) ?
                         { dotnetInstall: installKey, installingExtensions: owners } as InstallRecord : x));
                 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
@@ -63,9 +63,9 @@ export class InstallTrackerSingleton
     public static getInstance(eventStream : IEventStream, extensionState : IExtensionState) : InstallTrackerSingleton
     {
         if(!InstallTrackerSingleton.instance)
-            {
-                InstallTrackerSingleton.instance = new InstallTrackerSingleton(eventStream, extensionState);
-            }
+        {
+            InstallTrackerSingleton.instance = new InstallTrackerSingleton(eventStream, extensionState);
+        }
 
         return InstallTrackerSingleton.instance;
     }

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
@@ -42,13 +42,13 @@ interface InProgressInstall
 
 export class InstallTrackerSingleton
 {
-    private static instance: InstallTrackerSingleton;
+    protected static instance: InstallTrackerSingleton;
 
     protected inProgressInstalls: Set<InProgressInstall> = new Set<InProgressInstall>();
     private readonly installingVersionsKey = 'installing';
     private readonly installedVersionsKey = 'installed';
 
-    protected constructor(protected readonly eventStream : IEventStream, protected extensionState : IExtensionState)
+    protected constructor(protected eventStream : IEventStream, protected extensionState : IExtensionState)
     {
 
     }
@@ -61,6 +61,12 @@ export class InstallTrackerSingleton
             }
 
         return InstallTrackerSingleton.instance;
+    }
+
+    protected overrideMembers(eventStream : IEventStream, extensionState : IExtensionState)
+    {
+        InstallTrackerSingleton.instance.eventStream = eventStream;
+        InstallTrackerSingleton.instance.extensionState = extensionState;
     }
 
     protected executeWithLock = async <A extends any[], R>(alreadyHoldingLock : boolean, f: (...args: A) => R, ...args: A): Promise<R> =>

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallationGraveyard.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallationGraveyard.ts
@@ -33,7 +33,7 @@ export class InstallationGraveyard
         if(!(graveyard instanceof Set))
         {
             graveyard = new Set<LocalDotnetInstall>(
-                Object.entries(graveyard).map(([key, path]) => ({ dotnetInstall: getAssumedInstallInfo(this.context, key, null), path }) as LocalDotnetInstall)
+                Object.entries(graveyard).map(([key, path]) => ({ dotnetInstall: getAssumedInstallInfo(key, null), path }) as LocalDotnetInstall)
             );
         }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
@@ -14,7 +14,7 @@ import { DotnetInstall } from './DotnetInstall';
 
 export class InstallationValidator extends IInstallationValidator {
     public validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder = false): void {
-        const dotnetValidationFailed = `Validation of .dotnet installation for version ${install} failed:`;
+        const dotnetValidationFailed = `Validation of .dotnet installation for version ${JSON.stringify(install)} failed:`;
         const folder = path.dirname(dotnetPath);
 
         if(!isDotnetFolder)

--- a/vscode-dotnet-runtime-library/src/Acquisition/VersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/VersionResolver.ts
@@ -130,7 +130,7 @@ export class VersionResolver implements IVersionResolver {
             catch (error : any)
             {
                 this.context.eventStream.post(new DotnetVersionResolutionError(new EventCancellationError('DotnetVersionResolutionError',
-                    error?.message ?? ''), getAssumedInstallInfo(this.context, version, mode)));
+                    error?.message ?? ''), getAssumedInstallInfo(version, mode)));
                 reject(error);
             }
         });
@@ -151,7 +151,7 @@ export class VersionResolver implements IVersionResolver {
         {
             const err = new DotnetVersionResolutionError(new EventCancellationError('DotnetVersionResolutionError',
                 `The requested and or resolved version is invalid.`),
-                getAssumedInstallInfo(this.context, version, this.context.installMode));
+                getAssumedInstallInfo(version, this.context.installMode));
             this.context.eventStream.post(err);
             throw err.error;
         }
@@ -177,7 +177,7 @@ export class VersionResolver implements IVersionResolver {
             Debugging.log(`Resolving the version: ${version} ... it is invalid!`, this.context.eventStream);
             const err = new DotnetVersionResolutionError(new EventCancellationError('DotnetVersionResolutionError',
                 `An invalid version was requested. Version: ${version}`),
-                getAssumedInstallInfo(this.context, version, this.context.installMode));
+                getAssumedInstallInfo(version, this.context.installMode));
             this.context.eventStream.post(err);
             throw err.error;
         }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -540,7 +540,6 @@ export class DotnetAcquisitionDeletion extends DotnetAcquisitionMessage {
 export class DotnetFallbackInstallScriptUsed extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetFallbackInstallScriptUsed';
 }
-
 export abstract class DotnetCustomMessageEvent extends DotnetAcquisitionMessage {
     constructor(public readonly eventMessage: string) { super(); }
 
@@ -561,6 +560,32 @@ export class NoExtensionIdProvided extends DotnetCustomMessageEvent {
     public readonly eventName = 'NoExtensionIdProvided';
 }
 
+
+export class ConvertingLegacyInstallRecord extends DotnetCustomMessageEvent {
+    public readonly eventName = 'ConvertingLegacyInstallRecord';
+}
+export class FoundTrackingVersions extends DotnetCustomMessageEvent {
+    public readonly eventName = 'FoundTrackingVersions';
+}
+export class RemovingVersionFromExtensionState extends DotnetCustomMessageEvent {
+    public readonly eventName = 'RemovingVersionFromExtensionState';
+}
+
+export class RemovingExtensionFromList extends DotnetCustomMessageEvent {
+    public readonly eventName = 'RemovingExtensionFromList';
+}
+
+export class RemovingOwnerFromList extends DotnetCustomMessageEvent {
+    public readonly eventName = 'RemovingOwnerFromList';
+}
+
+export class SkipAddingInstallEvent extends DotnetCustomMessageEvent {
+    public readonly eventName = 'SkipAddingInstallEvent';
+}
+
+export class AddTrackingVersions extends DotnetCustomMessageEvent {
+    public readonly eventName = 'AddTrackingVersions';
+}
 
 export class DotnetWSLCheckEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetWSLCheckEvent';

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -445,7 +445,7 @@ ${stderr}`));
         else
         {
             this.context?.eventStream.post(new CommandExecutionEvent(`Executing command ${fullCommandStringForTelemetryOnly}
-with options ${options}.`));
+with options ${JSON.stringify(options)}.`));
             const commandResult = proc.spawnSync(command.commandRoot, command.commandParts, options);
             if(this.returnStatus)
             {

--- a/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
@@ -77,7 +77,7 @@ export async function callWithErrorHandling<T>(callback: () => T, context: IIssu
         if(acquireContext?.installMode === 'sdk' && acquireContext.acquisitionContext?.installType === 'global')
         {
             context.eventStream.post(new DotnetGlobalSDKAcquisitionError(error, (caughtError?.eventType) ?? 'Unknown',
-               GetDotnetInstallInfo(acquireContext.acquisitionContext.version, acquireContext.installMode, 'global', acquireContext.installingArchitecture ??
+               GetDotnetInstallInfo(acquireContext.acquisitionContext.version, acquireContext.installMode, 'global', acquireContext.acquisitionContext.architecture ??
 
                 DotnetCoreAcquisitionWorker.defaultArchitecture()
              )));

--- a/vscode-dotnet-runtime-library/src/Utils/InstallKeyUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/InstallKeyUtilities.ts
@@ -66,7 +66,7 @@ export function getVersionFromLegacyInstallKey(installKey: string): string {
 /**
  * @deprecated This function is for legacy install keys only. Do not use for new code.
  */
-export function getAssumedInstallInfo(context : IAcquisitionWorkerContext, key: string, mode : DotnetInstallMode | null): DotnetInstall {
+export function getAssumedInstallInfo(key: string, mode : DotnetInstallMode | null): DotnetInstall {
     return {
         installKey: key,
         version: getVersionFromLegacyInstallKey(key),

--- a/vscode-dotnet-runtime-library/src/index.ts
+++ b/vscode-dotnet-runtime-library/src/index.ts
@@ -34,7 +34,7 @@ export * from './Utils/WebRequestWorker';
 export * from './Acquisition/DotnetCoreAcquisitionWorker';
 export * from './Acquisition/DotnetInstall';
 export * from './Acquisition/IAcquisitionWorkerContext';
-export * from './Acquisition/GetDirectoryPerMode';
+export * from './Acquisition/DirectoryProviderFactory';
 export * from './Acquisition/InstallRecord';
 export * from './Acquisition/AcquisitionInvoker';
 export * from './Acquisition/DotnetCoreDependencyInstaller'

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -593,7 +593,8 @@ export class MockInstallTracker extends InstallTrackerSingleton
 {
     constructor(eventStream : IEventStream, extensionState : IExtensionState)
     {
-        super(eventStream, extensionState);
+        this.instance.eventStream = eventStream;
+        this.instance.extensionState = extensionState;
     }
 
     public getExtensionState() : IExtensionState

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -594,6 +594,8 @@ export class MockInstallTracker extends InstallTrackerSingleton
     constructor(eventStream : IEventStream, extensionState : IExtensionState)
     {
         super(eventStream, extensionState);
+        // Cause an instance to exist so that we can override the members.
+        const _ = InstallTrackerSingleton.getInstance(eventStream, extensionState);
         this.overrideMembers(eventStream, extensionState);
     }
 

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -593,8 +593,8 @@ export class MockInstallTracker extends InstallTrackerSingleton
 {
     constructor(eventStream : IEventStream, extensionState : IExtensionState)
     {
-        this.instance.eventStream = eventStream;
-        this.instance.extensionState = extensionState;
+        super(eventStream, extensionState);
+        this.overrideMembers(eventStream, extensionState);
     }
 
     public getExtensionState() : IExtensionState

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -51,7 +51,7 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
     {
         const extContext = new MockExtensionContext();
         const eventStream = new MockEventStream();
-        new MockInstallTracker(eventStream, extContext);
+        const _ = new MockInstallTracker(eventStream, extContext);
         return [eventStream, extContext];
     }
 
@@ -294,7 +294,7 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
         await AssertInstallRuntime(worker, extensionContext, eventStream, runtimeV6, invoker, ctx);
 
         // Install similar SDKs without an architecture.
-        const sdkCtx = getMockAcquisitionContext('sdk', sdkV5, expectedTimeoutTime, eventStream, extensionContext);
+        const sdkCtx = getMockAcquisitionContext('sdk', sdkV5, expectedTimeoutTime, eventStream, extensionContext, null);
         await AssertInstallSDK(worker, extensionContext, eventStream, sdkV5, invoker, sdkCtx);
         migrateContextToNewInstall(sdkCtx, sdkV6, null);
         await AssertInstallSDK(worker, extensionContext, eventStream, sdkV6, invoker, sdkCtx);
@@ -304,9 +304,9 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
         await AssertInstallRuntime(worker, extensionContext, eventStream, runtimeV5, invoker, ctx);
 
         // 5.0 legacy runtime should be replaced, but 6.0 runtime should remain, and all SDK items should remain.
-        let detailedRemainingInstalls : InstallRecord[] = extensionContext.get<InstallRecord[]>(installedVersionsKey, []).concat(extensionContext.get<InstallRecord[]>(installedVersionsKey, []));
+        let detailedRemainingInstalls : InstallRecord[] = extensionContext.get<InstallRecord[]>(installedVersionsKey, []);
         let remainingInstalls : string[] = detailedRemainingInstalls.map(x => x.dotnetInstall.installKey);
-        assert.deepStrictEqual(remainingInstalls, [runtimeV6, '5.0.00~x64', sdkV5, sdkV6],
+        assert.deepStrictEqual(remainingInstalls, ['5.0.00~x64', runtimeV6, sdkV5, sdkV6],
             'Only The Requested Legacy Runtime is replaced when new runtime is installed');
 
         // Install a legacy runtime again to make sure its not removed when installing a new SDK with the same version
@@ -318,11 +318,11 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
         await AssertInstallSDK(worker, extensionContext, eventStream, sdkV5, invoker, sdkCtx);
 
         // 6.0 sdk legacy should remain, as well as 5.0 and 6.0 runtime. 5.0 SDK should be removed.
-        detailedRemainingInstalls = extensionContext.get<InstallRecord[]>(installedVersionsKey, []).concat(extensionContext.get<InstallRecord[]>(installedVersionsKey, []));
+        detailedRemainingInstalls = extensionContext.get<InstallRecord[]>(installedVersionsKey, []);
         remainingInstalls = detailedRemainingInstalls.map(x => x.dotnetInstall.installKey);
-        assert.deepStrictEqual(remainingInstalls, [runtimeV6, '5.0.00~x64', runtimeV5, sdkV6, '5.0.100~x64'],
+        assert.deepStrictEqual(remainingInstalls, ['5.0.00~x64', runtimeV6, sdkV6, runtimeV5, '5.0.100~x64'],
             'Only The Requested Legacy SDK is replaced when new SDK is installed');
-    }).timeout(expectedTimeoutTime * 600000);
+    }).timeout(expectedTimeoutTime * 6);
 
     test('Repeated Acquisition', async () => {
         const version = '1.0';

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -24,6 +24,7 @@ import {
     MockDotnetCoreAcquisitionWorker,
     MockEventStream,
     MockExtensionContext,
+    MockInstallTracker,
     NoInstallAcquisitionInvoker,
     RejectingAcquisitionInvoker,
 } from '../mocks/MockObjects';
@@ -33,6 +34,7 @@ import { InstallOwner, InstallRecord } from '../../Acquisition/InstallRecord';
 import { GetDotnetInstallInfo } from '../../Acquisition/DotnetInstall';
 import { DotnetInstallMode } from '../../Acquisition/DotnetInstallMode';
 import { IAcquisitionWorkerContext } from '../../Acquisition/IAcquisitionWorkerContext';
+import { InstallTrackerSingleton } from '../../Acquisition/InstallTrackerSingleton';
 
 const assert = chai.assert;
 chai.use(chaiAsPromised);
@@ -51,6 +53,8 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
         const acquireWorkerContext = getMockAcquisitionContext(mode, version, 100000, eventStream, context, arch)
         const acquisitionWorker = getMockAcquisitionWorker(acquireWorkerContext);
         const invoker = new NoInstallAcquisitionInvoker(eventStream, acquisitionWorker);
+
+        new MockInstallTracker(eventStream, context).setExtensionState(context);
         return [acquisitionWorker, eventStream, context, invoker, acquireWorkerContext];
     }
 

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -61,7 +61,7 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
     function migrateWorkerToNewInstall(worker : IAcquisitionWorkerContext, newVersion : string, newArch : string | null | undefined)
     {
         worker.acquisitionContext.version = newVersion;
-        worker.installingArchitecture = newArch;
+        worker.acquisitionContext.architecture = newArch;
     }
 
     function getExpectedPath(version: string, isRuntimeInstall: boolean): string {
@@ -193,9 +193,9 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
 
         for (const version of versions)
         {
-            const installKey = DotnetCoreAcquisitionWorker.getInstallKeyCustomArchitecture(workerContext.acquisitionContext.version, workerContext.acquisitionContext.architecture, 'local');
             migrateWorkerToNewInstall(workerContext, version, os.arch());
             const res = await acquisitionWorker.acquireRuntime(workerContext, invoker);
+            const installKey = DotnetCoreAcquisitionWorker.getInstallKeyCustomArchitecture(workerContext.acquisitionContext.version, workerContext.acquisitionContext.architecture, 'local');
             await assertAcquisitionSucceeded(installKey, res.dotnetPath, eventStream, context);
         }
 

--- a/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
@@ -47,7 +47,7 @@ suite('InstallTracker Unit Tests', () => {
     test('It Creates a New Record for a New Install', async () => {
         resetExtensionState();
 
-        const validator = new MockInstallTracker(mockContext);
+        const validator = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);
         await validator.trackInstallingVersion(mockContext, defaultInstall);
 
         const expected : InstallRecord[] = [
@@ -62,7 +62,7 @@ suite('InstallTracker Unit Tests', () => {
     test('Re-Tracking is a No-Op', async () => {
         resetExtensionState();
 
-        const validator = new MockInstallTracker(mockContext);
+        const validator = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);
         await validator.trackInstallingVersion(mockContext, defaultInstall);
         await validator.trackInstallingVersion(mockContext, defaultInstall);
 
@@ -84,13 +84,14 @@ suite('InstallTracker Unit Tests', () => {
     test('It Only Adds the Extension Id to an Existing Install Copy', async () => {
         resetExtensionState();
 
-        const validator = new MockInstallTracker(mockContext);
+        const validator = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);
         await validator.trackInstalledVersion(mockContext, defaultInstall);
 
-        const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension);
+        // TODO: verify these tests still work
+        const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension.eventStream, mockContext.extensionState);
         // Inject the extension state from the old class into the new one, because in vscode its a shared global state but here its mocked
         otherRequesterValidator.setExtensionState(validator.getExtensionState());
-        await otherRequesterValidator.trackInstalledVersion(mockContext, defaultInstall);
+        await otherRequesterValidator.trackInstalledVersion(mockContextFromOtherExtension, defaultInstall);
 
         const expected : InstallRecord[] = [
             {
@@ -106,13 +107,13 @@ suite('InstallTracker Unit Tests', () => {
     test('It Works With Different Installs From Multiple or Same Requesters', async () => {
         resetExtensionState();
 
-        const validator = new MockInstallTracker(mockContext);
+        const validator = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);
         await validator.trackInstalledVersion(mockContext, defaultInstall);
 
-        const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension);
+        const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension.eventStream, mockContext.extensionState);
         // Inject the extension state from the old class into the new one, because in vscode its a shared global state but here its mocked
         otherRequesterValidator.setExtensionState(validator.getExtensionState());
-        await otherRequesterValidator.trackInstalledVersion(mockContext, secondInstall);
+        await otherRequesterValidator.trackInstalledVersion(mockContextFromOtherExtension, secondInstall);
 
         const expected : InstallRecord[] = [
             {
@@ -132,7 +133,7 @@ suite('InstallTracker Unit Tests', () => {
     test('It Removes the Record if No Other Owners Exist', async () => {
         resetExtensionState();
 
-        const validator = new MockInstallTracker(mockContext);
+        const validator = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);
         await validator.trackInstallingVersion(mockContext, defaultInstall);
         await validator.trackInstalledVersion(mockContext, defaultInstall);
 
@@ -145,10 +146,10 @@ suite('InstallTracker Unit Tests', () => {
     test('It Only Removes the Extension Id if Other Owners Exist', async () => {
         resetExtensionState();
 
-        const validator = new MockInstallTracker(mockContext);
+        const validator = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);
         await validator.trackInstalledVersion(mockContext, defaultInstall);
 
-        const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension);
+        const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension.eventStream, mockContextFromOtherExtension.extensionState);
         // Inject the extension state from the old class into the new one, because in vscode its a shared global state but here its mocked
         otherRequesterValidator.setExtensionState(validator.getExtensionState());
         await otherRequesterValidator.trackInstalledVersion(mockContext, defaultInstall);
@@ -170,7 +171,7 @@ suite('InstallTracker Unit Tests', () => {
     test('It Converts Legacy Install Key String to New Type with Null Owner', async () => {
         resetExtensionState();
 
-        const validator = new MockInstallTracker(mockContext);
+        const validator = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);
 
         const extensionStateWithLegacyStrings = new MockExtensionContext();
         extensionStateWithLegacyStrings.update('installed', [defaultInstall.installKey, secondInstall.installKey]);
@@ -194,7 +195,7 @@ suite('InstallTracker Unit Tests', () => {
     test('It Handles Null Owner Gracefully on Duplicate Install and Removal', async () => {
         resetExtensionState();
 
-        const validator = new MockInstallTracker(mockContext);
+        const validator = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);
 
         const extensionStateWithLegacyStrings = new MockExtensionContext();
         extensionStateWithLegacyStrings.update('installed', [defaultInstall.installKey, secondInstall.installKey]);
@@ -236,15 +237,15 @@ suite('InstallTracker Unit Tests', () => {
     test('It Can Reclassify an Install from Installing to Installed', async () => {
         resetExtensionState();
 
-        const validator = new MockInstallTracker(mockContext);
+        const validator = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);
         await validator.trackInstallingVersion(mockContext, defaultInstall);
 
-        const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension);
+        const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension.eventStream, mockContext.extensionState);
         // Inject the extension state from the old class into the new one, because in vscode its a shared global state but here its mocked
         otherRequesterValidator.setExtensionState(validator.getExtensionState());
-        await otherRequesterValidator.trackInstallingVersion(mockContext, defaultInstall);
-        await otherRequesterValidator.trackInstallingVersion(mockContext, secondInstall);
-        await otherRequesterValidator.reclassifyInstallingVersionToInstalled(mockContext, secondInstall);
+        await otherRequesterValidator.trackInstallingVersion(mockContextFromOtherExtension, defaultInstall);
+        await otherRequesterValidator.trackInstallingVersion(mockContextFromOtherExtension, secondInstall);
+        await otherRequesterValidator.reclassifyInstallingVersionToInstalled(mockContextFromOtherExtension, secondInstall);
 
         let expectedInstalling : InstallRecord[] = [
             {

--- a/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
@@ -155,7 +155,7 @@ suite('InstallTracker Unit Tests', () => {
         await otherRequesterValidator.trackInstalledVersion(mockContext, defaultInstall);
 
         validator.setExtensionState(otherRequesterValidator.getExtensionState());
-        await validator.untrackInstalledVersion(mockContext, defaultInstall);
+        await validator.untrackInstalledVersion(mockContextFromOtherExtension, defaultInstall);
 
         const expected : InstallRecord[] = [
             {
@@ -264,7 +264,7 @@ suite('InstallTracker Unit Tests', () => {
         assert.deepStrictEqual(await otherRequesterValidator.getExistingInstalls(true), expectedInstalled, 'The installing version was moved from installing to installed');
         assert.deepStrictEqual(await otherRequesterValidator.getExistingInstalls(false), expectedInstalling, 'The installing version was not erroneously moved');
 
-        await otherRequesterValidator.reclassifyInstallingVersionToInstalled(mockContext, defaultInstall);
+        await otherRequesterValidator.reclassifyInstallingVersionToInstalled(mockContextFromOtherExtension, defaultInstall);
 
         expectedInstalled = [
             {

--- a/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
@@ -48,7 +48,7 @@ suite('InstallTracker Unit Tests', () => {
         resetExtensionState();
 
         const validator = new MockInstallTracker(mockContext);
-        await validator.trackInstallingVersion(defaultInstall);
+        await validator.trackInstallingVersion(mockContext, defaultInstall);
 
         const expected : InstallRecord[] = [
             {
@@ -63,8 +63,8 @@ suite('InstallTracker Unit Tests', () => {
         resetExtensionState();
 
         const validator = new MockInstallTracker(mockContext);
-        await validator.trackInstallingVersion(defaultInstall);
-        await validator.trackInstallingVersion(defaultInstall);
+        await validator.trackInstallingVersion(mockContext, defaultInstall);
+        await validator.trackInstallingVersion(mockContext, defaultInstall);
 
         const expected : InstallRecord[] = [
             {
@@ -74,8 +74,8 @@ suite('InstallTracker Unit Tests', () => {
         ]
         assert.deepStrictEqual(await validator.getExistingInstalls(false), expected, 'It did not create a 2nd record for the same installing install');
 
-        await validator.trackInstalledVersion(defaultInstall);
-        await validator.trackInstalledVersion(defaultInstall);
+        await validator.trackInstalledVersion(mockContext, defaultInstall);
+        await validator.trackInstalledVersion(mockContext, defaultInstall);
 
         assert.deepStrictEqual(await validator.getExistingInstalls(true), expected, 'It did not create a 2nd record for the same INSTALLED install');
 
@@ -85,12 +85,12 @@ suite('InstallTracker Unit Tests', () => {
         resetExtensionState();
 
         const validator = new MockInstallTracker(mockContext);
-        await validator.trackInstalledVersion(defaultInstall);
+        await validator.trackInstalledVersion(mockContext, defaultInstall);
 
         const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension);
         // Inject the extension state from the old class into the new one, because in vscode its a shared global state but here its mocked
         otherRequesterValidator.setExtensionState(validator.getExtensionState());
-        await otherRequesterValidator.trackInstalledVersion(defaultInstall);
+        await otherRequesterValidator.trackInstalledVersion(mockContext, defaultInstall);
 
         const expected : InstallRecord[] = [
             {
@@ -107,12 +107,12 @@ suite('InstallTracker Unit Tests', () => {
         resetExtensionState();
 
         const validator = new MockInstallTracker(mockContext);
-        await validator.trackInstalledVersion(defaultInstall);
+        await validator.trackInstalledVersion(mockContext, defaultInstall);
 
         const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension);
         // Inject the extension state from the old class into the new one, because in vscode its a shared global state but here its mocked
         otherRequesterValidator.setExtensionState(validator.getExtensionState());
-        await otherRequesterValidator.trackInstalledVersion(secondInstall);
+        await otherRequesterValidator.trackInstalledVersion(mockContext, secondInstall);
 
         const expected : InstallRecord[] = [
             {
@@ -133,12 +133,12 @@ suite('InstallTracker Unit Tests', () => {
         resetExtensionState();
 
         const validator = new MockInstallTracker(mockContext);
-        await validator.trackInstallingVersion(defaultInstall);
-        await validator.trackInstalledVersion(defaultInstall);
+        await validator.trackInstallingVersion(mockContext, defaultInstall);
+        await validator.trackInstalledVersion(mockContext, defaultInstall);
 
-        await validator.untrackInstallingVersion(defaultInstall);
+        await validator.untrackInstallingVersion(mockContext, defaultInstall);
         assert.deepStrictEqual(await validator.getExistingInstalls(false), [], 'Installing version gets removed with no further owners');
-        await validator.untrackInstalledVersion(defaultInstall);
+        await validator.untrackInstalledVersion(mockContext, defaultInstall);
         assert.deepStrictEqual(await validator.getExistingInstalls(true), [], 'Installed version gets removed with no further owners (installing must be ok)');
     }).timeout(defaultTimeoutTime);
 
@@ -146,15 +146,15 @@ suite('InstallTracker Unit Tests', () => {
         resetExtensionState();
 
         const validator = new MockInstallTracker(mockContext);
-        await validator.trackInstalledVersion(defaultInstall);
+        await validator.trackInstalledVersion(mockContext, defaultInstall);
 
         const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension);
         // Inject the extension state from the old class into the new one, because in vscode its a shared global state but here its mocked
         otherRequesterValidator.setExtensionState(validator.getExtensionState());
-        await otherRequesterValidator.trackInstalledVersion(defaultInstall);
+        await otherRequesterValidator.trackInstalledVersion(mockContext, defaultInstall);
 
         validator.setExtensionState(otherRequesterValidator.getExtensionState());
-        await validator.untrackInstalledVersion(defaultInstall);
+        await validator.untrackInstalledVersion(mockContext, defaultInstall);
 
         const expected : InstallRecord[] = [
             {
@@ -211,12 +211,12 @@ suite('InstallTracker Unit Tests', () => {
             }
         ]
 
-        await validator.trackInstalledVersion(defaultInstall);
+        await validator.trackInstalledVersion(mockContext, defaultInstall);
 
         assert.deepStrictEqual(expected, await validator.getExistingInstalls(true), 'It added the new owner to the existing null install');
 
-        await validator.untrackInstalledVersion(defaultInstall);
-        await validator.untrackInstalledVersion(secondInstall);
+        await validator.untrackInstalledVersion(mockContext, defaultInstall);
+        await validator.untrackInstalledVersion(mockContext, secondInstall);
 
         const expectedTwo : InstallRecord[] = [
             {
@@ -237,14 +237,14 @@ suite('InstallTracker Unit Tests', () => {
         resetExtensionState();
 
         const validator = new MockInstallTracker(mockContext);
-        await validator.trackInstallingVersion(defaultInstall);
+        await validator.trackInstallingVersion(mockContext, defaultInstall);
 
         const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension);
         // Inject the extension state from the old class into the new one, because in vscode its a shared global state but here its mocked
         otherRequesterValidator.setExtensionState(validator.getExtensionState());
-        await otherRequesterValidator.trackInstallingVersion(defaultInstall);
-        await otherRequesterValidator.trackInstallingVersion(secondInstall);
-        await otherRequesterValidator.reclassifyInstallingVersionToInstalled(secondInstall);
+        await otherRequesterValidator.trackInstallingVersion(mockContext, defaultInstall);
+        await otherRequesterValidator.trackInstallingVersion(mockContext, secondInstall);
+        await otherRequesterValidator.reclassifyInstallingVersionToInstalled(mockContext, secondInstall);
 
         let expectedInstalling : InstallRecord[] = [
             {
@@ -263,7 +263,7 @@ suite('InstallTracker Unit Tests', () => {
         assert.deepStrictEqual(await otherRequesterValidator.getExistingInstalls(true), expectedInstalled, 'The installing version was moved from installing to installed');
         assert.deepStrictEqual(await otherRequesterValidator.getExistingInstalls(false), expectedInstalling, 'The installing version was not erroneously moved');
 
-        await otherRequesterValidator.reclassifyInstallingVersionToInstalled(defaultInstall);
+        await otherRequesterValidator.reclassifyInstallingVersionToInstalled(mockContext, defaultInstall);
 
         expectedInstalled = [
             {
@@ -295,7 +295,7 @@ was moved from installing to installed`);
         // So this is the safer option.
         assert.deepStrictEqual(await otherRequesterValidator.getExistingInstalls(false), expectedInstalling, 'The installing version from another extension does NOT get moved');
 
-        await validator.reclassifyInstallingVersionToInstalled(defaultInstall);
+        await validator.reclassifyInstallingVersionToInstalled(mockContext, defaultInstall);
 
         assert.deepStrictEqual(await validator.getExistingInstalls(false), [], 'The installing version gets cleared.');
 

--- a/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
@@ -152,10 +152,10 @@ suite('InstallTracker Unit Tests', () => {
         const otherRequesterValidator = new MockInstallTracker(mockContextFromOtherExtension.eventStream, mockContextFromOtherExtension.extensionState);
         // Inject the extension state from the old class into the new one, because in vscode its a shared global state but here its mocked
         otherRequesterValidator.setExtensionState(validator.getExtensionState());
-        await otherRequesterValidator.trackInstalledVersion(mockContext, defaultInstall);
+        await otherRequesterValidator.trackInstalledVersion(mockContextFromOtherExtension, defaultInstall);
 
         validator.setExtensionState(otherRequesterValidator.getExtensionState());
-        await validator.untrackInstalledVersion(mockContextFromOtherExtension, defaultInstall);
+        await validator.untrackInstalledVersion(mockContext, defaultInstall);
 
         const expected : InstallRecord[] = [
             {

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -41,8 +41,7 @@ export function getMockAcquisitionContext(mode: DotnetInstallMode, version : str
 
 export function getMockAcquisitionWorker(mockContext : IAcquisitionWorkerContext) : MockDotnetCoreAcquisitionWorker
 {
-    const acquisitionWorker = new MockDotnetCoreAcquisitionWorker(mockContext,
-        getMockUtilityContext(), new MockVSCodeExtensionContext());
+    const acquisitionWorker = new MockDotnetCoreAcquisitionWorker(getMockUtilityContext(), new MockVSCodeExtensionContext());
     return acquisitionWorker;
 }
 

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -39,10 +39,9 @@ export function getMockAcquisitionContext(mode: DotnetInstallMode, version : str
     return workerContext;
 }
 
-export function getMockAcquisitionWorker(installMode: DotnetInstallMode, version : string, arch? : string | null, customEventStream? : MockEventStream,
-    customContext? : MockExtensionContext, directory? : IInstallationDirectoryProvider) : MockDotnetCoreAcquisitionWorker
+export function getMockAcquisitionWorker(mockContext : IAcquisitionWorkerContext) : MockDotnetCoreAcquisitionWorker
 {
-    const acquisitionWorker = new MockDotnetCoreAcquisitionWorker(getMockAcquisitionContext(installMode, version, undefined, customEventStream, customContext, arch, directory),
+    const acquisitionWorker = new MockDotnetCoreAcquisitionWorker(mockContext,
         getMockUtilityContext(), new MockVSCodeExtensionContext());
     return acquisitionWorker;
 }

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -12,7 +12,7 @@ import { IAcquisitionWorkerContext } from '../../Acquisition/IAcquisitionWorkerC
 import { IEventStream } from '../../EventStream/EventStream';
 import { IUtilityContext } from '../../Utils/IUtilityContext';
 import { IInstallationDirectoryProvider } from '../../Acquisition/IInstallationDirectoryProvider';
-import { getDirectoryByMode } from '../../Acquisition/GetDirectoryPerMode';
+import { directoryProviderFactory } from '../../Acquisition/DirectoryProviderFactory';
 import { DotnetInstallMode } from '../../Acquisition/DotnetInstallMode';
 
 const standardTimeoutTime = 100000;
@@ -32,7 +32,7 @@ export function getMockAcquisitionContext(mode: DotnetInstallMode, version : str
         timeoutSeconds: timeoutTime,
         installMode: mode,
         proxyUrl: undefined,
-        installDirectoryProvider: directory ? directory : getDirectoryByMode(mode, ''),
+        installDirectoryProvider: directory ? directory : directoryProviderFactory(mode, ''),
         isExtensionTelemetryInitiallyEnabled: true
     };
     return workerContext;

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -27,11 +27,10 @@ export function getMockAcquisitionContext(mode: DotnetInstallMode, version : str
         storagePath: '',
         extensionState: extensionContext,
         eventStream: myEventStream,
-        acquisitionContext: getMockAcquireContext(version, arch === null),
+        acquisitionContext: getMockAcquireContext(version, arch),
         installationValidator: new MockInstallationValidator(myEventStream),
         timeoutSeconds: timeoutTime,
         installMode: mode,
-        installingArchitecture: arch,
         proxyUrl: undefined,
         installDirectoryProvider: directory ? directory : getDirectoryByMode(mode, ''),
         isExtensionTelemetryInitiallyEnabled: true
@@ -54,12 +53,12 @@ export function getMockUtilityContext() : IUtilityContext
     return utilityContext;
 }
 
-export function getMockAcquireContext(nextAcquiringVersion : string, legacy = false) : IDotnetAcquireContext
+export function getMockAcquireContext(nextAcquiringVersion : string, arch : string | null | undefined) : IDotnetAcquireContext
 {
     const acquireContext : IDotnetAcquireContext =
     {
         version: nextAcquiringVersion,
-        architecture: legacy ? null : os.arch(),
+        architecture: arch,
         requestingExtensionId: 'test'
     };
     return acquireContext;

--- a/vscode-dotnet-runtime-library/src/test/unit/WebRequestWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WebRequestWorker.test.ts
@@ -35,9 +35,10 @@ const staticWebsiteUrl = 'https://dotnetcli.blob.core.windows.net/dotnet/release
 suite('WebRequestWorker Unit Tests', () => {
     test('Acquire Version Network Failure', async () => {
         const eventStream = new MockEventStream();
-        const acquisitionWorker = new DotnetCoreAcquisitionWorker(getMockAcquisitionContext('runtime', '', undefined, eventStream), getMockUtilityContext(), new MockVSCodeExtensionContext());
+        const mockContext = getMockAcquisitionContext('runtime', '1.0', undefined, eventStream);
+        const acquisitionWorker = new DotnetCoreAcquisitionWorker(getMockUtilityContext(), new MockVSCodeExtensionContext());
         const invoker = new ErrorAcquisitionInvoker(eventStream);
-        return assert.isRejected(acquisitionWorker.acquireRuntime('1.0', invoker), Error, '.NET Acquisition Failed');
+        return assert.isRejected(acquisitionWorker.acquireRuntime(mockContext, invoker), Error, '.NET Acquisition Failed');
     }).timeout(maxTimeoutTime);
 
     test('Install Script Request Failure', async () => {

--- a/vscode-dotnet-sdk-extension/src/extension.ts
+++ b/vscode-dotnet-sdk-extension/src/extension.ts
@@ -194,7 +194,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
             const fakeContext = getContext(null);
             const versionResolver = new VersionResolver(fakeContext);
 
-            const resolvedVersion = await versionResolver.getFullSDKVersion(commandContext.version);
+            commandContext.version = await versionResolver.getFullSDKVersion(commandContext.version);
             const dotnetPath = await acquisitionWorker.acquireStatus(fakeContext, 'sdk');
             return dotnetPath;
         }, issueContext(commandContext.errorConfiguration, 'acquireSDKStatus'));

--- a/vscode-dotnet-sdk-extension/src/extension.ts
+++ b/vscode-dotnet-sdk-extension/src/extension.ts
@@ -40,6 +40,7 @@ import {
     WindowDisplayWorker,
     Debugging,
     CommandExecutor,
+    getDirectoryByMode,
 } from 'vscode-dotnet-runtime-library';
 
 import { dotnetCoreAcquisitionExtensionId } from './DotnetCoreAcquisitionId';
@@ -125,21 +126,11 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         }
     }
 
-    const acquisitionContext : IAcquisitionWorkerContext = {
-        storagePath,
-        extensionState: context.globalState,
-        eventStream,
-        installationValidator: new InstallationValidator(eventStream),
-        installMode: 'sdk',
-        timeoutSeconds: resolvedTimeoutSeconds,
-        installDirectoryProvider: new SdkInstallationDirectoryProvider(storagePath),
-        acquisitionContext : null,
-        isExtensionTelemetryInitiallyEnabled : isExtensionTelemetryEnabled,
-    };
-    const acquisitionWorker = new DotnetCoreAcquisitionWorker(acquisitionContext, utilContext, vsCodeExtensionContext);
-    const versionResolver = new VersionResolver(acquisitionContext);
 
-    const dotnetAcquireRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquire}`, async (commandContext: IDotnetAcquireContext) => {
+    const acquisitionWorker = new DotnetCoreAcquisitionWorker(utilContext, vsCodeExtensionContext);
+
+    const dotnetAcquireRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquire}`, async (commandContext: IDotnetAcquireContext) =>
+    {
         Debugging.log(`The SDK Extension Acquire Command was Invoked.`, eventStream);
 
         if (commandContext.requestingExtensionId === undefined)
@@ -151,11 +142,13 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
             return Promise.reject(`${commandContext.requestingExtensionId} is not a known requesting extension id. The vscode-dotnet-sdk extension can only be used by ms-dotnettools.vscode-dotnet-pack.`);
         }
 
+        const acquisitionContext = getContext(commandContext);
+        const versionResolver = new VersionResolver(acquisitionContext);
+
         const pathResult = callWithErrorHandling(async () => {
             eventStream.post(new DotnetSDKAcquisitionStarted(commandContext.requestingExtensionId));
 
             eventStream.post(new DotnetAcquisitionRequested(commandContext.version, commandContext.requestingExtensionId));
-            acquisitionWorker.setAcquisitionContext(commandContext);
             telemetryObserver?.setAcquisitionContext(acquisitionContext, commandContext);
 
             if(commandContext.installType === 'global')
@@ -169,7 +162,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
                 }
 
                 const globalInstallerResolver = new GlobalInstallerResolver(acquisitionContext, commandContext.version);
-                const dotnetPath = await acquisitionWorker.acquireGlobalSDK(globalInstallerResolver);
+                const dotnetPath = await acquisitionWorker.acquireGlobalSDK(acquisitionContext, globalInstallerResolver);
 
                 new CommandExecutor(acquisitionContext, utilContext).setPathEnvVar(dotnetPath.dotnetPath, troubleshootingUrl, displayWorker, vsCodeExtensionContext, true);
                 Debugging.log(`Returning path: ${dotnetPath}.`, eventStream);
@@ -180,8 +173,9 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
                 Debugging.log(`Acquisition Request was remarked as local.`, eventStream);
 
                 const resolvedVersion = await versionResolver.getFullSDKVersion(commandContext.version);
+                acquisitionContext.acquisitionContext.version = resolvedVersion;
                 const acquisitionInvoker = new LocalAcquisitionInvoker(acquisitionContext, utilContext);
-                const dotnetPath = await acquisitionWorker.acquireSDK(resolvedVersion, acquisitionInvoker);
+                const dotnetPath = await acquisitionWorker.acquireSDK(acquisitionContext, acquisitionInvoker);
 
                 const pathEnvVar = path.dirname(dotnetPath.dotnetPath);
                 new CommandExecutor(acquisitionContext, utilContext).setPathEnvVar(pathEnvVar, troubleshootingUrl, displayWorker, vsCodeExtensionContext, false);
@@ -197,19 +191,19 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
     const dotnetAcquireStatusRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquireStatus}`, async (commandContext: IDotnetAcquireContext) => {
         const pathResult = callWithErrorHandling(async () => {
             eventStream.post(new DotnetAcquisitionStatusRequested(commandContext.version, commandContext.requestingExtensionId));
+            const fakeContext = getContext(null);
+            const versionResolver = new VersionResolver(fakeContext);
+
             const resolvedVersion = await versionResolver.getFullSDKVersion(commandContext.version);
-            const dotnetPath = await acquisitionWorker.acquireStatus(resolvedVersion, 'sdk');
+            const dotnetPath = await acquisitionWorker.acquireStatus(fakeContext, 'sdk');
             return dotnetPath;
         }, issueContext(commandContext.errorConfiguration, 'acquireSDKStatus'));
         return pathResult;
     });
 
-
-
-
     const dotnetUninstallAllRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.uninstallAll}`, async (commandContext: IDotnetUninstallContext | undefined) => {
         await callWithErrorHandling(async () => {
-            await acquisitionWorker.uninstallAll();
+            await acquisitionWorker.uninstallAll(eventStream, getDirectoryByMode('sdk', context.globalStoragePath).getStoragePath(), context.globalState);
         }, issueContext(commandContext ? commandContext.errorConfiguration : undefined, 'uninstallAll'));
     });
 
@@ -220,6 +214,27 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         await vscode.env.clipboard.writeText(issueBody);
         open(url);
     });
+
+    function getContext(commandContext : IDotnetAcquireContext | null) : IAcquisitionWorkerContext
+    {
+        const acquisitionContext : IAcquisitionWorkerContext = {
+            storagePath,
+            extensionState: context.globalState,
+            eventStream,
+            installationValidator: new InstallationValidator(eventStream),
+            installMode: 'sdk',
+            timeoutSeconds: resolvedTimeoutSeconds,
+            installDirectoryProvider: new SdkInstallationDirectoryProvider(storagePath),
+            acquisitionContext : commandContext ?? { // See runtime extension for more details on this fake context.
+                version: 'unspecified',
+                architecture: os.arch(),
+                requestingExtensionId: 'notAnAcquisitionCall',
+            },
+            isExtensionTelemetryInitiallyEnabled : isExtensionTelemetryEnabled,
+        };
+
+        return acquisitionContext;
+    }
 
     context.subscriptions.push(
         dotnetAcquireRegistration,

--- a/vscode-dotnet-sdk-extension/src/extension.ts
+++ b/vscode-dotnet-sdk-extension/src/extension.ts
@@ -40,7 +40,7 @@ import {
     WindowDisplayWorker,
     Debugging,
     CommandExecutor,
-    getDirectoryByMode,
+    directoryProviderFactory,
 } from 'vscode-dotnet-runtime-library';
 
 import { dotnetCoreAcquisitionExtensionId } from './DotnetCoreAcquisitionId';
@@ -203,7 +203,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
 
     const dotnetUninstallAllRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.uninstallAll}`, async (commandContext: IDotnetUninstallContext | undefined) => {
         await callWithErrorHandling(async () => {
-            await acquisitionWorker.uninstallAll(eventStream, getDirectoryByMode('sdk', storagePath).getStoragePath(), context.globalState);
+            await acquisitionWorker.uninstallAll(eventStream, directoryProviderFactory('sdk', storagePath).getStoragePath(), context.globalState);
         }, issueContext(commandContext ? commandContext.errorConfiguration : undefined, 'uninstallAll'));
     });
 

--- a/vscode-dotnet-sdk-extension/src/extension.ts
+++ b/vscode-dotnet-sdk-extension/src/extension.ts
@@ -203,7 +203,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
 
     const dotnetUninstallAllRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.uninstallAll}`, async (commandContext: IDotnetUninstallContext | undefined) => {
         await callWithErrorHandling(async () => {
-            await acquisitionWorker.uninstallAll(eventStream, getDirectoryByMode('sdk', context.globalStoragePath).getStoragePath(), context.globalState);
+            await acquisitionWorker.uninstallAll(eventStream, getDirectoryByMode('sdk', storagePath).getStoragePath(), context.globalState);
         }, issueContext(commandContext ? commandContext.errorConfiguration : undefined, 'uninstallAll'));
     });
 

--- a/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -92,7 +92,8 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
 
     const version = currentSDKVersion;
     const earlierVersion = '3.1';
-    const acquisitionWorker = getMockAcquisitionWorker('sdk', version, undefined, eventStream, context, installDirectoryProvider);
+    const mockContext = getMockAcquisitionContext('sdk', version, 10000, eventStream, context, undefined, installDirectoryProvider);
+    const acquisitionWorker = getMockAcquisitionWorker(mockContext);
 
     // Write 'preinstalled' SDKs
     const dotnetDir = installDirectoryProvider.getInstallDir(version);
@@ -109,7 +110,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
 
     // Assert preinstalled SDKs are detected
     const acquisitionInvoker = new NoInstallAcquisitionInvoker(eventStream, acquisitionWorker);
-    const result = await acquisitionWorker.acquireSDK(version, acquisitionInvoker);
+    const result = await acquisitionWorker.acquireSDK(mockContext, acquisitionInvoker);
     assert.equal(path.dirname(result.dotnetPath), dotnetDir, 'preinstalled sdk path is the same as installed sdk path on api call');
     const preinstallEvents = eventStream.events
       .filter(event => event instanceof DotnetPreinstallDetected)
@@ -131,11 +132,12 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     const installDirectoryProvider = new SdkInstallationDirectoryProvider(storagePath);
 
     const version = currentSDKVersion;
-    const acquisitionWorker = getMockAcquisitionWorker('sdk', version, undefined, undefined, undefined, installDirectoryProvider);
+    const mockContext = getMockAcquisitionContext('sdk', version, 10000, undefined, undefined, undefined, installDirectoryProvider);
+    const acquisitionWorker = getMockAcquisitionWorker(mockContext);
 
     const currentVersionInstallKey =  DotnetCoreAcquisitionWorker.getInstallKeyCustomArchitecture(version, os.arch());
     // Ensure nothing is returned when there is no preinstalled SDK
-    const noPreinstallResult = await acquisitionWorker.acquireStatus(version, 'sdk');
+    const noPreinstallResult = await acquisitionWorker.acquireStatus(mockContext, 'sdk');
     assert.isUndefined(noPreinstallResult);
 
     // Write 'preinstalled' SDK
@@ -147,7 +149,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     fs.writeFileSync(dotnetExePath, '');
 
     // Assert preinstalled SDKs are detected
-    const result = await acquisitionWorker.acquireStatus(version, 'sdk');
+    const result = await acquisitionWorker.acquireStatus(mockContext, 'sdk');
     assert.equal(path.dirname(result!.dotnetPath), dotnetDir);
 
     // Clean up storage


### PR DESCRIPTION
The first PR of many for adding support for ASP.NET Runtime installation.
I will try to break it up into smaller pieces.

This is a refactoring to make it so we don't need to write ourselves out of a paper bag when adding support for ASP.NET.
The `DotnetCoreAcquisitionWorker` is the main driving force for all installations.

Currently, the requested installation information is held in a `Context`. The `Context` used to be passed to the worker upon construction. This is an anti-pattern, though I can see several reasons why it was designed this way (the context object needs to be around in certain places beforehand for information to be accurate, coupled logic that needed to be decoupled, etc) but it ends up creating multiple sources of truth and requires several workers to be made which duplicates code.

Now the `Context` is passed to the worker per install request, which matches its real use case, considering the Context holds information about an individual installation request.

Without this change we will end up with a ton of code duplication and overhead to maintain a separate code path for ASP.NET management.
