### PR TITLE
Add API to uninstall just one runtime

### DIFF
--- a/pipeline-templates/package-vsix.yaml
+++ b/pipeline-templates/package-vsix.yaml
@@ -1,5 +1,6 @@
 parameters:
   pool: ''
+  SignType: ''
 
 jobs:
 - job: ${{ parameters.pool.os }}_Package
@@ -34,7 +35,7 @@ jobs:
         VERSION=`node -p "require('./package.json').version"`
       else
         VERSION_NUM=`node -p "require('./package.json').version"`
-        VERSION="$VERSION_NUM-alpha-$(Build.BuildId)"
+        VERSION="$VERSION_NUM"
       fi
       npm version $VERSION --allow-same-version
       echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
@@ -45,8 +46,23 @@ jobs:
       npm install rimraf --reg https://registry.npmjs.org/ --verbose
       npm install vsce -g --reg https://registry.npmjs.org/ --verbose
       vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn
+      cp $(package-name)-$(GetVersion.version).vsix ../packages
     displayName: 📦 Package Artifact
     workingDirectory: $(dir-name)
+  - task: UseDotNet@2
+    displayName: 🔮 Use .NET SDK
+    inputs:
+      packageType: sdk
+      useGlobalJson: true
+  - task: MicroBuildSigningPlugin@4
+    displayName: 🔧 Install MicroBuild Signing Plugin
+    inputs:
+      signType: ${{ parameters.SignType }}
+      zipSources: false
+    env:
+      TeamName: VS Core
+  - script: dotnet build msbuild/signVsix -v:normal
+    displayName: 🖊️ Sign VSIXes
   - task: CopyFiles@2
     displayName: '📩 Copy Artifact'
     inputs:

--- a/pipeline-templates/package-vsix.yaml
+++ b/pipeline-templates/package-vsix.yaml
@@ -1,6 +1,5 @@
 parameters:
   pool: ''
-  SignType: ''
 
 jobs:
 - job: ${{ parameters.pool.os }}_Package
@@ -35,7 +34,7 @@ jobs:
         VERSION=`node -p "require('./package.json').version"`
       else
         VERSION_NUM=`node -p "require('./package.json').version"`
-        VERSION="$VERSION_NUM"
+        VERSION="$VERSION_NUM-alpha-$(Build.BuildId)"
       fi
       npm version $VERSION --allow-same-version
       echo "##vso[task.setvariable variable=version;isOutput=true]$VERSION"
@@ -46,23 +45,8 @@ jobs:
       npm install rimraf --reg https://registry.npmjs.org/ --verbose
       npm install vsce -g --reg https://registry.npmjs.org/ --verbose
       vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn
-      cp $(package-name)-$(GetVersion.version).vsix ../packages
     displayName: 📦 Package Artifact
     workingDirectory: $(dir-name)
-  - task: UseDotNet@2
-    displayName: 🔮 Use .NET SDK
-    inputs:
-      packageType: sdk
-      useGlobalJson: true
-  - task: MicroBuildSigningPlugin@4
-    displayName: 🔧 Install MicroBuild Signing Plugin
-    inputs:
-      signType: ${{ parameters.SignType }}
-      zipSources: false
-    env:
-      TeamName: VS Core
-  - script: dotnet build msbuild/signVsix -v:normal
-    displayName: 🖊️ Sign VSIXes
   - task: CopyFiles@2
     displayName: '📩 Copy Artifact'
     inputs:

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -499,11 +499,11 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
     }
 
 
-    public async uninstallLocalRuntimeOrSDK(context: IAcquisitionWorkerContext, install : DotnetInstall)
+    public async uninstallLocalRuntimeOrSDK(context: IAcquisitionWorkerContext, install : DotnetInstall) : Promise<string>
     {
         if(install.isGlobal)
         {
-            return;
+            return '0';
         }
 
         try
@@ -522,13 +522,20 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
 
             graveyard.remove(install);
             context.eventStream.post(new DotnetInstallGraveyardEvent(`Success at uninstalling ${JSON.stringify(install)} in path ${dotnetInstallDir}`));
+            return '0';
         }
         catch(error : any)
         {
-            context.eventStream.post(new SuppressedAcquisitionError(error, `The attempt to uninstall .NET ${install} failed - was .NET in use?`))
+            context.eventStream.post(new SuppressedAcquisitionError(error, `The attempt to uninstall .NET ${install} failed - was .NET in use?`));
+            return error?.message ?? '1';
         }
     }
 
+    public async uninstallGlobal(context: IAcquisitionWorkerContext, install : DotnetInstall) : Promise<string>
+    {
+        // Do nothing right now. Add this in another PR.
+        return '1';
+    }
 
     private removeFolderRecursively(eventStream: IEventStream, folderPath: string) {
         eventStream.post(new DotnetAcquisitionDeletion(folderPath));

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -499,7 +499,7 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
     }
 
 
-    public async uninstallLocalRuntimeOrSDK(context: IAcquisitionWorkerContext, install : DotnetInstall) : Promise<string>
+    public async uninstallLocalRuntimeOrSDK(context: IAcquisitionWorkerContext, install : DotnetInstall, force = false) : Promise<string>
     {
         if(install.isGlobal)
         {
@@ -516,9 +516,9 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
 
             this.removeFolderRecursively(context.eventStream, dotnetInstallDir);
 
-            await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).untrackInstalledVersion(context, install);
+            await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).untrackInstalledVersion(context, install, force);
             // this is the only place where installed and installing could deal with pre existing installing id
-            await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).untrackInstallingVersion(context, install);
+            await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).untrackInstallingVersion(context, install, force);
 
             graveyard.remove(install);
             context.eventStream.post(new DotnetInstallGraveyardEvent(`Success at uninstalling ${JSON.stringify(install)} in path ${dotnetInstallDir}`));
@@ -531,7 +531,7 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
         }
     }
 
-    public async uninstallGlobal(context: IAcquisitionWorkerContext, install : DotnetInstall) : Promise<string>
+    public async uninstallGlobal(context: IAcquisitionWorkerContext, install : DotnetInstall, force = false) : Promise<string>
     {
         // Do nothing right now. Add this in another PR.
         return '1';

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
@@ -244,18 +244,18 @@ ${convertedInstalls.map(x => `${JSON.stringify(x.dotnetInstall)} owned by ${x.in
         await this.trackInstalledVersion(context, install);
     }
 
-    public async untrackInstallingVersion(context : IAcquisitionWorkerContext, install : DotnetInstall)
+    public async untrackInstallingVersion(context : IAcquisitionWorkerContext, install : DotnetInstall, force = false)
     {
-        await this.removeVersionFromExtensionState(context, this.installingVersionsId, install);
+        await this.removeVersionFromExtensionState(context, this.installingVersionsId, install, force);
         this.removePromise(install);
     }
 
-    public async untrackInstalledVersion(context : IAcquisitionWorkerContext, install : DotnetInstall)
+    public async untrackInstalledVersion(context : IAcquisitionWorkerContext, install : DotnetInstall, force = false)
     {
-        await this.removeVersionFromExtensionState(context, this.installedVersionsId, install);
+        await this.removeVersionFromExtensionState(context, this.installedVersionsId, install, force);
     }
 
-    protected async removeVersionFromExtensionState(context : IAcquisitionWorkerContext, idStr: string, installIdObj: DotnetInstall)
+    protected async removeVersionFromExtensionState(context : IAcquisitionWorkerContext, idStr: string, installIdObj: DotnetInstall, forceUninstall = false)
     {
         return this.executeWithLock( false, async (id: string, install: DotnetInstall) =>
         {
@@ -275,12 +275,13 @@ ${convertedInstalls.map(x => `${JSON.stringify(x.dotnetInstall)} owned by ${x.in
 
                 const preExistingRecord = installRecord.at(0);
                 const owners = preExistingRecord?.installingExtensions.filter(x => x !== context.acquisitionContext?.requestingExtensionId);
-                if((owners?.length ?? 0) < 1)
+                if(forceUninstall || (owners?.length ?? 0) < 1)
                 {
                     // There are no more references/extensions that depend on this install, so remove the install from the list entirely.
                     // For installing versions, there should only ever be 1 owner.
                     // For installed versions, there can be N owners.
-                    this.eventStream.post(new RemovingExtensionFromList(`The last owner ${context.acquisitionContext?.requestingExtensionId} removed ${JSON.stringify(install)} entirely from the state.`));
+                    this.eventStream.post(new RemovingExtensionFromList(forceUninstall ? `At the request of ${context.acquisitionContext?.requestingExtensionId}, we force uninstalled ${JSON.stringify(install)}.` :
+                        `The last owner ${context.acquisitionContext?.requestingExtensionId} removed ${JSON.stringify(install)} entirely from the state.`));
                     await this.extensionState.update(id, existingInstalls.filter(x => !IsEquivalentInstallation(x.dotnetInstall, install)));
                 }
                 else

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
@@ -164,6 +164,18 @@ Installs: ${[...this.inProgressInstalls].map(x => x.dotnetInstall.installId).joi
         }, installId);
     }
 
+    public async canUninstall(isFinishedInstall : boolean, dotnetInstall : DotnetInstall) : Promise<boolean>
+    {
+        return this.executeWithLock( false, async (id: string, install: DotnetInstall) =>
+        {
+            this.eventStream.post(new RemovingVersionFromExtensionState(`Removing ${JSON.stringify(install)} with id ${id} from the state.`));
+            const existingInstalls = await this.getExistingInstalls(id === this.installedVersionsId, true);
+            const installRecord = existingInstalls.filter(x => IsEquivalentInstallation(x.dotnetInstall, install));
+
+            return installRecord.length === 0 || installRecord[0].installingExtensions.length === 0;
+        }, isFinishedInstall ? this.installedVersionsId : this.installingVersionsId, dotnetInstall);
+    }
+
     public async uninstallAllRecords() : Promise<void>
     {
         return this.executeWithLock( false, async () =>

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -436,6 +436,10 @@ export class DotnetNotInstallRelatedCommandFailed extends DotnetNonAcquisitionEr
         }
 }
 
+export class InvalidUninstallRequest extends DotnetNonAcquisitionError {
+    public readonly eventName = 'InvalidUninstallRequest';
+}
+
 export class DotnetCommandFailed extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetCommandFailed';
 

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -197,7 +197,7 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
         assert.equal(events.length, 1);
     }
 
-    async function acquireAndUninstall(version : string, mode : DotnetInstallMode, type : DotnetInstallType)
+    async function acquireAndUninstallAll(version : string, mode : DotnetInstallMode, type : DotnetInstallType)
     {
         const [eventStream, extContext] = setupStates();
         const ctx = getMockAcquisitionContext(mode, version, expectedTimeoutTime, eventStream, extContext);
@@ -281,17 +281,17 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function () {
 
     test('Acquire Runtime and UninstallAll', async () =>
     {
-        await acquireAndUninstall('1.0', 'runtime', 'local');
+        await acquireAndUninstallAll('1.0', 'runtime', 'local');
     }).timeout(expectedTimeoutTime);
 
     test('Acquire ASP.NET and UninstallAll', async () =>
     {
-        await acquireAndUninstall('1.0', 'aspnetcore', 'local');
+        await acquireAndUninstallAll('1.0', 'aspnetcore', 'local');
     }).timeout(expectedTimeoutTime);
 
     test('Acquire SDK and UninstallAll', async () =>
     {
-        await acquireAndUninstall('6.0', 'sdk', 'local');
+        await acquireAndUninstallAll('6.0', 'sdk', 'local');
     }).timeout(expectedTimeoutTime);
 
     test('Graveyard Removes Failed Uninstalls', async () => {

--- a/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -299,7 +299,11 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.exists(result, 'basic install works');
     assert.exists(result!.dotnetPath, 'basic install has path');
     let sdkDirs = fs.readdirSync(path.join(path.dirname(result!.dotnetPath), 'sdk'));
-    assert.isNotEmpty(sdkDirs.filter(dir => dir.includes(version)), 'sdk directories include version');
+    assert.isNotEmpty(sdkDirs.filter(dir => dir.includes(version)), `sdk directories include version?
+PATH: ${result!.dotnetPath}
+PATH SUBDIRECTORIES: ${fs.readdirSync(path.dirname(result!.dotnetPath))}
+SDK SUBDIRECTORIES: ${sdkDirs}
+VERSION: ${version}`);
 
     // Install 5.0
     version = '5.0';


### PR DESCRIPTION
The existing API surface only allowed uninstallation of ALL runtimes.
This `uninstall` API currently only works with local installs but it will be expanded to allow global ones.
We can enforce more strict checking in the api caller request since it's not going to break anything.

`force` was added as a later option for when we allow users to force override and uninstall a version even if other extensions still depend on the installation.