### PR TITLE
Try to find the .NET SDK PATH on Mac if it Installs to Unexpected Loc

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -417,7 +417,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         }
         catch(error : any)
         {
-            if(install.isGlobal && os.platform() === 'darwin')
+            if(os.platform() === 'darwin')
             {
                     const executor = new CommandExecutor(context, this.utilityContext);
                     const result = await executor.execute(CommandExecutor.makeCommand('which', ['dotnet']));

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
@@ -11,6 +11,7 @@ import {
 } from '../EventStream/EventStreamEvents';
 import { IInstallationValidator } from './IInstallationValidator';
 import { DotnetInstall } from './DotnetInstall';
+import { CommandExecutor } from '../Utils/CommandExecutor';
 
 export class InstallationValidator extends IInstallationValidator {
     public validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder = false): void {
@@ -41,7 +42,8 @@ export class InstallationValidator extends IInstallationValidator {
     }
 
     private assertOrThrowError(check: boolean, message: string, install: DotnetInstall, dotnetPath: string) {
-        if (!check) {
+        if (!check)
+        {
             this.eventStream.post(new DotnetInstallationValidationError(new Error(message), install, dotnetPath));
             throw new EventBasedError('DotnetInstallationValidationError', message);
         }


### PR DESCRIPTION
Our highest failure for .NET SDK Installs on Mac only is that the `InstallationValidator` which checks the hard-coded expected path of Installation does not find .NET in the expected location. Unfortunately, nobody has reported this so we can't get more info from them.

To get to this point in the code of `Validation`, everything has to have succeeded, including the installer only returning and exiting 0, which it would only do upon installation success.

I'm guessing there is some undocumented case where the .NET SDK is installed to a different location, but I couldn't find where.

Here is our path check. https://github.com/dotnet/vscode-dotnet-runtime/blob/main/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts#L239

According to the installer source code and our documentation, it should only install to this location or with x64 during emulation.
```
<PkgInstallDirectory>/usr/local/share/dotnet</PkgInstallDirectory>
      <x64EmulationPkgInstallDirectory>/usr/local/share/dotnet/x64</x64EmulationPkgInstallDirectory>
```

The 64 directory however, is only for when you install a 64-bit SDK on an ARM Mac. We wouldn't expect this to happen because we only install the SDK that matches os.platform(), so we should never install an x64 SDK on an ARM machine.

I'm curious to see where this path is and this will also help us track that. It's a bit of a hack, but I think it will have the desired outcome.