### PR TITLE
Version 2.1.1, Hot fix for installation record tracking

### DIFF
--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -33,7 +33,7 @@
 		},
 		"../vscode-dotnet-runtime-extension": {
 			"name": "vscode-dotnet-runtime",
-			"version": "2.1.0",
+			"version": "2.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/chai-as-promised": "^7.1.8",

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -1830,7 +1830,7 @@ util-deprecate@^1.0.1:
     fsevents "^2.3.3"
 
 "vscode-dotnet-runtime@file:../vscode-dotnet-runtime-extension":
-  version "2.1.0"
+  version "2.1.1"
   resolved "file:../vscode-dotnet-runtime-extension"
   dependencies:
     "@types/chai-as-promised" "^7.1.8"

--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## [2.1.1] - 2024-07-18
+
+Fixes a bug introduced in 2.1.0 where '.includes' would not exist.
+
 ## [2.1.0] - 2024-07-18
 
 Fixes a bug with permissions when running the .NET Installer.

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-dotnet-runtime",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-dotnet-runtime",
-			"version": "2.1.0",
+			"version": "2.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/chai-as-promised": "^7.1.8",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -13,7 +13,7 @@
 	"description": "This extension installs and manages different versions of the .NET SDK and Runtime.",
 	"appInsightsKey": "02dc18e0-7494-43b2-b2a3-18ada5fcb522",
 	"icon": "images/dotnetIcon.png",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"publisher": "ms-dotnettools",
 	"engines": {
 		"vscode": "^1.74.0"

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -316,7 +316,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
     private async checkForPartialInstalls(context: IAcquisitionWorkerContext, installId : DotnetInstall)
     {
         const installingVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls(false);
-        const partialInstall = installingVersions.some(x => x.dotnetInstall.installId === installId.installId);
+        const partialInstall = installingVersions?.some(x => x.dotnetInstall.installId === installId.installId);
 
         // Don't count it as partial if the promise is still being resolved.
         // The promises get wiped out upon reload, so we can check this.

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
@@ -15,6 +15,15 @@ export interface DotnetInstall {
     installMode: DotnetInstallMode;
 }
 
+export interface DotnetInstallWithKey
+{
+    installKey: string;
+    version: string;
+    architecture: string;
+    isGlobal: boolean;
+    installMode: DotnetInstallMode;
+}
+
 /**
  * @remarks
  * The id can be a type containing all of the information or the 'legacy' id which is a string that contains all of the information.

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallRecord.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallRecord.ts
@@ -3,7 +3,7 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
 
-import { DotnetInstall } from './DotnetInstall';
+import { DotnetInstall, DotnetInstallWithKey } from './DotnetInstall';
 
 /**
  * @remarks
@@ -27,9 +27,19 @@ export interface InstallRecord
     installingExtensions: InstallOwner[];
 }
 
+/**
+ * This is for when the installId was called installKey, which was changed to prevent telemetry filtering issues because of the word 'key' being
+ * a bad word for vscode.
+ */
+export interface InstallRecordWithKey
+{
+    dotnetInstall: DotnetInstallWithKey;
+    installingExtensions: InstallOwner[];
+}
+
 
 /**
  * @remarks
  * The record can be the type or it can be a 'legacy' record from old installs which is just a string with the install key.
  */
-export type InstallRecordOrStr = InstallRecord | string;
+export type InstallRecordOrStr = InstallRecord | string | InstallRecordWithKey;

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
@@ -26,6 +26,7 @@ import {
 } from '../EventStream/EventStreamEvents';
 import {
     DotnetInstall,
+    DotnetInstallWithKey,
     GetDotnetInstallInfo,
     InstallToStrings,
     IsEquivalentInstallation,
@@ -203,9 +204,24 @@ Installs: ${[...this.inProgressInstalls].map(x => x.dotnetInstall.installId).joi
                         } as InstallRecord
                     );
                 }
+                else if(install.dotnetInstall.hasOwnProperty('installKey'))
+                {
+                    convertedInstalls.push(
+                        {
+                            dotnetInstall: {
+                                installId: (install.dotnetInstall as DotnetInstallWithKey).installKey,
+                                version: install.dotnetInstall.version,
+                                architecture: install.dotnetInstall.architecture,
+                                isGlobal: install.dotnetInstall.isGlobal,
+                                installMode: install.dotnetInstall.installMode
+                            } as DotnetInstall,
+                            installingExtensions: install.installingExtensions,
+                        } as InstallRecord
+                    )
+                }
                 else
                 {
-                    convertedInstalls.push(install);
+                    convertedInstalls.push(install as InstallRecord);
                 }
             });
 

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -175,7 +175,7 @@ export class WebRequestWorker
         }
         catch(error : any)
         {
-            if(error?.message.contains('ENOSPC'))
+            if(error?.message?.contains('ENOSPC'))
             {
                 const err = new DiskIsFullError(new EventBasedError('DiskIsFullError',
 `You don't have enough space left on your disk to install the .NET SDK. Please clean up some space.`), getInstallFromContext(this.context));


### PR DESCRIPTION
We renamed our data structures in https://github.com/dotnet/vscode-dotnet-runtime/pull/1882 from 'key' to 'id' because the string 'key' is filtered out of all log events via vscode because 'key' looks like a secret. We did this in a rush and vendor testing did not have pre-existing machine state to realize the old data structure would still be in the local memory for pre-existing users. This we would cause a null reference exception on `.includes()`. This converts the data in memory to the new type.