### PR TITLE
Fix Linux Update

### DIFF
--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
-## [2.0.9] - 2024-??-??
+## [2.0.9] - 2024-07-12
 
 Fixes a bug where permissions were not granted to run the .NET Installer. (EPERM issue.)
 
@@ -16,6 +16,10 @@ Fixes a bug where the installer file would be deleted or not properly downloaded
 Performance improvements.
 
 Fixes a bug with apt-get lock holding (status 100) on Linux with package management.
+
+Adds acquireStatus support for ASP.NET runtime installs.
+
+Other bug fixes.
 
 ## [2.0.8] - 2024-07-09
 

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -372,4 +372,21 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     await testAcquire('aspnetcore');
   }).timeout(standardTimeoutTime);
 
+  test('acquireStatus does respect Mode', async () =>
+  {
+    const runtimeContext : IDotnetAcquireContext = { version: '5.0', requestingExtensionId, mode: 'runtime' };
+    const aspNetContext : IDotnetAcquireContext =  { version: '5.0', requestingExtensionId, mode: 'aspnetcore' };
+
+    let result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquireStatus', runtimeContext);
+    assert.notExists(result);
+    result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquireStatus', aspNetContext);
+    assert.notExists(result);
+
+    result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', runtimeContext);
+    assert.exists(result);
+
+    result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquireStatus', aspNetContext);
+    assert.equal(undefined, result, 'Acquire Status for no ASP.NET installed when Runtime is installed should not mistake Runtime Install as ASP.NET Install');
+  }).timeout(standardTimeoutTime);
+
 });

--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -8,9 +8,6 @@
                 "commandParts": [
                     "-o",
                     "DPkg::Lock::Timeout=120",
-                    "update",
-                    "||",
-                    "apt-get",
                     "update"
                 ]
             },


### PR DESCRIPTION
This adds a very simple additional test for the acquireStatus API earlier, that I forgot to push while I wasn't feeling well. 

This also fixes an issue with update, the || operator does not work in this context and itll treat it as an optional flag thats invalid. It was hacky to do anyway, so I just got rid of it.