### PR TITLE
Fix offline detection

### DIFF
--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -68,7 +68,7 @@
 				"run-script-os": "^1.1.6",
 				"semver": "^7.6.2",
 				"shelljs": "^0.8.5",
-				"typescript": "4.4.4",
+				"typescript": "^5.5.4",
 				"vscode-extension-telemetry": "^0.4.3",
 				"vscode-test": "^1.6.1"
 			},
@@ -5553,7 +5553,7 @@
 				"run-script-os": "^1.1.6",
 				"semver": "^7.6.2",
 				"shelljs": "^0.8.5",
-				"typescript": "4.4.4",
+				"typescript": "^5.5.4",
 				"vscode-extension-telemetry": "^0.4.3",
 				"vscode-test": "^1.6.1"
 			}

--- a/vscode-dotnet-runtime-extension/yarn.lock
+++ b/vscode-dotnet-runtime-extension/yarn.lock
@@ -1882,7 +1882,7 @@ util-deprecate@~1.0.1:
     run-script-os "^1.1.6"
     semver "^7.6.2"
     shelljs "^0.8.5"
-    typescript "4.4.4"
+    typescript "^5.5.4"
     vscode-extension-telemetry "^0.4.3"
     vscode-test "^1.6.1"
   optionalDependencies:

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -501,10 +501,10 @@ export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionErr
 
     public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return this.install ? {ErrorMessage : this.error.message,
-            AcquisitionErrorInstallId : this.install?.installId ?? 'null',
-             ...InstallToStrings(this.install),
+            AcquisitionErrorInstallId : this.install.installId ?? 'null',
+            ...InstallToStrings(this.install),
             ErrorName : this.error.name,
-            StackTrace : this.error.stack ? this.error.stack : ''}
+            StackTrace : this.error.stack ?? ''}
             :
             {ErrorMessage : this.error.message,
                 AcquisitionErrorInstallId : 'null',

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -388,6 +388,10 @@ export class UserManualInstallFailure extends SuppressedAcquisitionError {
     eventName = 'UserManualInstallFailure';
 }
 
+export class OffilneDetectionLogicTriggered extends SuppressedAcquisitionError {
+    eventName = 'OffilneDetectionLogicTriggered';
+}
+
 export class DotnetInstallationValidationMissed extends SuppressedAcquisitionError {
     eventName = 'DotnetInstallationValidationMissed';
 }
@@ -496,11 +500,16 @@ export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionErr
     }
 
     public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        return {ErrorMessage : this.error.message,
+        return this.install ? {ErrorMessage : this.error.message,
             AcquisitionErrorInstallId : this.install?.installId ?? 'null',
-            ...InstallToStrings(this.install!),
+             ...InstallToStrings(this.install),
             ErrorName : this.error.name,
-            StackTrace : this.error.stack ? this.error.stack : ''};
+            StackTrace : this.error.stack ? this.error.stack : ''}
+            :
+            {ErrorMessage : this.error.message,
+                AcquisitionErrorInstallId : 'null',
+                ErrorName : this.error.name,
+                StackTrace : this.error.stack ? this.error.stack : ''};
         }
     }
 

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -509,7 +509,7 @@ export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionErr
             {ErrorMessage : this.error.message,
                 AcquisitionErrorInstallId : 'null',
                 ErrorName : this.error.name,
-                StackTrace : this.error.stack ? this.error.stack : ''};
+                StackTrace : this.error.stack ?? ''};
         }
     }
 

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -12,7 +12,6 @@ import * as fs from 'fs';
 import { promisify } from 'util';
 import stream = require('stream');
 
-
 import { IAcquisitionWorkerContext } from '../Acquisition/IAcquisitionWorkerContext';
 import { IEventStream } from '../EventStream/EventStream';
 import {

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -107,12 +107,12 @@ export class WebRequestWorker
 
     public static async isOnline(timeoutSec : number, eventStream : IEventStream) : Promise<boolean>
     {
-        const googleDNS = 'www.microsoft.com';
+        const microsoftServer = 'www.microsoft.com';
         const expectedDNSResolutionTimeMs = Math.max(timeoutSec * 100, 100); // Assumption: DNS resolution should take less than 1/10 of the time it'd take to download .NET.
         // ... 100 ms is there as a default to prevent the dns resolver from throwing a runtime error if the user sets timeoutSeconds to 0.
 
         const dnsResolver = new dns.promises.Resolver({ timeout: expectedDNSResolutionTimeMs });
-        const couldConnect = await dnsResolver.resolve(googleDNS).then(() =>
+        const couldConnect = await dnsResolver.resolve(microsoftServer).then(() =>
         {
             return true;
         }).catch((error : any) =>

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -15,7 +15,17 @@ import stream = require('stream');
 
 import { IAcquisitionWorkerContext } from '../Acquisition/IAcquisitionWorkerContext';
 import { IEventStream } from '../EventStream/EventStream';
-import {DiskIsFullError, DotnetDownloadFailure, DotnetOfflineFailure, EventBasedError, EventCancellationError, OffilneDetectionLogicTriggered, SuppressedAcquisitionError, WebRequestError, WebRequestSent } from '../EventStream/EventStreamEvents';
+import {
+    DiskIsFullError,
+    DotnetDownloadFailure,
+    DotnetOfflineFailure,
+    EventBasedError,
+    EventCancellationError,
+    OffilneDetectionLogicTriggered,
+    SuppressedAcquisitionError,
+    WebRequestError,
+    WebRequestSent
+} from '../EventStream/EventStreamEvents';
 import { getInstallFromContext } from './InstallIdUtilities';
 /* tslint:disable:no-any */
 

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -7,13 +7,16 @@ import axiosRetry from 'axios-retry';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { getProxySettings } from 'get-proxy-settings';
 import { AxiosCacheInstance, buildMemoryStorage, setupCache } from 'axios-cache-interceptor';
-import {DiskIsFullError, DotnetDownloadFailure, EventBasedError, SuppressedAcquisitionError, WebRequestError, WebRequestSent } from '../EventStream/EventStreamEvents';
-import { getInstallFromContext } from './InstallIdUtilities';
-
+import * as dns from 'dns';
 import * as fs from 'fs';
 import { promisify } from 'util';
 import stream = require('stream');
+
+
 import { IAcquisitionWorkerContext } from '../Acquisition/IAcquisitionWorkerContext';
+import { IEventStream } from '../EventStream/EventStream';
+import {DiskIsFullError, DotnetDownloadFailure, DotnetOfflineFailure, EventBasedError, EventCancellationError, OffilneDetectionLogicTriggered, SuppressedAcquisitionError, WebRequestError, WebRequestSent } from '../EventStream/EventStreamEvents';
+import { getInstallFromContext } from './InstallIdUtilities';
 /* tslint:disable:no-any */
 
 export class WebRequestWorker
@@ -72,9 +75,15 @@ export class WebRequestWorker
             throw new EventBasedError('AxiosGetFailedWithInvalidURL', `Request to the url ${this.url} failed, as the URL is invalid.`);
         }
         const timeoutCancelTokenHook = new AbortController();
-        const timeout = setTimeout(() =>
+        const timeout = setTimeout(async () =>
         {
             timeoutCancelTokenHook.abort();
+            if(!(await WebRequestWorker.isOnline(this.websiteTimeoutMs / 1000, this.context.eventStream)))
+            {
+                const offlineError = new EventBasedError('DotnetOfflineFailure', 'No internet connection detected: Cannot install .NET');
+                this.context.eventStream.post(new DotnetOfflineFailure(offlineError, null));
+                throw offlineError;
+            }
             const formattedError = new Error(`TIMEOUT: The request to ${this.url} timed out at ${this.websiteTimeoutMs} ms. This only occurs if your internet
  or the url are experiencing connection difficulties; not if the server is being slow to respond. Check your connection, the url, and or increase the timeout value here: https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md#install-script-timeouts`);
             this.context.eventStream.post(new WebRequestError(new EventBasedError('WebRequestError', formattedError.message, formattedError.stack), null));
@@ -95,6 +104,24 @@ export class WebRequestWorker
         return this.makeWebRequest(true, retriesCount);
     }
 
+
+    public static async isOnline(timeoutSec : number, eventStream : IEventStream) : Promise<boolean>
+    {
+        const googleDNS = 'www.microsoft.com';
+        const expectedDNSResolutionTimeMs = Math.max(timeoutSec * 100, 100); // Assumption: DNS resolution should take less than 1/10 of the time it'd take to download .NET.
+        // ... 100 ms is there as a default to prevent the dns resolver from throwing a runtime error if the user sets timeoutSeconds to 0.
+
+        const dnsResolver = new dns.promises.Resolver({ timeout: expectedDNSResolutionTimeMs });
+        const couldConnect = await dnsResolver.resolve(googleDNS).then(() =>
+        {
+            return true;
+        }).catch((error : any) =>
+        {
+            eventStream.post(new OffilneDetectionLogicTriggered((error as EventCancellationError), `DNS resolution failed at microsoft.com, ${JSON.stringify(error)}.`));
+            return false;
+        });
+        return couldConnect;
+    }
     /**
      *
      * @param urlInQuestion


### PR DESCRIPTION
8.8.8.8 blocks our requests. We can use microsoft.com instead, if our app is checking using microsoft, well, if microsoft is down we've learned that the app will have problems anyways , so if that is down it doesnt matter as much.
for https://github.com/dotnet/vscode-dotnet-runtime/issues/1850 

aspnet 2.0 is unavailable from the web server. this shows me plugging the internet off and plugging back in to see the detection works properly for the user is offline vs the file dne on web server. 
![image](https://github.com/user-attachments/assets/7115a60c-c9ea-4813-92c4-bb9da6411876)
