### PR TITLE
Fix ARM64 Installation Windows Detection Logic

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -133,7 +133,7 @@ This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/is
                 }
                 const err = new DotnetConflictingGlobalWindowsInstallError(new EventCancellationError(
                     'DotnetConflictingGlobalWindowsInstallError',
-                    `An global install is already on the machine: version ${conflictingVersion}, that conflicts with the requested version.
+                    `A global install is already on the machine: version ${conflictingVersion}, that conflicts with the requested version.
                     Please uninstall this version first if you would like to continue.
                     If Visual Studio is installed, you may need to use the VS Setup Window to uninstall the SDK component.`), getInstallFromContext(this.acquisitionContext));
                 this.acquisitionContext.eventStream.post(err);

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -452,9 +452,10 @@ Permissions: ${JSON.stringify(await this.commandRunner.execute(CommandExecutor.m
         {
             const sdkInstallRecords64Bit = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\dotnet\\Setup\\InstalledVersions\\x64\\sdk';
             const sdkInstallRecords32Bit = sdkInstallRecords64Bit.replace('x64', 'x86');
+            const sdkInstallRecordsArm64 = sdkInstallRecords64Bit.replace('x64', 'arm64');
 
-            const queries = [sdkInstallRecords32Bit, sdkInstallRecords64Bit];
-            for ( const query of queries)
+            const queries = [sdkInstallRecords32Bit, sdkInstallRecords64Bit, sdkInstallRecordsArm64];
+            for ( const query of queries )
             {
                 try
                 {


### PR DESCRIPTION
.NET can be installed with a different registry key https://github.com/dotnet/sdk/blob/main/src/Installer/redist-installer/packaging/windows/bundle.wxs#L111 using arm64, as found in this code, which we didn't know about. 

There are already tests for x64 vs x86 installations and when one exists but the other doesn't. These tests use mock registry output query values. Adding arm64 would not really increase the coverage, so I have not edited those tests.

for https://github.com/dotnet/vscode-dotnet-runtime/issues/1566.