### PR TITLE
Add failure handling for file integrity check

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -184,7 +184,7 @@ We cannot verify our .NET file host at this time. Please try again later or inst
 
     private async userChoosesToContinueWithInvalidHash() : Promise<boolean>
     {
-        const yes = validationPromptConstants.allowOption
+        const yes = validationPromptConstants.allowOption;
         const no = validationPromptConstants.cancelOption;
         const message = validationPromptConstants.noSignatureMessage;
 

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -396,6 +396,14 @@ export class WebRequestError extends DotnetAcquisitionError {
     public readonly eventName = 'WebRequestError';
 }
 
+export class DiskIsFullError extends DotnetAcquisitionError {
+    public readonly eventName = 'DiskIsFullError';
+}
+
+export class DotnetDownloadFailure extends DotnetAcquisitionError {
+    public readonly eventName = 'DotnetDownloadFailure';
+}
+
 export class DotnetPreinstallDetectionError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetPreinstallDetectionError';
 }
@@ -712,6 +720,14 @@ export abstract class DotnetCustomMessageEvent extends DotnetAcquisitionMessage 
     public getProperties() {
         return { Message: this.eventMessage };
     }
+}
+
+export abstract class DotnetVisibleWarningEvent extends DotnetCustomMessageEvent {
+    public readonly type = EventType.DotnetVisibleWarning;
+}
+
+export class DotnetFileIntegrityFailureEvent extends DotnetVisibleWarningEvent {
+    public readonly eventName = 'DotnetFileIntegrityFailureEvent';
 }
 
 export class DotnetVersionCategorizedEvent extends DotnetCustomMessageEvent {

--- a/vscode-dotnet-runtime-library/src/EventStream/EventType.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventType.ts
@@ -20,8 +20,8 @@ export enum EventType {
     DotnetTotalSuccessEvent,
     DotnetUpgradedEvent,
     SuppressedAcquisitionError,
+    DotnetVisibleWarning,
     DotnetInstallExpectedAbort,
-
     DotnetModalChildEvent, // For sub-events that are published as a more specific version of an existing published generic event.
     // Example: DotnetAcquisitionStarted -> Children events are RuntimeStarted, SDKStarted, etc.
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
@@ -13,6 +13,7 @@ import {
     DotnetExistingPathResolutionCompleted,
     DotnetInstallExpectedAbort,
     DotnetUpgradedEvent,
+    DotnetVisibleWarningEvent,
 } from './EventStreamEvents';
 import { EventType } from './EventType';
 import { IEvent } from './IEvent';
@@ -73,6 +74,11 @@ export class OutputChannelObserver implements IEventStreamObserver {
                 if (event instanceof DotnetExistingPathResolutionCompleted) {
                     this.outputChannel.append(`Using configured .NET path: ${ (event as DotnetExistingPathResolutionCompleted).resolvedPath }\n`);
                 }
+                break;
+            case EventType.DotnetVisibleWarning:
+                this.outputChannel.appendLine('');
+                this.outputChannel.appendLine((event as DotnetVisibleWarningEvent).eventMessage);
+                this.outputChannel.appendLine('');
                 break;
             case EventType.DotnetAcquisitionAlreadyInstalled:
                 if(event instanceof DotnetAcquisitionAlreadyInstalled)

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -7,7 +7,7 @@ import axiosRetry from 'axios-retry';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { getProxySettings } from 'get-proxy-settings';
 import { AxiosCacheInstance, buildMemoryStorage, setupCache } from 'axios-cache-interceptor';
-import {EventBasedError, SuppressedAcquisitionError, WebRequestError, WebRequestSent } from '../EventStream/EventStreamEvents';
+import {DiskIsFullError, DotnetDownloadFailure, EventBasedError, SuppressedAcquisitionError, WebRequestError, WebRequestSent } from '../EventStream/EventStreamEvents';
 import { getInstallFromContext } from './InstallKeyUtilities';
 
 import * as fs from 'fs';
@@ -164,12 +164,33 @@ export class WebRequestWorker
         const finished = promisify(stream.finished);
         const file = fs.createWriteStream(dest, { flags: 'wx' });
         const options = await this.getAxiosOptions(3, {responseType: 'stream', transformResponse: (x : any) => x}, false);
-        await this.axiosGet(url, options)
-        .then(response =>
+        try
         {
-            response.data.pipe(file);
-            return finished(file);
-        });
+            await this.axiosGet(url, options)
+            .then(response =>
+            {
+                response.data.pipe(file);
+                return finished(file);
+            });
+        }
+        catch(error : any)
+        {
+            if(error?.message.contains('ENOSPC'))
+            {
+                const err = new DiskIsFullError(new EventBasedError('DiskIsFullError',
+`You don't have enough space left on your disk to install the .NET SDK. Please clean up some space.`), getInstallFromContext(this.context));
+                this.context.eventStream.post(err);
+                throw err.error;
+            }
+            else
+            {
+                const err = new DotnetDownloadFailure(new EventBasedError('DotnetDownloadFailure',
+`We failed to download the .NET Installer. Please try to install the .NET SDK manually.
+Error: ${error.message}`), getInstallFromContext(this.context));
+                this.context.eventStream.post(err);
+                throw err.error;
+            }
+        }
     }
 
     private async getAxiosOptions(numRetries: number, furtherOptions? : {}, keepAlive = true)


### PR DESCRIPTION
This is now what is hitting the EPERM and ENOENT errors. We need to skip the check and see what happens from here, such as allowing to elevate via windows.

This also adds specific handlers for when we fail to download the SDK.