### PR TITLE
Interpret Installer Exit Codes

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -399,7 +399,8 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         if(installerResult !== '0')
         {
             const err = new DotnetNonZeroInstallerExitCodeError(new EventBasedError('DotnetNonZeroInstallerExitCodeError',
-                `An error was raised by the .NET SDK installer. The exit code it gave us: ${installerResult}`), install);
+                `An error was raised by the .NET SDK installer. The exit code it gave us: ${installerResult}.
+${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
             context.eventStream.post(err);
             throw err;
         }

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -78,6 +78,40 @@ export class WinMacGlobalInstaller extends IGlobalInstaller {
         this.webWorker = new WebRequestWorker(context, installerUrl);
     }
 
+    public static InterpretExitCode(code : string) : string
+    {
+        const reportLogMessage = `Please provide your .NET Installer log (note our privacy notice), which can be found at %temp%.
+The file has a name like 'Microsoft_.NET_SDK*.log and should appear in recent files.
+This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/issues.`
+
+        switch(code)
+        {
+            case '1':
+                return `The .NET SDK installer has failed with a generic failure. ${reportLogMessage}`;
+            case '5':
+                return `Insufficient permissions are available to install .NET. Please run the installer as an administrator.`;
+            case '67':
+                return `A network name has not resolved. ${reportLogMessage}`;
+            case '112':
+                return `The disk is full. Please free up space and try again.`;
+            case '255':
+                return `The .NET Installer was terminated by another process unexpectedly. Please try again.`;
+            case '1260':
+                return `The .NET SDK is blocked by group policy. Can you please report this at https://github.com/dotnet/vscode-dotnet-runtime/issues`
+            case '1603':
+                return `A peculiar system error prevented the .NET SDK from installing. ${reportLogMessage}`;
+            case '1618':
+                return `Another installation is in progress. Please wait for the other installation to finish and try again.`;
+            case '000751':
+                return `An unknown error occurred. ${reportLogMessage}`;
+            case '2147500037':
+                return `An unspecified error occurred. ${reportLogMessage}`;
+            case '2147942405':
+                return `Insufficient permissions are available to install .NET. Please try again as an administrator.`;
+        }
+        return '';
+    }
+
     public async installSDK(install : DotnetInstall): Promise<string>
     {
         // Check for conflicting windows installs

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -103,7 +103,7 @@ This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/is
             case '1603':
                 return `Fatal error during .NET SDK installation. ${reportLogMessage}`;
             case '1618':
-                return `Another installation is in progress. Please wait for the other installation to finish and try again.`;
+                return `Another installation is already in progress. Complete that installation before proceeding with this install.`;
             case '000751':
                 return `An unknown error occurred, which might be an OS page fault. ${reportLogMessage}`;
             case '2147500037':

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -103,7 +103,7 @@ This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/is
             case '1618':
                 return `Another installation is in progress. Please wait for the other installation to finish and try again.`;
             case '000751':
-                return `An unknown error occurred. ${reportLogMessage}`;
+                return `An unknown error occurred, which might be an OS page fault. ${reportLogMessage}`;
             case '2147500037':
                 return `An unspecified error occurred. ${reportLogMessage}`;
             case '2147942405':

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -101,7 +101,7 @@ This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/is
             case '1460':
                 return `The .NET SDK had a timeout error. ${reportLogMessage}`;
             case '1603':
-                return `A peculiar system error prevented the .NET SDK from installing. ${reportLogMessage}`;
+                return `Fatal error during .NET SDK installation. ${reportLogMessage}`;
             case '1618':
                 return `Another installation is in progress. Please wait for the other installation to finish and try again.`;
             case '000751':

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -98,6 +98,8 @@ This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/is
                 return `The .NET Installer was terminated by another process unexpectedly. Please try again.`;
             case '1260':
                 return `The .NET SDK is blocked by group policy. Can you please report this at https://github.com/dotnet/vscode-dotnet-runtime/issues`
+            case '1460':
+                return `The .NET SDK had a timeout error. ${reportLogMessage}`;
             case '1603':
                 return `A peculiar system error prevented the .NET SDK from installing. ${reportLogMessage}`;
             case '1618':

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -91,7 +91,7 @@ This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/is
             case '5':
                 return `Insufficient permissions are available to install .NET. Please run the installer as an administrator.`;
             case '67':
-                return `A network name has not resolved. ${reportLogMessage}`;
+                return `The network name cannot be found. ${reportLogMessage}`;
             case '112':
                 return `The disk is full. Please free up space and try again.`;
             case '255':

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -105,7 +105,7 @@ This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/is
             case '1618':
                 return `Another installation is already in progress. Complete that installation before proceeding with this install.`;
             case '000751':
-                return `An unknown error occurred, which might be an OS page fault. ${reportLogMessage}`;
+                return `Page fault was satisfied by reading from a secondary storage device. ${reportLogMessage}`;
             case '2147500037':
                 return `An unspecified error occurred. ${reportLogMessage}`;
             case '2147942405':


### PR DESCRIPTION
These will give the user more actionable items, and also increase the chances the post a log so we can help them if something goes wrong and understand the issue better.

Error code interpretation comes from https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--1300-1699- pages, the installer source code, and joeloff (area expert)