### PR TITLE
2.0.8 branding

### DIFF
--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -33,7 +33,7 @@
 		},
 		"../vscode-dotnet-runtime-extension": {
 			"name": "vscode-dotnet-runtime",
-			"version": "2.0.7",
+			"version": "2.0.8",
 			"license": "MIT",
 			"dependencies": {
 				"@types/chai-as-promised": "^7.1.8",

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -1831,7 +1831,7 @@
 
 "vscode-dotnet-runtime@file:../vscode-dotnet-runtime-extension":
   "resolved" "file:../vscode-dotnet-runtime-extension"
-  "version" "2.0.7"
+  "version" "2.0.8"
   dependencies:
     "@types/chai-as-promised" "^7.1.8"
     "@vscode/test-electron" "^2.3.9"

--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## [2.0.8] - 2024-07-09
+
+Fixes issues with offline detection and timeouts.
+
 ## [2.0.7] - 2024-06-30
 
 Adds support for ASP.NET Core Runtime installation via the `acquire` API.

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-dotnet-runtime",
-	"version": "2.0.7",
+	"version": "2.0.8",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-dotnet-runtime",
-			"version": "2.0.7",
+			"version": "2.0.8",
 			"license": "MIT",
 			"dependencies": {
 				"@types/chai-as-promised": "^7.1.8",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -13,7 +13,7 @@
 	"description": "This extension installs and manages different versions of the .NET SDK and Runtime.",
 	"appInsightsKey": "02dc18e0-7494-43b2-b2a3-18ada5fcb522",
 	"icon": "images/dotnetIcon.png",
-	"version": "2.0.7",
+	"version": "2.0.8",
 	"publisher": "ms-dotnettools",
 	"engines": {
 		"vscode": "^1.74.0"


### PR DESCRIPTION
Bump the version. We are only including 1 change in this version to see how bad it impacts success rates.
https://github.com/dotnet/vscode-dotnet-runtime/pull/1782 for older examples.