### PR TITLE
Allow detecting pre existing global installs

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -323,6 +323,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             {
                 if(!(await this.sdkIsFound(context, context.acquisitionContext.version)))
                 {
+                    InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).untrackInstalledVersion(context, install);
                     return null;
                 }
             }
@@ -418,7 +419,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         context.eventStream.post(new DotnetGlobalVersionResolutionCompletionEvent(`The version we resolved that was requested is: ${installingVersion}.`));
         this.checkForPartialInstalls(context, install);
 
-        let installedVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls(true);
+        const installedVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls(true);
 
         const installer : IGlobalInstaller = os.platform() === 'linux' ?
             new LinuxGlobalInstaller(context, this.utilityContext, installingVersion) :

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -272,18 +272,10 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
                 context.extensionState).checkForUnrecordedLocalSDKSuccessfulInstall(context, dotnetInstallDir, installedVersions);
         }
 
-        if (installedVersions.some(x => IsEquivalentInstallation(x.dotnetInstall, install) && (fs.existsSync(dotnetPath) || this.usingNoInstallInvoker)))
+        const existingInstall = await this.getExistingInstall(context, installedVersions, install, dotnetPath);
+        if(existingInstall)
         {
-            // Version requested has already been installed.
-            // We don't do this check with global acquisition, since external sources can more easily tamper with installs.
-            context.installationValidator.validateDotnetInstall(install, dotnetPath);
-
-            context.eventStream.post(new DotnetAcquisitionAlreadyInstalled(install,
-                (context.acquisitionContext && context.acquisitionContext.requestingExtensionId)
-                ? context.acquisitionContext.requestingExtensionId : null));
-
-            await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).trackInstalledVersion(context, install);
-            return dotnetPath;
+            return existingInstall;
         }
 
         // We update the extension state to indicate we're starting a .NET Core installation.
@@ -311,6 +303,52 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).reclassifyInstallingVersionToInstalled(context, install);
 
         return dotnetPath;
+    }
+
+    private async getExistingInstall(context: IAcquisitionWorkerContext, installedVersions : InstallRecord[], install : DotnetInstall, dotnetPath : string) : Promise<string | null>
+    {
+        if (installedVersions.some(x => IsEquivalentInstallation(x.dotnetInstall, install) && (fs.existsSync(dotnetPath) || this.usingNoInstallInvoker)))
+        {
+            // Version requested has already been installed.
+            try
+            {
+                context.installationValidator.validateDotnetInstall(install, dotnetPath, false, false);
+            }
+            catch(error : any)
+            {
+                return null;
+            }
+
+            if(context.acquisitionContext.installType === 'global')
+            {
+                if(!(await this.sdkIsFound(context, context.acquisitionContext.version)))
+                {
+                    return null;
+                }
+            }
+
+            context.eventStream.post(new DotnetAcquisitionAlreadyInstalled(install,
+                (context.acquisitionContext && context.acquisitionContext.requestingExtensionId)
+                ? context.acquisitionContext.requestingExtensionId : null));
+
+            await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).trackInstalledVersion(context, install);
+            return dotnetPath;
+        }
+        return null;
+    }
+
+    private async sdkIsFound(context : IAcquisitionWorkerContext, version : string) : Promise<boolean>
+    {
+        const executor = new CommandExecutor(context, this.utilityContext);
+        const listSDKsCommand = CommandExecutor.makeCommand('dotnet', ['--list-sdks']);
+        const result = await executor.execute(listSDKsCommand, null, false);
+
+        if(result.status !== '0')
+        {
+            return false;
+        }
+
+        return result.stdout.includes(version);
     }
 
     private async checkForPartialInstalls(context: IAcquisitionWorkerContext, installId : DotnetInstall)
@@ -380,12 +418,11 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         context.eventStream.post(new DotnetGlobalVersionResolutionCompletionEvent(`The version we resolved that was requested is: ${installingVersion}.`));
         this.checkForPartialInstalls(context, install);
 
+        let installedVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls(true);
+
         const installer : IGlobalInstaller = os.platform() === 'linux' ?
             new LinuxGlobalInstaller(context, this.utilityContext, installingVersion) :
             new WinMacGlobalInstaller(context, this.utilityContext, installingVersion, await globalInstallerResolver.getInstallerUrl(), await globalInstallerResolver.getInstallerHash());
-
-        await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).trackInstallingVersion(context, install);
-        context.eventStream.post(new DotnetAcquisitionStarted(install, installingVersion, context.acquisitionContext.requestingExtensionId));
 
         // See if we should return a fake path instead of running the install
         if(process.env.VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH && process.env.VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH === 'true')
@@ -393,6 +430,17 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
             context.eventStream.post(new DotnetFakeSDKEnvironmentVariableTriggered(`VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH has been set.`));
             return 'fake-sdk';
         }
+
+        let dotnetPath : string = await installer.getExpectedGlobalSDKPath(installingVersion,
+            context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture));
+        const existingInstall = await this.getExistingInstall(context, installedVersions, install, dotnetPath);
+        if(existingInstall)
+        {
+            return existingInstall;
+        }
+
+        context.eventStream.post(new DotnetAcquisitionStarted(install, installingVersion, context.acquisitionContext.requestingExtensionId));
+        await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).trackInstallingVersion(context, install);
 
         context.eventStream.post(new DotnetBeginGlobalInstallerExecution(`Beginning to run installer for ${JSON.stringify(install)} in ${os.platform()}.`))
         const installerResult = await installer.installSDK(install);
@@ -407,14 +455,11 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
             throw err;
         }
 
-        let installedSDKPath : string = await installer.getExpectedGlobalSDKPath(installingVersion,
-            context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture));
-
         TelemetryUtilities.setDotnetSDKTelemetryToMatch(context.isExtensionTelemetryInitiallyEnabled, this.extensionContext, context, this.utilityContext);
 
         try
         {
-            context.installationValidator.validateDotnetInstall(install, installedSDKPath, os.platform() !== 'win32');
+            context.installationValidator.validateDotnetInstall(install, dotnetPath, os.platform() !== 'win32');
         }
         catch(error : any)
         {
@@ -425,7 +470,7 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
                     if(result.status === '0')
                     {
                         context.eventStream.post(new DotnetInstallationValidated(install));
-                        installedSDKPath = result.stdout;
+                        dotnetPath = result.stdout;
                     }
                     else
                     {
@@ -437,12 +482,12 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
             throw error;
         }
 
-        context.eventStream.post(new DotnetAcquisitionCompleted(install, installedSDKPath, installingVersion));
+        context.eventStream.post(new DotnetAcquisitionCompleted(install, dotnetPath, installingVersion));
 
         await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).reclassifyInstallingVersionToInstalled(context, install);
 
         context.eventStream.post(new DotnetGlobalAcquisitionCompletionEvent(`The version ${JSON.stringify(install)} completed successfully.`));
-        return installedSDKPath;
+        return dotnetPath;
     }
 
     /**

--- a/vscode-dotnet-runtime-library/src/Acquisition/IInstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IInstallationValidator.ts
@@ -9,5 +9,5 @@ import { DotnetInstall } from './DotnetInstall';
 export abstract class IInstallationValidator {
     constructor(protected readonly eventStream: IEventStream) {}
 
-    public abstract validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder? : boolean): void;
+    public abstract validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder? : boolean, failOnErr? : boolean): void;
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -388,6 +388,10 @@ export class UserManualInstallFailure extends SuppressedAcquisitionError {
     eventName = 'UserManualInstallFailure';
 }
 
+export class DotnetInstallationValidationMissed extends SuppressedAcquisitionError {
+    eventName = 'DotnetInstallationValidationMissed';
+}
+
 export class OSXOpenNotAvailableError extends DotnetAcquisitionError {
     public readonly eventName = 'OSXOpenNotAvailableError';
 }


### PR DESCRIPTION
For https://github.com/dotnet/vscode-dotnet-runtime/issues/1625

A global .NET SDK installation can be uninstalled externally. We keep track of installs but we need to handle when they are uninstalled externally and remove their record. When we do this, we can also trust our record keeping better to prevent having to do extra work to check if the installation needs to be done again by relying on our records.

Checked:
If uninstalling SDK by program files without using the extension, the extension can still detect the SDK no longer exists even if it has a record for it. The screenshot shows the records and that it attempted to install despite having the record.
![image](https://github.com/user-attachments/assets/9f3a440c-2d02-46a8-8cd7-81b0aa14a237)
