### PR TITLE
Remove references to the string 'key' and change them to 'id'

### DIFF
--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -182,8 +182,8 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
             return mode === 'aspnetcore' ? worker.acquireLocalASPNET(runtimeContext, acquisitionInvoker) : worker.acquireLocalRuntime(runtimeContext, acquisitionInvoker);
         }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, 'acquire', commandContext.version), commandContext.requestingExtensionId, runtimeContext);
 
-        const installId = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, mode, 'local');
-        const install = {installId : installId, version : commandContext.version, installMode: mode, isGlobal: false,
+        const installationId = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, mode, 'local');
+        const install = {installId : installationId, version : commandContext.version, installMode: mode, isGlobal: false,
             architecture: commandContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture()} as DotnetInstall;
 
         if(dotnetPath !== undefined && dotnetPath?.dotnetPath)
@@ -244,8 +244,8 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
             return dotnetPath;
         }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, commandKeys.acquireGlobalSDK), commandContext.requestingExtensionId, sdkContext);
 
-        const installId = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, commandContext.mode, 'global');
-        const install = {installId : installId, version : commandContext.version, installMode: commandContext.mode, isGlobal: true,
+        const installationId = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, commandContext.mode, 'global');
+        const install = {installId : installationId, version : commandContext.version, installMode: commandContext.mode, isGlobal: true,
             architecture: commandContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture()} as DotnetInstall;
 
         if(pathResult !== undefined && pathResult?.dotnetPath)

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -182,8 +182,8 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
             return mode === 'aspnetcore' ? worker.acquireLocalASPNET(runtimeContext, acquisitionInvoker) : worker.acquireLocalRuntime(runtimeContext, acquisitionInvoker);
         }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, 'acquire', commandContext.version), commandContext.requestingExtensionId, runtimeContext);
 
-        const iKey = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, mode, 'local');
-        const install = {installId : iKey, version : commandContext.version, installMode: mode, isGlobal: false,
+        const id = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, mode, 'local');
+        const install = {installId : id, version : commandContext.version, installMode: mode, isGlobal: false,
             architecture: commandContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture()} as DotnetInstall;
 
         if(dotnetPath !== undefined && dotnetPath?.dotnetPath)
@@ -244,8 +244,8 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
             return dotnetPath;
         }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, commandKeys.acquireGlobalSDK), commandContext.requestingExtensionId, sdkContext);
 
-        const iKey = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, commandContext.mode, 'global');
-        const install = {installId : iKey, version : commandContext.version, installMode: commandContext.mode, isGlobal: true,
+        const id = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, commandContext.mode, 'global');
+        const install = {installId : id, version : commandContext.version, installMode: commandContext.mode, isGlobal: true,
             architecture: commandContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture()} as DotnetInstall;
 
         if(pathResult !== undefined && pathResult?.dotnetPath)

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -56,7 +56,7 @@ import {
     UserManualInstallFailure,
     DotnetInstall,
     EventCancellationError,
-    getInstallKeyCustomArchitecture,
+    getInstallIdCustomArchitecture,
     DotnetInstallType,
     DotnetAcquisitionTotalSuccessEvent,
     isRunningUnderWSL
@@ -182,8 +182,8 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
             return mode === 'aspnetcore' ? worker.acquireLocalASPNET(runtimeContext, acquisitionInvoker) : worker.acquireLocalRuntime(runtimeContext, acquisitionInvoker);
         }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, 'acquire', commandContext.version), commandContext.requestingExtensionId, runtimeContext);
 
-        const iKey = getInstallKeyCustomArchitecture(commandContext.version, commandContext.architecture, mode, 'local');
-        const install = {installKey : iKey, version : commandContext.version, installMode: mode, isGlobal: false,
+        const iKey = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, mode, 'local');
+        const install = {installId : iKey, version : commandContext.version, installMode: mode, isGlobal: false,
             architecture: commandContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture()} as DotnetInstall;
 
         if(dotnetPath !== undefined && dotnetPath?.dotnetPath)
@@ -244,8 +244,8 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
             return dotnetPath;
         }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, commandKeys.acquireGlobalSDK), commandContext.requestingExtensionId, sdkContext);
 
-        const iKey = getInstallKeyCustomArchitecture(commandContext.version, commandContext.architecture, commandContext.mode, 'global');
-        const install = {installKey : iKey, version : commandContext.version, installMode: commandContext.mode, isGlobal: true,
+        const iKey = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, commandContext.mode, 'global');
+        const install = {installId : iKey, version : commandContext.version, installMode: commandContext.mode, isGlobal: true,
             architecture: commandContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture()} as DotnetInstall;
 
         if(pathResult !== undefined && pathResult?.dotnetPath)

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -182,8 +182,8 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
             return mode === 'aspnetcore' ? worker.acquireLocalASPNET(runtimeContext, acquisitionInvoker) : worker.acquireLocalRuntime(runtimeContext, acquisitionInvoker);
         }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, 'acquire', commandContext.version), commandContext.requestingExtensionId, runtimeContext);
 
-        const id = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, mode, 'local');
-        const install = {installId : id, version : commandContext.version, installMode: mode, isGlobal: false,
+        const installId = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, mode, 'local');
+        const install = {installId : installId, version : commandContext.version, installMode: mode, isGlobal: false,
             architecture: commandContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture()} as DotnetInstall;
 
         if(dotnetPath !== undefined && dotnetPath?.dotnetPath)
@@ -244,8 +244,8 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
             return dotnetPath;
         }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, commandKeys.acquireGlobalSDK), commandContext.requestingExtensionId, sdkContext);
 
-        const id = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, commandContext.mode, 'global');
-        const install = {installId : id, version : commandContext.version, installMode: commandContext.mode, isGlobal: true,
+        const installId = getInstallIdCustomArchitecture(commandContext.version, commandContext.architecture, commandContext.mode, 'global');
+        const install = {installId : installId, version : commandContext.version, installMode: commandContext.mode, isGlobal: true,
             architecture: commandContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture()} as DotnetInstall;
 
         if(pathResult !== undefined && pathResult?.dotnetPath)

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -15,7 +15,7 @@ import {
   IExistingPaths,
   IDotnetListVersionsContext,
   IDotnetListVersionsResult,
-  getInstallKeyCustomArchitecture,
+  getInstallIdCustomArchitecture,
   ITelemetryEvent,
   MockExtensionConfiguration,
   MockExtensionContext,
@@ -232,7 +232,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
 
     const rntVersion = '2.2';
     const fullyResolvedVersion = '2.2.8'; // 2.2 is very much out of support, so we don't expect this to change to a newer version
-    const installKey = getInstallKeyCustomArchitecture(fullyResolvedVersion, os.arch(), 'runtime', 'local');
+    const installId = getInstallIdCustomArchitecture(fullyResolvedVersion, os.arch(), 'runtime', 'local');
 
     const context: IDotnetAcquireContext = { version: rntVersion, requestingExtensionId };
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
@@ -249,7 +249,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     const startedEvent = MockTelemetryReporter.telemetryEvents.find((event: ITelemetryEvent) => event.eventName === 'DotnetAcquisitionStarted');
     assert.exists(startedEvent, 'Acquisition started event gets published');
     assert.include(startedEvent!.properties!.AcquisitionStartVersion, rntVersion, 'Acquisition started event has a starting version');
-    assert.include(startedEvent!.properties!.AcquisitionInstallKey, installKey, 'Acquisition started event has a install key');
+    assert.include(startedEvent!.properties!.AcquisitionInstallId, installId, 'Acquisition started event has a install key');
 
     const completedEvent = MockTelemetryReporter.telemetryEvents.find((event: ITelemetryEvent) => event.eventName === 'DotnetAcquisitionCompleted');
     assert.exists(completedEvent, 'Acquisition completed events exist');

--- a/vscode-dotnet-runtime-library/src/Acquisition/ASPNetRuntimeInstallationDirectoryProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/ASPNetRuntimeInstallationDirectoryProvider.ts
@@ -7,9 +7,9 @@ import * as path from 'path';
 import { IInstallationDirectoryProvider } from './IInstallationDirectoryProvider';
 
 export class ASPNetRuntimeInstallationDirectoryProvider extends IInstallationDirectoryProvider {
-    public getInstallDir(installKey: string): string
+    public getInstallDir(installId: string): string
     {
-        const dotnetInstallDir = path.join(this.getStoragePath(), installKey);
+        const dotnetInstallDir = path.join(this.getStoragePath(), installId);
         return dotnetInstallDir;
     }
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -183,7 +183,7 @@ You will need to restart VS Code after these changes. If PowerShell is still not
      * @remarks Some users have reported not having powershell.exe or having execution policy that fails property evaluation functions in powershell install scripts.
      * We use this function to throw better errors if powershell is not configured correctly.
      */
-    private async verifyPowershellCanRun(installContext : IDotnetInstallationContext, installKey : DotnetInstall) : Promise<string>
+    private async verifyPowershellCanRun(installContext : IDotnetInstallationContext, installId : DotnetInstall) : Promise<string>
     {
         let knownError = false;
         let error = null;
@@ -230,7 +230,7 @@ If you cannot safely and confidently change the execution policy, try setting a 
 
         if(error != null)
         {
-            this.eventStream.post(new DotnetAcquisitionScriptError(error as Error, installKey));
+            this.eventStream.post(new DotnetAcquisitionScriptError(error as Error, installId));
             throw new EventBasedError('DotnetAcquisitionScriptError', error?.message, error?.stack);
         }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -250,7 +250,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
      *
      * @param version The version of the object to acquire.
      * @param installRuntime true if the request is to install the runtime, false for the SDK.
-     * @param install The install record / key of the version managed by us.
+     * @param install The install record / id of the version managed by us.
      * @returns the dotnet path of the acquired dotnet.
      *
      * @remarks it is called "core" because it is the meat of the actual acquisition work; this has nothing to do with .NET core vs framework.
@@ -424,9 +424,9 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
      * @param installedVersions - all of the currently installed versions of dotnet managed by the extension
      * @param version - the version that is about to be installed
      *
-     * @remarks Before, installed versions used their version as the 'install key' in the promises and folder structure.
-     * We changed this install key to include architecture so different architectures could be installed side-by-side.
-     * This means any installs that were made before version 1.8.0 will not have the architecture in their install key.
+     * @remarks Before, installed versions used their version as the 'install id' in the promises and folder structure.
+     * We changed this install id to include architecture so different architectures could be installed side-by-side.
+     * This means any installs that were made before version 1.8.0 will not have the architecture in their install id.
      * They should be removed. This is what makes an install 'legacy'.
      *
      * This function only removes the legacy install with the same version as 'version'.
@@ -434,7 +434,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
      * Assuming the install succeeds, this will not break as the legacy install of 'version' will be replaced by a non-legacy one upon completion.
      *
      * Many (if not most) legacy installs will actually hold the same content as the newly installed runtime/sdk.
-     * But since we don't want to be in the business of detecting their architecture, we chose this option as opposed to renaming and install key and folder
+     * But since we don't want to be in the business of detecting their architecture, we chose this option as opposed to renaming and install id and folder
      * ... for the legacy install.
      *
      * Note : only local installs were ever 'legacy.'
@@ -462,7 +462,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         let legacyInstalls : InstallRecord[] = [];
         for(const install of allInstalls)
         {
-            // Assumption: .NET versions so far did not include ~ in them, but we do for our non-legacy keys.
+            // Assumption: .NET versions so far did not include ~ in them, but we do for our non-legacy ids.
             if(!install.dotnetInstall.installId.includes('~'))
             {
                 context.eventStream.post(new DotnetLegacyInstallDetectedEvent(`A legacy install was detected -- ${JSON.stringify(install)}.`));
@@ -491,7 +491,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             this.removeFolderRecursively(context.eventStream, dotnetInstallDir);
 
             await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).untrackInstalledVersion(context, install);
-            // this is the only place where installed and installing could deal with pre existing installing key
+            // this is the only place where installed and installing could deal with pre existing installing id
             await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).untrackInstallingVersion(context, install);
 
             graveyard.remove(install);

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
@@ -17,16 +17,16 @@ export interface DotnetInstall {
 
 /**
  * @remarks
- * The key can be a type containing all of the information or the 'legacy' key which is a string that contains all of the information.
+ * The id can be a type containing all of the information or the 'legacy' id which is a string that contains all of the information.
  */
 export type DotnetInstallOrStr = DotnetInstall | string;
 
 /**
  *
  * @returns True if the underlying installs are the exact same 'files'.
- * An 'install' is technically marked on disk by its install key.
- * The key could theoretically be temporarily shared between installs that are not the same underlying files.
- * For example, if the install key becomes '8', then '8' could at one point hold 8.0.100, then later 8.0.200.
+ * An 'install' is technically marked on disk by its install id.
+ * The id could theoretically be temporarily shared between installs that are not the same underlying files.
+ * For example, if the install id becomes '8', then '8' could at one point hold 8.0.100, then later 8.0.200.
  * That is not the case at the moment, but it is a possibility.
  * Think carefully between using this and IsEquivalentInstallation
  */
@@ -51,14 +51,14 @@ export function IsEquivalentInstallation(a: DotnetInstall, b: DotnetInstall): bo
 /**
  * @returns A string set representing the installation of either a .NET runtime or .NET SDK.
  */
-export function InstallToStrings(key: DotnetInstall)
+export function InstallToStrings(id: DotnetInstall)
 {
     return {
-        installId: key.installId,
-        version: key.version,
-        architecture: key.architecture,
-        isGlobal: key.isGlobal.toString(),
-        installMode: key.installMode.toString()
+        installId: id.installId,
+        version: id.version,
+        architecture: id.architecture,
+        isGlobal: id.isGlobal.toString(),
+        installMode: id.installMode.toString()
     };
 }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
@@ -4,11 +4,11 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { DotnetInstallType } from '../IDotnetAcquireContext';
-import { getInstallKeyCustomArchitecture } from '../Utils/InstallKeyUtilities';
+import { getInstallIdCustomArchitecture } from '../Utils/InstallIdUtilities';
 import { DotnetInstallMode } from './DotnetInstallMode';
 
 export interface DotnetInstall {
-    installKey: string;
+    installId: string;
     version: string;
     architecture: string;
     isGlobal: boolean;
@@ -45,7 +45,7 @@ export function IsEquivalentInstallationFile(a: DotnetInstall, b: DotnetInstall)
  */
 export function IsEquivalentInstallation(a: DotnetInstall, b: DotnetInstall): boolean
 {
-    return a.installKey === b.installKey;
+    return a.installId === b.installId;
 }
 
 /**
@@ -54,7 +54,7 @@ export function IsEquivalentInstallation(a: DotnetInstall, b: DotnetInstall): bo
 export function InstallToStrings(key: DotnetInstall)
 {
     return {
-        installKey: key.installKey,
+        installId: key.installId,
         version: key.version,
         architecture: key.architecture,
         isGlobal: key.isGlobal.toString(),
@@ -71,7 +71,7 @@ export function looksLikeRuntimeVersion(version: string): boolean
 export function GetDotnetInstallInfo(installVersion: string, installationMode: DotnetInstallMode, installType: DotnetInstallType, installArchitecture: string): DotnetInstall
 {
     return {
-        installKey: getInstallKeyCustomArchitecture(installVersion, installArchitecture, installationMode, installType),
+        installId: getInstallIdCustomArchitecture(installVersion, installArchitecture, installationMode, installType),
         version: installVersion,
         architecture: installArchitecture,
         isGlobal: installType === 'global',

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
@@ -51,14 +51,14 @@ export function IsEquivalentInstallation(a: DotnetInstall, b: DotnetInstall): bo
 /**
  * @returns A string set representing the installation of either a .NET runtime or .NET SDK.
  */
-export function InstallToStrings(id: DotnetInstall)
+export function InstallToStrings(install: DotnetInstall)
 {
     return {
-        installId: id.installId,
-        version: id.version,
-        architecture: id.architecture,
-        isGlobal: id.isGlobal.toString(),
-        installMode: id.installMode.toString()
+        installId: install.installId,
+        version: install.version,
+        architecture: install.architecture,
+        isGlobal: install.isGlobal.toString(),
+        installMode: install.installMode.toString()
     };
 }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/GlobalInstallerResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GlobalInstallerResolver.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 
 import { WebRequestWorker } from '../Utils/WebRequestWorker';
 import { VersionResolver } from './VersionResolver';
-import { getInstallFromContext } from '../Utils/InstallKeyUtilities';
+import { getInstallFromContext } from '../Utils/InstallIdUtilities';
 import { DotnetFeatureBandDoesNotExistError,
         DotnetFileIntegrityCheckEvent,
         DotnetInvalidReleasesJSONError,

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
@@ -17,7 +17,7 @@ import { LinuxPackageCollection } from './LinuxPackageCollection';
 import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IUtilityContext } from '../Utils/IUtilityContext';
-import { getInstallFromContext } from '../Utils/InstallKeyUtilities';
+import { getInstallFromContext } from '../Utils/InstallIdUtilities';
 /* tslint:disable:no-any */
 
 /**

--- a/vscode-dotnet-runtime-library/src/Acquisition/IInstallationDirectoryProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IInstallationDirectoryProvider.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 export abstract class IInstallationDirectoryProvider {
     constructor(protected storagePath: string) { }
 
-    public abstract getInstallDir(installKey: string): string;
+    public abstract getInstallDir(installId: string): string;
 
     public getStoragePath(): string {
         const installFolderName = process.env._VSCODE_DOTNET_INSTALL_FOLDER || '.dotnet';

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallScriptAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallScriptAcquisitionWorker.ts
@@ -14,7 +14,7 @@ import {
 import { WebRequestWorker } from '../Utils/WebRequestWorker';
 import { Debugging } from '../Utils/Debugging';
 import { FileUtilities } from '../Utils/FileUtilities';
-import { getInstallFromContext } from '../Utils/InstallKeyUtilities';
+import { getInstallFromContext } from '../Utils/InstallIdUtilities';
 
 import { IInstallScriptAcquisitionWorker } from './IInstallScriptAcquisitionWorker';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
@@ -52,8 +52,8 @@ export class InstallTrackerSingleton
     protected static instance: InstallTrackerSingleton;
 
     protected inProgressInstalls: Set<InProgressInstall> = new Set<InProgressInstall>();
-    private readonly installingVersionsKey = 'installing';
-    private readonly installedVersionsKey = 'installed';
+    private readonly installingVersionsid = 'installing';
+    private readonly installedVersionsid = 'installed';
 
     protected constructor(protected eventStream : IEventStream, protected extensionState : IExtensionState)
     {
@@ -124,16 +124,16 @@ export class InstallTrackerSingleton
 
     /**
      *
-     * @param key the install key to get a working install promise for.
+     * @param id the install id to get a working install promise for.
      */
-    public getPromise(key : DotnetInstall) : Promise<string> | null
+    public getPromise(id : DotnetInstall) : Promise<string> | null
     {
             this.inProgressInstalls.forEach(x =>
             {
-                const xAsKey = x.dotnetInstall as DotnetInstall;
-                if(IsEquivalentInstallationFile(xAsKey, key))
+                const xAsid = x.dotnetInstall as DotnetInstall;
+                if(IsEquivalentInstallationFile(xAsid, id))
                 {
-                    this.eventStream.post(new DotnetAcquisitionStatusResolved(key, key.version));
+                    this.eventStream.post(new DotnetAcquisitionStatusResolved(id, id.version));
                     return x.installingPromise;
                 }
             })
@@ -142,20 +142,20 @@ export class InstallTrackerSingleton
 
     public async addPromise(installId : DotnetInstall, installPromise : Promise<string>) : Promise<void>
     {
-        return this.executeWithLock( false, (key : DotnetInstall, workingInstall : Promise<string>) =>
+        return this.executeWithLock( false, (id : DotnetInstall, workingInstall : Promise<string>) =>
         {
-            this.inProgressInstalls.add({ dotnetInstall: key, installingPromise: workingInstall });
+            this.inProgressInstalls.add({ dotnetInstall: id, installingPromise: workingInstall });
         }, installId, installPromise);
     }
 
     protected async removePromise(installId : DotnetInstall) : Promise<void>
     {
-        return this.executeWithLock( false, (key : DotnetInstall) =>
+        return this.executeWithLock( false, (id : DotnetInstall) =>
         {
-            const resolvedInstall : InProgressInstall | undefined = [...this.inProgressInstalls].find(x => IsEquivalentInstallation(x.dotnetInstall as DotnetInstall, key));
+            const resolvedInstall : InProgressInstall | undefined = [...this.inProgressInstalls].find(x => IsEquivalentInstallation(x.dotnetInstall as DotnetInstall, id));
             if(!resolvedInstall)
             {
-                this.eventStream.post(new NoMatchingInstallToStopTracking(`No matching install to stop tracking for ${key.installId}.
+                this.eventStream.post(new NoMatchingInstallToStopTracking(`No matching install to stop tracking for ${id.installId}.
 Installs: ${[...this.inProgressInstalls].map(x => x.dotnetInstall.installId).join(', ')}`));
                 return;
             }
@@ -167,14 +167,14 @@ Installs: ${[...this.inProgressInstalls].map(x => x.dotnetInstall.installId).joi
     {
         return this.executeWithLock( false, async () =>
         {
-            // This does not uninstall global things yet, so don't remove their keys.
+            // This does not uninstall global things yet, so don't remove their ids.
             const installingVersions = await this.getExistingInstalls(false, true);
             const remainingInstallingVersions = installingVersions.filter(x => x.dotnetInstall.isGlobal);
-            await this.extensionState.update(this.installingVersionsKey, remainingInstallingVersions);
+            await this.extensionState.update(this.installingVersionsid, remainingInstallingVersions);
 
             const installedVersions = await this.getExistingInstalls(true, true);
             const remainingInstalledVersions = installedVersions.filter(x => x.dotnetInstall.isGlobal);
-            await this.extensionState.update(this.installedVersionsKey, remainingInstalledVersions);
+            await this.extensionState.update(this.installedVersionsid, remainingInstalledVersions);
         }, );
     }
 
@@ -186,7 +186,7 @@ Installs: ${[...this.inProgressInstalls].map(x => x.dotnetInstall.installId).joi
     {
         return this.executeWithLock( alreadyHoldingLock, (getAlreadyInstalledVersions : boolean) =>
         {
-            const extensionStateAccessor = getAlreadyInstalledVersions ? this.installedVersionsKey : this.installingVersionsKey;
+            const extensionStateAccessor = getAlreadyInstalledVersions ? this.installedVersionsid : this.installingVersionsid;
             const existingInstalls = this.extensionState.get<InstallRecordOrStr[]>(extensionStateAccessor, []);
             const convertedInstalls : InstallRecord[] = [];
 
@@ -211,7 +211,7 @@ Installs: ${[...this.inProgressInstalls].map(x => x.dotnetInstall.installId).joi
 
             this.extensionState.update(extensionStateAccessor, convertedInstalls);
 
-            this.eventStream.post(new FoundTrackingVersions(`${getAlreadyInstalledVersions ? this.installedVersionsKey : this.installingVersionsKey} :
+            this.eventStream.post(new FoundTrackingVersions(`${getAlreadyInstalledVersions ? this.installedVersionsid : this.installingVersionsid} :
 ${convertedInstalls.map(x => `${JSON.stringify(x.dotnetInstall)} owned by ${x.installingExtensions.map(owner => owner ?? 'null').join(', ')}\n`)}`));
             return convertedInstalls;
         }, getAlreadyInstalledVersion);
@@ -226,21 +226,21 @@ ${convertedInstalls.map(x => `${JSON.stringify(x.dotnetInstall)} owned by ${x.in
 
     public async untrackInstallingVersion(context : IAcquisitionWorkerContext, install : DotnetInstall)
     {
-        await this.removeVersionFromExtensionState(context, this.installingVersionsKey, install);
+        await this.removeVersionFromExtensionState(context, this.installingVersionsid, install);
         this.removePromise(install);
     }
 
     public async untrackInstalledVersion(context : IAcquisitionWorkerContext, install : DotnetInstall)
     {
-        await this.removeVersionFromExtensionState(context, this.installedVersionsKey, install);
+        await this.removeVersionFromExtensionState(context, this.installedVersionsid, install);
     }
 
-    protected async removeVersionFromExtensionState(context : IAcquisitionWorkerContext, keyStr: string, installIdObj: DotnetInstall)
+    protected async removeVersionFromExtensionState(context : IAcquisitionWorkerContext, idStr: string, installIdObj: DotnetInstall)
     {
-        return this.executeWithLock( false, async (key: string, install: DotnetInstall) =>
+        return this.executeWithLock( false, async (id: string, install: DotnetInstall) =>
         {
-            this.eventStream.post(new RemovingVersionFromExtensionState(`Removing ${JSON.stringify(install)} with key ${key} from the state.`));
-            const existingInstalls = await this.getExistingInstalls(key === this.installedVersionsKey, true);
+            this.eventStream.post(new RemovingVersionFromExtensionState(`Removing ${JSON.stringify(install)} with id ${id} from the state.`));
+            const existingInstalls = await this.getExistingInstalls(id === this.installedVersionsid, true);
             const installRecord = existingInstalls.filter(x => IsEquivalentInstallation(x.dotnetInstall, install));
 
             if(installRecord)
@@ -261,36 +261,36 @@ ${convertedInstalls.map(x => `${JSON.stringify(x.dotnetInstall)} owned by ${x.in
                     // For installing versions, there should only ever be 1 owner.
                     // For installed versions, there can be N owners.
                     this.eventStream.post(new RemovingExtensionFromList(`The last owner ${context.acquisitionContext?.requestingExtensionId} removed ${JSON.stringify(install)} entirely from the state.`));
-                    await this.extensionState.update(key, existingInstalls.filter(x => !IsEquivalentInstallation(x.dotnetInstall, install)));
+                    await this.extensionState.update(id, existingInstalls.filter(x => !IsEquivalentInstallation(x.dotnetInstall, install)));
                 }
                 else
                 {
                     // There are still other extensions that depend on this install, so merely remove this requesting extension from the list of owners.
                     this.eventStream.post(new RemovingOwnerFromList(`The owner ${context.acquisitionContext?.requestingExtensionId} removed ${JSON.stringify(install)} itself from the list, but ${owners?.join(', ')} remain.`));
-                    await this.extensionState.update(key, existingInstalls.map(x => IsEquivalentInstallation(x.dotnetInstall, install) ?
+                    await this.extensionState.update(id, existingInstalls.map(x => IsEquivalentInstallation(x.dotnetInstall, install) ?
                         { dotnetInstall: install, installingExtensions: owners } as InstallRecord : x));
                 }
             }
-        }, keyStr, installIdObj);
+        }, idStr, installIdObj);
     }
 
     public async trackInstallingVersion(context : IAcquisitionWorkerContext, install: DotnetInstall)
     {
-        await this.addVersionToExtensionState(context, this.installingVersionsKey, install);
+        await this.addVersionToExtensionState(context, this.installingVersionsid, install);
     }
 
     public async trackInstalledVersion(context : IAcquisitionWorkerContext, install: DotnetInstall)
     {
-        await this.addVersionToExtensionState(context, this.installedVersionsKey, install);
+        await this.addVersionToExtensionState(context, this.installedVersionsid, install);
     }
 
-    protected async addVersionToExtensionState(context : IAcquisitionWorkerContext, keyStr: string, installObj: DotnetInstall, alreadyHoldingLock = false)
+    protected async addVersionToExtensionState(context : IAcquisitionWorkerContext, idStr: string, installObj: DotnetInstall, alreadyHoldingLock = false)
     {
-        return this.executeWithLock( alreadyHoldingLock, async (key: string, install: DotnetInstall) =>
+        return this.executeWithLock( alreadyHoldingLock, async (id: string, install: DotnetInstall) =>
         {
-            this.eventStream.post(new RemovingVersionFromExtensionState(`Adding ${JSON.stringify(install)} with key ${key} from the state.`));
+            this.eventStream.post(new RemovingVersionFromExtensionState(`Adding ${JSON.stringify(install)} with id ${id} from the state.`));
 
-            const existingVersions = await this.getExistingInstalls(key === this.installedVersionsKey, true);
+            const existingVersions = await this.getExistingInstalls(id === this.installedVersionsid, true);
             const preExistingInstallIndex = existingVersions.findIndex(x => IsEquivalentInstallation(x.dotnetInstall, install));
 
             if(preExistingInstallIndex !== -1)
@@ -315,17 +315,17 @@ ${convertedInstalls.map(x => `${JSON.stringify(x.dotnetInstall)} owned by ${x.in
                 );
             }
 
-            this.eventStream.post(new AddTrackingVersions(`Updated ${keyStr} :
+            this.eventStream.post(new AddTrackingVersions(`Updated ${idStr} :
 ${existingVersions.map(x => `${JSON.stringify(x.dotnetInstall)} owned by ${x.installingExtensions.map(owner => owner ?? 'null').join(', ')}\n`)}`));
-            await this.extensionState.update(key, existingVersions);
-        }, keyStr, installObj);
+            await this.extensionState.update(id, existingVersions);
+        }, idStr, installObj);
     }
 
     public async checkForUnrecordedLocalSDKSuccessfulInstall(context : IAcquisitionWorkerContext, dotnetInstallDirectory: string, installedInstallIdsList: InstallRecord[]): Promise<InstallRecord[]>
     {
         return this.executeWithLock( false, async (dotnetInstallDir: string, installedInstallIds: InstallRecord[]) =>
         {
-            let localSDKDirectoryKeyIter = '';
+            let localSDKDirectoryidIter = '';
             try
             {
                 // Determine installed version(s) of local SDKs for the EDU bundle.
@@ -334,16 +334,16 @@ ${existingVersions.map(x => `${JSON.stringify(x.dotnetInstall)} owned by ${x.ins
                 // Update extension state
                 for (const installId of installIds)
                 {
-                    localSDKDirectoryKeyIter = installId;
+                    localSDKDirectoryidIter = installId;
                     const installRecord = GetDotnetInstallInfo(getVersionFromLegacyInstallId(installId), 'sdk', 'local', DotnetCoreAcquisitionWorker.defaultArchitecture());
                     this.eventStream.post(new DotnetPreinstallDetected(installRecord));
-                    await this.addVersionToExtensionState(context, this.installedVersionsKey, installRecord, true);
+                    await this.addVersionToExtensionState(context, this.installedVersionsid, installRecord, true);
                     installedInstallIds.push({ dotnetInstall: installRecord, installingExtensions: [ null ] } as InstallRecord);
                 }
             }
             catch (error)
             {
-                this.eventStream.post(new DotnetPreinstallDetectionError(error as Error, GetDotnetInstallInfo(localSDKDirectoryKeyIter, 'sdk', 'local',
+                this.eventStream.post(new DotnetPreinstallDetectionError(error as Error, GetDotnetInstallInfo(localSDKDirectoryidIter, 'sdk', 'local',
                     DotnetCoreAcquisitionWorker.defaultArchitecture())));
             }
             return installedInstallIds;

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallationGraveyard.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallationGraveyard.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IsEquivalentInstallationFile } from './DotnetInstall';
-import { getAssumedInstallInfo } from '../Utils/InstallKeyUtilities';
+import { getAssumedInstallInfo } from '../Utils/InstallIdUtilities';
 import { DotnetInstall } from './DotnetInstall';
 
 interface LocalDotnetInstall
@@ -14,7 +14,7 @@ interface LocalDotnetInstall
     path: string;
 }
 
-type LegacyGraveyardOrModernGraveyard = { [installKeys: string]: string } | Set<LocalDotnetInstall>
+type LegacyGraveyardOrModernGraveyard = { [installIds: string]: string } | Set<LocalDotnetInstall>
 
 export class InstallationGraveyard
 {
@@ -47,17 +47,17 @@ export class InstallationGraveyard
         return new Set([...graveyard].map(x => x.dotnetInstall));
     }
 
-    public async add(installKey : DotnetInstall, newPath : string)
+    public async add(installId : DotnetInstall, newPath : string)
     {
         const graveyard = await this.getGraveyard();
-        const newGraveyard = graveyard.add({ dotnetInstall: installKey, path: newPath } as LocalDotnetInstall);
+        const newGraveyard = graveyard.add({ dotnetInstall: installId, path: newPath } as LocalDotnetInstall);
         await this.context.extensionState.update(this.installPathsGraveyardKey, newGraveyard);
     }
 
-    public async remove(installKey : DotnetInstall)
+    public async remove(installId : DotnetInstall)
     {
         const graveyard = await this.getGraveyard();
-        const newGraveyard : Set<LocalDotnetInstall> = new Set([...graveyard].filter(x => !IsEquivalentInstallationFile(x.dotnetInstall, installKey)));
+        const newGraveyard : Set<LocalDotnetInstall> = new Set([...graveyard].filter(x => !IsEquivalentInstallationFile(x.dotnetInstall, installId)));
         await this.context.extensionState.update(this.installPathsGraveyardKey, newGraveyard);
     }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -25,7 +25,7 @@ import { IDistroDotnetSDKProvider } from './IDistroDotnetSDKProvider';
 import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { IUtilityContext } from '../Utils/IUtilityContext';
 import { IDotnetAcquireContext } from '../IDotnetAcquireContext'
-import { getInstallFromContext } from '../Utils/InstallKeyUtilities';
+import { getInstallFromContext } from '../Utils/InstallIdUtilities';
 import { DotnetInstallMode } from './DotnetInstallMode';
 
 /**

--- a/vscode-dotnet-runtime-library/src/Acquisition/RuntimeInstallationDirectoryProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RuntimeInstallationDirectoryProvider.ts
@@ -7,8 +7,8 @@ import * as path from 'path';
 import { IInstallationDirectoryProvider } from './IInstallationDirectoryProvider';
 
 export class RuntimeInstallationDirectoryProvider extends IInstallationDirectoryProvider {
-    public getInstallDir(installKey: string): string {
-        const dotnetInstallDir = path.join(this.getStoragePath(), installKey);
+    public getInstallDir(installId: string): string {
+        const dotnetInstallDir = path.join(this.getStoragePath(), installId);
         return dotnetInstallDir;
     }
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/SdkInstallationDirectoryProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/SdkInstallationDirectoryProvider.ts
@@ -6,7 +6,7 @@
 import { IInstallationDirectoryProvider } from './IInstallationDirectoryProvider';
 
 export class SdkInstallationDirectoryProvider extends IInstallationDirectoryProvider {
-    public getInstallDir(installKey: string): string {
+    public getInstallDir(installId: string): string {
         return this.getStoragePath();
     }
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/VersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/VersionResolver.ts
@@ -15,7 +15,7 @@ import {
     EventBasedError
 } from '../EventStream/EventStreamEvents';
 import { WebRequestWorker } from '../Utils/WebRequestWorker';
-import { getInstallFromContext } from '../Utils/InstallKeyUtilities';
+import { getInstallFromContext } from '../Utils/InstallIdUtilities';
 import { Debugging } from '../Utils/Debugging';
 
 import { IVersionResolver } from './IVersionResolver';
@@ -26,7 +26,7 @@ import { DotnetVersionSupportPhase,
     IDotnetVersion
 } from '../IDotnetListVersionsContext';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
-import { getAssumedInstallInfo } from '../Utils/InstallKeyUtilities';
+import { getAssumedInstallInfo } from '../Utils/InstallIdUtilities';
 import { DotnetInstallMode } from './DotnetInstallMode';
 /* tslint:disable:no-any */
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -11,7 +11,7 @@ import * as proc from 'child_process';
 import { FileUtilities } from '../Utils/FileUtilities';
 import { VersionResolver } from './VersionResolver';
 import { WebRequestWorker } from '../Utils/WebRequestWorker';
-import { getInstallFromContext } from '../Utils/InstallKeyUtilities';
+import { getInstallFromContext } from '../Utils/InstallIdUtilities';
 import { CommandExecutor } from '../Utils/CommandExecutor';
 import {
     DotnetAcquisitionAlreadyInstalled,

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -209,7 +209,7 @@ export class DotnetAcquisitionCompleted extends IEvent {
         super();
     }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         if (telemetry) {
             return {...InstallToStrings(this.install),
                     AcquisitionCompletedInstallId : this.install.installId,
@@ -232,7 +232,7 @@ export abstract class DotnetAcquisitionError extends IEvent {
     /**
      *
      * @param error The error that triggered, so the call stack, etc. can be analyzed.
-     * @param install For acquisition errors, you MUST include this install key. For commands unrelated to acquiring or managing a specific dotnet version, you
+     * @param install For acquisition errors, you MUST include this install id. For commands unrelated to acquiring or managing a specific dotnet version, you
      * have the option to leave this parameter null. If it is NULL during acquisition the extension CANNOT properly manage what it has finished installing or not.
      */
     constructor(public readonly error: Error, public readonly install: DotnetInstall | null)
@@ -240,7 +240,7 @@ export abstract class DotnetAcquisitionError extends IEvent {
         super();
     }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {ErrorName : this.error.name,
                 ErrorMessage : this.error.message,
                 StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
@@ -263,7 +263,7 @@ export class DotnetAcquisitionFinalError extends GenericModalEvent
         this.installType = install.isGlobal ? 'global' : 'local';
     }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {ErrorName : this.error.name,
                 ErrorMessage : this.error.message,
                 StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
@@ -286,7 +286,7 @@ abstract class DotnetAcquisitionFinalErrorBase extends DotnetAcquisitionError
         this.type = EventType.DotnetAcquisitionFinalError;
     }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
                 FailureMode: this.originalEventName,
                 ErrorName : this.error.name,
@@ -321,7 +321,7 @@ export abstract class DotnetNonAcquisitionError extends IEvent {
         super();
     }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {ErrorName : this.error.name,
                 ErrorMessage : this.error.message,
                 StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : ''};
@@ -335,7 +335,7 @@ export abstract class DotnetInstallExpectedAbort extends IEvent {
     /**
      *
      * @param error The error that triggered, so the call stack, etc. can be analyzed.
-     * @param install For acquisition errors, you MUST include this install key. For commands unrelated to acquiring or managing a specific dotnet version, you
+     * @param install For acquisition errors, you MUST include this install id. For commands unrelated to acquiring or managing a specific dotnet version, you
      * have the option to leave this parameter null. If it is NULL during acquisition the extension CANNOT properly manage what it has finished installing or not.
      */
     constructor(public readonly error: Error, public readonly install: DotnetInstall | null)
@@ -343,7 +343,7 @@ export abstract class DotnetInstallExpectedAbort extends IEvent {
         super();
     }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
     {
         if(this.install)
         {
@@ -371,7 +371,7 @@ export class SuppressedAcquisitionError extends IEvent {
         super();
     }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
                 SupplementMessage : this.supplementalMessage,
                 ErrorName : this.error.name,
@@ -427,7 +427,7 @@ export class DotnetNotInstallRelatedCommandFailed extends DotnetNonAcquisitionEr
         super(error);
     }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             ErrorMessage : this.error.message,
             CommandName : this.command,
@@ -443,7 +443,7 @@ export class DotnetCommandFailed extends DotnetAcquisitionError {
         super(error, install);
     }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {ErrorMessage : this.error.message,
             CommandName : this.command,
             ErrorName : this.error.name,
@@ -487,7 +487,7 @@ export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionErr
         super(error, install);
     }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {ErrorMessage : this.error.message,
             AcquisitionErrorInstallId : this.install?.installId ?? 'null',
             ...InstallToStrings(this.install!),
@@ -545,7 +545,7 @@ export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError
         super(error, installId);
     }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
     {
         if(this.install)
         {
@@ -586,7 +586,7 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
         this.fileStructure = this.getFileStructure();
     }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         if(this.install)
         {
             return {ErrorMessage : this.error.message,
@@ -632,7 +632,7 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
 export class DotnetAcquisitionDistroUnknownError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetAcquisitionDistroUnknownError';
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {ErrorMessage : this.error.message,
             ErrorName : this.error.name,
             StackTrace : this.error.stack ? this.error.stack : '',
@@ -645,7 +645,7 @@ export class DotnetAcquisitionDistroUnknownError extends DotnetInstallExpectedAb
 export abstract class DotnetAcquisitionSuccessEvent extends IEvent {
     public readonly type = EventType.DotnetAcquisitionSuccessEvent;
 
-    public getProperties(): { [key: string]: string } | undefined {
+    public getProperties(): { [id: string]: string } | undefined {
         return undefined;
     }
 }
@@ -696,7 +696,7 @@ export class DotnetExistingPathResolutionCompleted extends DotnetAcquisitionSucc
 export abstract class DotnetAcquisitionMessage extends IEvent {
     public type = EventType.DotnetAcquisitionMessage;
 
-    public getProperties(): { [key: string]: string } | undefined {
+    public getProperties(): { [id: string]: string } | undefined {
         return {};
     }
 }
@@ -1059,7 +1059,7 @@ export class DotnetAcquisitionScriptOutput extends DotnetAcquisitionMessage {
     public isError = true;
     constructor(public readonly install: DotnetInstall, public readonly output: string) { super(); }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             AcquisitionInstallId : this.install.installId,
             ...InstallToStrings(this.install!),
@@ -1072,7 +1072,7 @@ export class DotnetInstallationValidated extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetInstallationValidated';
     constructor(public readonly install: DotnetInstall) { super(); }
 
-    public getProperties(telemetry = false): { [key: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             ValidatedInstallId : this.install.installId,
             ...InstallToStrings(this.install!)

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -54,7 +54,7 @@ export class DotnetAcquisitionStarted extends GenericModalEvent
         return {
                 ...InstallToStrings(this.install),
                 AcquisitionStartVersion : this.startingVersion,
-                AcquisitionInstallKey : this.install.installKey,
+                AcquisitionInstallId : this.install.installId,
                 extensionId : this.requestingExtensionId
             };
     }
@@ -107,7 +107,7 @@ export class DotnetAcquisitionTotalSuccessEvent extends GenericModalEvent
     public getProperties() {
         return {
                 AcquisitionStartVersion : this.startingVersion,
-                AcquisitionInstallKey : this.install.installKey,
+                AcquisitionInstallId : this.install.installId,
                 ...InstallToStrings(this.install),
                 ExtensionId : TelemetryUtilities.HashData(this.requestingExtensionId),
                 FinalPath : this.finalPath,
@@ -119,13 +119,13 @@ abstract class DotnetAcquisitionTotalSuccessEventBase extends IEvent
 {
     public readonly type = EventType.DotnetModalChildEvent;
 
-    constructor(public readonly installKey: DotnetInstall) {
+    constructor(public readonly installId: DotnetInstall) {
         super();
     }
 
     public getProperties() {
         return {
-                ...InstallToStrings(this.installKey),
+                ...InstallToStrings(this.installId),
             };
     }
 }
@@ -212,14 +212,14 @@ export class DotnetAcquisitionCompleted extends IEvent {
     public getProperties(telemetry = false): { [key: string]: string } | undefined {
         if (telemetry) {
             return {...InstallToStrings(this.install),
-                    AcquisitionCompletedInstallKey : this.install.installKey,
+                    AcquisitionCompletedInstallId : this.install.installId,
                     AcquisitionCompletedVersion: this.version};
         }
         else
         {
             return {...InstallToStrings(this.install),
                     AcquisitionCompletedVersion: this.version,
-                    AcquisitionCompletedInstallKey : this.install.installKey,
+                    AcquisitionCompletedInstallId : this.install.installId,
                     AcquisitionCompletedDotnetPath : this.dotnetPath};
         }
     }
@@ -244,7 +244,7 @@ export abstract class DotnetAcquisitionError extends IEvent {
         return {ErrorName : this.error.name,
                 ErrorMessage : this.error.message,
                 StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
-                InstallKey : this.install?.installKey ?? 'null',
+                InstallId : this.install?.installId ?? 'null',
                 ...InstallToStrings(this.install!)};
     }
 }
@@ -267,7 +267,7 @@ export class DotnetAcquisitionFinalError extends GenericModalEvent
         return {ErrorName : this.error.name,
                 ErrorMessage : this.error.message,
                 StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
-                InstallKey : this.install?.installKey ?? 'null',
+                InstallId : this.install?.installId ?? 'null',
                 ...InstallToStrings(this.install!)};
     }
 }
@@ -292,7 +292,7 @@ abstract class DotnetAcquisitionFinalErrorBase extends DotnetAcquisitionError
                 ErrorName : this.error.name,
                 ErrorMessage : this.error.message,
                 StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
-                InstallKey : this.install?.installKey ?? 'null',
+                InstallId : this.install?.installId ?? 'null',
                 ...InstallToStrings(this.install!)
             };
     }
@@ -350,7 +350,7 @@ export abstract class DotnetInstallExpectedAbort extends IEvent {
         return {ErrorName : this.error.name,
                 ErrorMessage : this.error.message,
                 StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
-                InstallKey : this.install?.installKey ?? 'null',
+                InstallId : this.install?.installId ?? 'null',
                 ...InstallToStrings(this.install)};
         }
         else
@@ -358,7 +358,7 @@ export abstract class DotnetInstallExpectedAbort extends IEvent {
             return {ErrorName : this.error.name,
                     ErrorMessage : this.error.message,
                     StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
-                    InstallKey : 'null'};
+                    InstallId : 'null'};
         }
     }
 }
@@ -448,7 +448,7 @@ export class DotnetCommandFailed extends DotnetAcquisitionError {
             CommandName : this.command,
             ErrorName : this.error.name,
             StackTrace : this.error.stack ? this.error.stack : '',
-            InstallKey : this.install?.installKey ?? 'null',
+            InstallId : this.install?.installId ?? 'null',
             ...InstallToStrings(this.install!)};
         }
 }
@@ -489,7 +489,7 @@ export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionErr
 
     public getProperties(telemetry = false): { [key: string]: string } | undefined {
         return {ErrorMessage : this.error.message,
-            AcquisitionErrorInstallKey : this.install?.installKey ?? 'null',
+            AcquisitionErrorInstallId : this.install?.installId ?? 'null',
             ...InstallToStrings(this.install!),
             ErrorName : this.error.name,
             StackTrace : this.error.stack ? this.error.stack : ''};
@@ -541,8 +541,8 @@ export class DotnetOfflineFailure extends DotnetAcquisitionVersionError {
 export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError {
     public readonly eventName = 'DotnetAcquisitionTimeoutError';
 
-    constructor(error: Error, installKey: DotnetInstall | null, public readonly timeoutValue: number) {
-        super(error, installKey);
+    constructor(error: Error, installId: DotnetInstall | null, public readonly timeoutValue: number) {
+        super(error, installId);
     }
 
     public getProperties(telemetry = false): { [key: string]: string } | undefined
@@ -590,8 +590,8 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
         if(this.install)
         {
             return {ErrorMessage : this.error.message,
-                AcquisitionErrorInstallKey : this.install?.installKey ?? 'null',
-                InstallKey : this.install?.installKey ?? 'null',
+                AcquisitionErrorInstallId : this.install?.installId ?? 'null',
+                InstallId : this.install?.installId ?? 'null',
                 ...InstallToStrings(this.install),
                 ErrorName : this.error.name,
                 StackTrace : this.error.stack ? this.error.stack : '',
@@ -600,8 +600,8 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
         else
         {
             return {ErrorMessage : this.error.message,
-                AcquisitionErrorInstallKey : 'null',
-                InstallKey : 'null',
+                AcquisitionErrorInstallId : 'null',
+                InstallId : 'null',
                 ErrorName : this.error.name,
                 StackTrace : this.error.stack ? this.error.stack : '',
                 FileStructure : this.fileStructure};
@@ -636,7 +636,7 @@ export class DotnetAcquisitionDistroUnknownError extends DotnetInstallExpectedAb
         return {ErrorMessage : this.error.message,
             ErrorName : this.error.name,
             StackTrace : this.error.stack ? this.error.stack : '',
-            InstallKey : this.install?.installKey ?? 'null',
+            InstallId : this.install?.installId ?? 'null',
             ...InstallToStrings(this.install!)};
     }
 }
@@ -864,8 +864,8 @@ export class DotnetCommandFallbackOSEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetCommandFallbackOSEvent';
 }
 
-export class DotnetInstallKeyCreatedEvent extends DotnetCustomMessageEvent {
-    public readonly eventName = 'DotnetInstallKeyCreatedEvent';
+export class DotnetInstallIdCreatedEvent extends DotnetCustomMessageEvent {
+    public readonly eventName = 'DotnetInstallIdCreatedEvent';
 }
 
 export class DotnetLegacyInstallDetectedEvent extends DotnetCustomMessageEvent {
@@ -1018,7 +1018,7 @@ export class DotnetAcquisitionPartialInstallation extends DotnetAcquisitionMessa
     public getProperties() {
         return {
             ...InstallToStrings(this.install!),
-            PartialInstallationInstallKey: this.install.installKey
+            PartialInstallationInstallId: this.install.installId
         };
     }
 }
@@ -1027,12 +1027,12 @@ export class DotnetAcquisitionInProgress extends IEvent {
     public readonly type = EventType.DotnetAcquisitionInProgress;
 
     public readonly eventName = 'DotnetAcquisitionInProgress';
-    constructor(public readonly installKey: DotnetInstall, public readonly requestingExtensionId: string | null) { super(); }
+    constructor(public readonly installId: DotnetInstall, public readonly requestingExtensionId: string | null) { super(); }
 
     public getProperties() {
         return {
-            InProgressInstallationInstallKey : this.installKey.installKey,
-            ...InstallToStrings(this.installKey!),
+            InProgressInstallationInstallId : this.installId.installId,
+            ...InstallToStrings(this.installId!),
             extensionId : TelemetryUtilities.HashData(this.requestingExtensionId)};
     }
 }
@@ -1061,7 +1061,7 @@ export class DotnetAcquisitionScriptOutput extends DotnetAcquisitionMessage {
 
     public getProperties(telemetry = false): { [key: string]: string } | undefined {
         return {
-            AcquisitionInstallKey : this.install.installKey,
+            AcquisitionInstallId : this.install.installId,
             ...InstallToStrings(this.install!),
                 ScriptOutput: this.output
             };
@@ -1074,7 +1074,7 @@ export class DotnetInstallationValidated extends DotnetAcquisitionMessage {
 
     public getProperties(telemetry = false): { [key: string]: string } | undefined {
         return {
-            ValidatedInstallKey : this.install.installKey,
+            ValidatedInstallId : this.install.installId,
             ...InstallToStrings(this.install!)
         };
     }
@@ -1097,14 +1097,14 @@ export class DotnetAcquisitionStatusRequested extends DotnetAcquisitionMessage {
 export class DotnetAcquisitionStatusUndefined extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetAcquisitionStatusUndefined';
 
-    constructor(public readonly installKey: DotnetInstall) {
+    constructor(public readonly installId: DotnetInstall) {
         super();
     }
 
     public getProperties() {
         return {
-            AcquisitionStatusInstallKey : this.installKey.installKey,
-            ...InstallToStrings(this.installKey!)
+            AcquisitionStatusInstallId : this.installId.installId,
+            ...InstallToStrings(this.installId!)
         };
     }
 }
@@ -1112,14 +1112,14 @@ export class DotnetAcquisitionStatusUndefined extends DotnetAcquisitionMessage {
 export class DotnetAcquisitionStatusResolved extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetAcquisitionStatusResolved';
 
-    constructor(public readonly installKey: DotnetInstall, public readonly version: string) {
+    constructor(public readonly installId: DotnetInstall, public readonly version: string) {
         super();
     }
 
     public getProperties() {
         return {
-            AcquisitionStatusInstallKey : this.installKey.installKey,
-            ...InstallToStrings(this.installKey!),
+            AcquisitionStatusInstallId : this.installId.installId,
+            ...InstallToStrings(this.installId!),
             AcquisitionStatusVersion : this.version
             };
     }
@@ -1139,12 +1139,12 @@ export class WebRequestSent extends DotnetAcquisitionMessage {
 
 export class DotnetPreinstallDetected extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetPreinstallDetected';
-    constructor(public readonly installKey: DotnetInstall) { super(); }
+    constructor(public readonly installId: DotnetInstall) { super(); }
 
     public getProperties() {
         return {
-            ...InstallToStrings(this.installKey!),
-            PreinstalledInstallKey : this.installKey.installKey
+            ...InstallToStrings(this.installId!),
+            PreinstalledInstallId : this.installId.installId
             };
     }
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
@@ -34,7 +34,7 @@ export class OutputChannelObserver implements IEventStreamObserver {
             case EventType.DotnetAcquisitionStart:
                 const acquisitionStarted = event as DotnetAcquisitionStarted;
 
-                this.inProgressDownloads.push(acquisitionStarted.install.installKey);
+                this.inProgressDownloads.push(acquisitionStarted.install.installId);
 
                 this.outputChannel.append(`${acquisitionStarted.requestingExtensionId} requested to download the ${
                 acquisitionStarted.install.installMode === 'sdk' ? '.NET SDK' :
@@ -46,7 +46,7 @@ export class OutputChannelObserver implements IEventStreamObserver {
 
                 if (this.inProgressDownloads.length > 1) {
                     // Already a download in progress
-                    this.outputChannel.appendLine(` -- Concurrent download of '${acquisitionStarted.install.installKey}' started!`);
+                    this.outputChannel.appendLine(` -- Concurrent download of '${acquisitionStarted.install.installId}' started!`);
                     this.outputChannel.appendLine('');
                 } else {
                     this.startDownloadIndicator();
@@ -58,10 +58,10 @@ export class OutputChannelObserver implements IEventStreamObserver {
             case EventType.DotnetAcquisitionCompleted:
                 const acquisitionCompleted = event as DotnetAcquisitionCompleted;
                 this.outputChannel.appendLine(' Done!');
-                this.outputChannel.appendLine(`.NET ${acquisitionCompleted.install.installKey} executable path: ${acquisitionCompleted.dotnetPath}`);
+                this.outputChannel.appendLine(`.NET ${acquisitionCompleted.install.installId} executable path: ${acquisitionCompleted.dotnetPath}`);
                 this.outputChannel.appendLine('');
 
-                this.inProgressVersionDone(acquisitionCompleted.install.installKey);
+                this.inProgressVersionDone(acquisitionCompleted.install.installId);
 
                 if (this.inProgressDownloads.length > 0) {
                     const completedVersionString = `'${this.inProgressDownloads.join('\', \'')}'`;
@@ -86,7 +86,7 @@ export class OutputChannelObserver implements IEventStreamObserver {
                     this.outputChannel.append(`${
                         (event as DotnetAcquisitionAlreadyInstalled).requestingExtensionId
                     }: Trying to install .NET ${
-                        (event as DotnetAcquisitionAlreadyInstalled).install.installKey
+                        (event as DotnetAcquisitionAlreadyInstalled).install.installId
                     } but it already exists. No downloads or changes were made.\n`);
                 }
                 break;
@@ -96,25 +96,25 @@ export class OutputChannelObserver implements IEventStreamObserver {
                     this.outputChannel.append(`${
                         (event as DotnetAcquisitionInProgress).requestingExtensionId
                     } tried to install .NET ${
-                        (event as DotnetAcquisitionInProgress).installKey
+                        (event as DotnetAcquisitionInProgress).installId
                     } but that install had already been requested. No downloads or changes were made.\n`);
                 }
                 break;
             case EventType.DotnetAcquisitionError:
                 const error = event as DotnetAcquisitionError;
                 this.outputChannel.appendLine(`\nError : (${error.eventName ?? ''})`);
-                this.outputChannel.appendLine(`Failed to download .NET ${error.install?.installKey}:`);
+                this.outputChannel.appendLine(`Failed to download .NET ${error.install?.installId}:`);
                 this.outputChannel.appendLine(error.error.message);
                 this.outputChannel.appendLine('');
 
-                this.updateDownloadIndicators(error.install?.installKey);
+                this.updateDownloadIndicators(error.install?.installId);
                 break;
             case EventType.DotnetInstallExpectedAbort:
                 const abortEvent = event as DotnetInstallExpectedAbort;
-                this.outputChannel.appendLine(`Cancelled Installation of .NET ${abortEvent.install?.installKey}.`);
+                this.outputChannel.appendLine(`Cancelled Installation of .NET ${abortEvent.install?.installId}.`);
                 this.outputChannel.appendLine(abortEvent.error.message);
 
-                this.updateDownloadIndicators(abortEvent.install?.installKey);
+                this.updateDownloadIndicators(abortEvent.install?.installId);
                 break;
             case EventType.DotnetUpgradedEvent:
                 const upgradeMessage = event as DotnetUpgradedEvent;
@@ -131,11 +131,11 @@ export class OutputChannelObserver implements IEventStreamObserver {
         // Nothing to dispose
     }
 
-    private updateDownloadIndicators(installKey : string | null | undefined)
+    private updateDownloadIndicators(installId : string | null | undefined)
     {
-        if(installKey && installKey !== 'null')
+        if(installId && installId !== 'null')
         {
-            this.inProgressVersionDone(installKey);
+            this.inProgressVersionDone(installId);
         }
 
         if (this.inProgressDownloads.length > 0)

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -43,7 +43,7 @@ import {
 import {exec} from '@vscode/sudo-prompt';
 import * as lockfile from 'proper-lockfile';
 import { CommandExecutorCommand } from './CommandExecutorCommand';
-import { getInstallFromContext } from './InstallKeyUtilities';
+import { getInstallFromContext } from './InstallIdUtilities';
 
 
 import { ICommandExecutor } from './ICommandExecutor';

--- a/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
@@ -12,7 +12,7 @@ import {
     DotnetNotInstallRelatedCommandFailed,
     EventCancellationError
 } from '../EventStream/EventStreamEvents';
-import { getInstallFromContext } from './InstallKeyUtilities';
+import { getInstallFromContext } from './InstallIdUtilities';
 import { IIssueContext } from './IIssueContext';
 import { formatIssueUrl } from './IssueReporter';
 import { IAcquisitionWorkerContext } from '../Acquisition/IAcquisitionWorkerContext';

--- a/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
@@ -11,7 +11,7 @@ import { IAcquisitionWorkerContext } from '../Acquisition/IAcquisitionWorkerCont
 import { DotnetInstallType } from '../IDotnetAcquireContext';
 
 
-export function getInstallKeyCustomArchitecture(version : string, architecture: string | null | undefined, mode: DotnetInstallMode,
+export function getInstallIdCustomArchitecture(version : string, architecture: string | null | undefined, mode: DotnetInstallMode,
     installType : DotnetInstallType = 'local') : string
 {
     if(architecture === null || architecture === 'null')
@@ -33,7 +33,7 @@ export function getInstallFromContext(ctx : IAcquisitionWorkerContext) : DotnetI
     const acquireContext = ctx.acquisitionContext!;
 
     return {
-        installKey : getInstallKeyCustomArchitecture(acquireContext.version, acquireContext.architecture, ctx.acquisitionContext.mode!,
+        installId : getInstallIdCustomArchitecture(acquireContext.version, acquireContext.architecture, ctx.acquisitionContext.mode!,
             acquireContext.installType),
         version: acquireContext.version,
         architecture: acquireContext.architecture,
@@ -43,36 +43,36 @@ export function getInstallFromContext(ctx : IAcquisitionWorkerContext) : DotnetI
 
 
 }
-export function isRuntimeInstallKey(installKey: string): boolean {
-    const installKeyVersion = getVersionFromLegacyInstallKey(installKey);
-    return !(DOTNET_INSTALL_MODE_LIST.filter( (x : string) => x !== 'runtime')).some( (mode) => installKey.includes(mode))
-        && looksLikeRuntimeVersion(installKeyVersion);
+export function isRuntimeInstallId(installId: string): boolean {
+    const installIdVersion = getVersionFromLegacyInstallId(installId);
+    return !(DOTNET_INSTALL_MODE_LIST.filter( (x : string) => x !== 'runtime')).some( (mode) => installId.includes(mode))
+        && looksLikeRuntimeVersion(installIdVersion);
 }
 
-export function isGlobalLegacyInstallKey(installKey: string): boolean {
-    return installKey.toLowerCase().includes('global');
+export function isGlobalLegacyInstallId(installId: string): boolean {
+    return installId.toLowerCase().includes('global');
 }
 
-export function getArchFromLegacyInstallKey(installKey: string): string | undefined {
-    const splitKey = installKey.split('~');
+export function getArchFromLegacyInstallId(installId: string): string | undefined {
+    const splitKey = installId.split('~');
     if (splitKey.length >= 2) {
         return splitKey[1];
     }
     return undefined;
 }
 
-export function getVersionFromLegacyInstallKey(installKey: string): string {
-    if (isGlobalLegacyInstallKey(installKey)) {
-        const splitKey = installKey.split('-');
+export function getVersionFromLegacyInstallId(installId: string): string {
+    if (isGlobalLegacyInstallId(installId)) {
+        const splitKey = installId.split('-');
         return splitKey[0];
     }
-    else if (installKey.includes('~')) {
-        const splitKey = installKey.split('~');
+    else if (installId.includes('~')) {
+        const splitKey = installId.split('~');
         return splitKey[0];
     }
     else // legacy, legacy install key (before it included the arch)
     {
-        return installKey;
+        return installId;
     }
 }
 
@@ -81,15 +81,15 @@ export function getVersionFromLegacyInstallKey(installKey: string): string {
  */
 export function getAssumedInstallInfo(key: string, mode : DotnetInstallMode | null): DotnetInstall {
     return {
-        installKey: key,
-        version: getVersionFromLegacyInstallKey(key),
-        architecture: getArchFromLegacyInstallKey(key) ?? DotnetCoreAcquisitionWorker.defaultArchitecture(),
-        isGlobal: isGlobalLegacyInstallKey(key),
+        installId: key,
+        version: getVersionFromLegacyInstallId(key),
+        architecture: getArchFromLegacyInstallId(key) ?? DotnetCoreAcquisitionWorker.defaultArchitecture(),
+        isGlobal: isGlobalLegacyInstallId(key),
 
         // This code is for legacy install strings where the info was not recorded.
         // At the time only runtime or sdk was permitted and there were no outlier edge case versions that would be wrong.
         // So this assumption can hold true below. Do not utilize this going forward for new code.
-        installMode: mode ?? isRuntimeInstallKey(key) ? 'runtime' : 'sdk'
+        installMode: mode ?? isRuntimeInstallId(key) ? 'runtime' : 'sdk'
     };
 }
 

--- a/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
@@ -54,42 +54,42 @@ export function isGlobalLegacyInstallId(installId: string): boolean {
 }
 
 export function getArchFromLegacyInstallId(installId: string): string | undefined {
-    const splitKey = installId.split('~');
-    if (splitKey.length >= 2) {
-        return splitKey[1];
+    const splitId = installId.split('~');
+    if (splitId.length >= 2) {
+        return splitId[1];
     }
     return undefined;
 }
 
 export function getVersionFromLegacyInstallId(installId: string): string {
     if (isGlobalLegacyInstallId(installId)) {
-        const splitKey = installId.split('-');
-        return splitKey[0];
+        const splitId = installId.split('-');
+        return splitId[0];
     }
     else if (installId.includes('~')) {
-        const splitKey = installId.split('~');
-        return splitKey[0];
+        const splitId = installId.split('~');
+        return splitId[0];
     }
-    else // legacy, legacy install key (before it included the arch)
+    else // legacy, legacy install id (before it included the arch)
     {
         return installId;
     }
 }
 
 /**
- * @deprecated This function is for legacy install keys only. Do not use for new code.
+ * @deprecated This function is for legacy install ids only. Do not use for new code.
  */
-export function getAssumedInstallInfo(key: string, mode : DotnetInstallMode | null): DotnetInstall {
+export function getAssumedInstallInfo(id: string, mode : DotnetInstallMode | null): DotnetInstall {
     return {
-        installId: key,
-        version: getVersionFromLegacyInstallId(key),
-        architecture: getArchFromLegacyInstallId(key) ?? DotnetCoreAcquisitionWorker.defaultArchitecture(),
-        isGlobal: isGlobalLegacyInstallId(key),
+        installId: id,
+        version: getVersionFromLegacyInstallId(id),
+        architecture: getArchFromLegacyInstallId(id) ?? DotnetCoreAcquisitionWorker.defaultArchitecture(),
+        isGlobal: isGlobalLegacyInstallId(id),
 
         // This code is for legacy install strings where the info was not recorded.
         // At the time only runtime or sdk was permitted and there were no outlier edge case versions that would be wrong.
         // So this assumption can hold true below. Do not utilize this going forward for new code.
-        installMode: mode ?? isRuntimeInstallId(key) ? 'runtime' : 'sdk'
+        installMode: mode ?? isRuntimeInstallId(id) ? 'runtime' : 'sdk'
     };
 }
 

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -8,7 +8,7 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import { getProxySettings } from 'get-proxy-settings';
 import { AxiosCacheInstance, buildMemoryStorage, setupCache } from 'axios-cache-interceptor';
 import {DiskIsFullError, DotnetDownloadFailure, EventBasedError, SuppressedAcquisitionError, WebRequestError, WebRequestSent } from '../EventStream/EventStreamEvents';
-import { getInstallFromContext } from './InstallKeyUtilities';
+import { getInstallFromContext } from './InstallIdUtilities';
 
 import * as fs from 'fs';
 import { promisify } from 'util';

--- a/vscode-dotnet-runtime-library/src/index.ts
+++ b/vscode-dotnet-runtime-library/src/index.ts
@@ -26,7 +26,7 @@ export * from './Utils/FileUtilities';
 export * from './Utils/TypescriptUtilities';
 export * from './Utils/ICommandExecutor';
 export * from './Utils/IFileUtilities';
-export * from './Utils/InstallKeyUtilities';
+export * from './Utils/InstallIdUtilities';
 export * from './Utils/IIssueContext';
 export * from './Utils/IssueReporter';
 export * from './Utils/IVSCodeEnvironment';

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -121,7 +121,7 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
         const completedEvent = eventStream.events
             .find(event => event instanceof DotnetAcquisitionCompleted && (event as DotnetAcquisitionCompleted).install.installId === installId
                 && (event as DotnetAcquisitionCompleted).dotnetPath === expectedPath);
-        assert.exists(completedEvent, `The acquisition completed event appears for install key ${installId} and path ${expectedPath}`);
+        assert.exists(completedEvent, `The acquisition completed event appears for install id ${installId} and path ${expectedPath}`);
 
         //  Acquire got called with the correct args
         const acquireEvent = eventStream.events.find(event =>

--- a/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
@@ -17,7 +17,7 @@ const defaultInstall : DotnetInstall = {
     version: defaultVersion,
     isGlobal: false,
     architecture: os.arch(),
-    installKey: `${defaultVersion}~${os.arch()}`,
+    installId: `${defaultVersion}~${os.arch()}`,
     installMode: defaultMode
 }
 
@@ -25,7 +25,7 @@ const secondInstall : DotnetInstall = {
     version: secondVersion,
     isGlobal: false,
     architecture: os.arch(),
-    installKey: `${secondVersion}~${os.arch()}`,
+    installId: `${secondVersion}~${os.arch()}`,
     installMode: defaultMode
 }
 const defaultTimeoutTime = 5000;
@@ -173,7 +173,7 @@ suite('InstallTracker Unit Tests', () => {
         const validator = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);
 
         const extensionStateWithLegacyStrings = new MockExtensionContext();
-        extensionStateWithLegacyStrings.update('installed', [defaultInstall.installKey, secondInstall.installKey]);
+        extensionStateWithLegacyStrings.update('installed', [defaultInstall.installId, secondInstall.installId]);
         validator.setExtensionState(extensionStateWithLegacyStrings);
 
         const expected : InstallRecord[] = [
@@ -197,7 +197,7 @@ suite('InstallTracker Unit Tests', () => {
         const validator = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);
 
         const extensionStateWithLegacyStrings = new MockExtensionContext();
-        extensionStateWithLegacyStrings.update('installed', [defaultInstall.installKey, secondInstall.installKey]);
+        extensionStateWithLegacyStrings.update('installed', [defaultInstall.installId, secondInstall.installId]);
         validator.setExtensionState(extensionStateWithLegacyStrings);
 
         const expected : InstallRecord[] = [

--- a/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
@@ -167,7 +167,7 @@ suite('InstallTracker Unit Tests', () => {
 
     }).timeout(defaultTimeoutTime);
 
-    test('It Converts Legacy Install Key String to New Type with Null Owner', async () => {
+    test('It Converts Legacy Install Id String to New Type with Null Owner', async () => {
         resetExtensionState();
 
         const validator = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);

--- a/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -28,7 +28,7 @@ import {
   NoInstallAcquisitionInvoker,
   SdkInstallationDirectoryProvider,
   MockIndexWebRequestWorker,
-  getInstallKeyCustomArchitecture,
+  getInstallIdCustomArchitecture,
   IExistingPaths,
   getMockAcquisitionContext,
   getMockAcquisitionWorker,
@@ -98,11 +98,11 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     const dotnetDir = installDirectoryProvider.getInstallDir(version);
     const dotnetExePath = path.join(dotnetDir, `dotnet${os.platform() === 'win32' ? '.exe' : ''}`);
 
-    const sdkCurrentInstallKey = getInstallKeyCustomArchitecture(version, os.arch(), 'sdk', 'local');
-    const sdkDirCurrent = path.join(dotnetDir, 'sdk', sdkCurrentInstallKey);
+    const sdkCurrentInstallId = getInstallIdCustomArchitecture(version, os.arch(), 'sdk', 'local');
+    const sdkDirCurrent = path.join(dotnetDir, 'sdk', sdkCurrentInstallId);
 
-    const sdkEarlierInstallKey = getInstallKeyCustomArchitecture(earlierVersion, os.arch(), 'sdk', 'local');
-    const sdkDirEarlier = path.join(dotnetDir, 'sdk', sdkEarlierInstallKey);
+    const sdkEarlierInstallId = getInstallIdCustomArchitecture(earlierVersion, os.arch(), 'sdk', 'local');
+    const sdkDirEarlier = path.join(dotnetDir, 'sdk', sdkEarlierInstallId);
     fs.mkdirSync(sdkDirCurrent, { recursive: true });
     fs.mkdirSync(sdkDirEarlier, { recursive: true });
     fs.writeFileSync(dotnetExePath, '');
@@ -115,12 +115,12 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
       .filter(event => event instanceof DotnetPreinstallDetected)
       .map(event => event as DotnetPreinstallDetected);
     assert.equal(preinstallEvents.length, 2);
-    assert.exists(preinstallEvents.find(event => event.installKey.installKey === sdkCurrentInstallKey), 'The current sdk install key exists');
-    assert.exists(preinstallEvents.find(event => event.installKey.installKey === sdkEarlierInstallKey), 'The earlier sdk install key exists');
+    assert.exists(preinstallEvents.find(event => event.installId.installId === sdkCurrentInstallId), 'The current sdk install key exists');
+    assert.exists(preinstallEvents.find(event => event.installId.installId === sdkEarlierInstallId), 'The earlier sdk install key exists');
     const alreadyInstalledEvent = eventStream.events
       .find(event => event instanceof DotnetAcquisitionAlreadyInstalled) as DotnetAcquisitionAlreadyInstalled;
     assert.exists(alreadyInstalledEvent, 'An already installed event was posted');
-    assert.equal(alreadyInstalledEvent.install.installKey, sdkCurrentInstallKey, 'the current install is what was already installed');
+    assert.equal(alreadyInstalledEvent.install.installId, sdkCurrentInstallId, 'the current install is what was already installed');
 
     // Clean up storage
     rimraf.sync(dotnetDir);
@@ -134,7 +134,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     const mockContext = getMockAcquisitionContext('sdk', version, 10000, undefined, undefined, undefined, installDirectoryProvider);
     const acquisitionWorker = getMockAcquisitionWorker(mockContext);
 
-    const currentVersionInstallKey =  getInstallKeyCustomArchitecture(version, os.arch(), 'sdk', 'local');
+    const currentVersionInstallId =  getInstallIdCustomArchitecture(version, os.arch(), 'sdk', 'local');
     // Ensure nothing is returned when there is no preinstalled SDK
     const noPreinstallResult = await acquisitionWorker.acquireStatus(mockContext, 'sdk');
     assert.isUndefined(noPreinstallResult);
@@ -143,7 +143,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     const dotnetDir = installDirectoryProvider.getInstallDir(version);
     const dotnetExePath = path.join(dotnetDir, `dotnet${os.platform() === 'win32' ? '.exe' : ''}`);
 
-    const sdkDir50 = path.join(dotnetDir, 'sdk', currentVersionInstallKey);
+    const sdkDir50 = path.join(dotnetDir, 'sdk', currentVersionInstallId);
     fs.mkdirSync(sdkDir50, { recursive: true });
     fs.writeFileSync(dotnetExePath, '');
 


### PR DESCRIPTION
VS Code has a filter for the string 'key' -- this causes our telemetry to be dropped when referencing the term 'install key' as it thinks it may be a secret. https://github.com/microsoft/vscode/blob/48ba01b5896376718aa66a11c60305cb105815c0/src/vs/platform/telemetry/common/telemetryUtils.ts#L336

Id is safe. I talked with the vscode team and there is no good alternative besides turning off all telemetry safety scanning, which I didn't want to do.

Hence, 'key' --> 'id'