### PR TITLE
Move to node 20

### DIFF
--- a/pipeline-templates/install-node.yaml
+++ b/pipeline-templates/install-node.yaml
@@ -1,5 +1,5 @@
 steps:
 - task:  UseNode@1
   inputs:
-    version: '18.x'
+    version: '20.x'
   displayName: '⚛️ Install Node.js'


### PR DESCRIPTION
It includes some permissions changes and other stability fixes, vscode main is also now on node 20, so we might as well update the tooling. This wont cause any break or change in the product which is already tied to vscode, just the pipeline.