### PR TITLE
Fix parsing `-preview` versions in the registry when installed via Visual Studio

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/VersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/VersionResolver.ts
@@ -255,7 +255,7 @@ export class VersionResolver implements IVersionResolver {
      */
     private getPatchVersionString(fullySpecifiedVersion : string) : string
     {
-        const patch : string | undefined = fullySpecifiedVersion.split('.')?.at(2)?.substring(1).split('-')?.at(0);
+        const patch : string | undefined = fullySpecifiedVersion.split('.')?.at(2)?.substring(1)?.split('-')?.at(0);
         if(patch === undefined || !this.isNumber(patch))
         {
             const event = new DotnetFeatureBandDoesNotExistError(new EventCancellationError('DotnetFeatureBandDoesNotExistError',

--- a/vscode-dotnet-runtime-library/src/Acquisition/VersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/VersionResolver.ts
@@ -255,7 +255,7 @@ export class VersionResolver implements IVersionResolver {
      */
     private getPatchVersionString(fullySpecifiedVersion : string) : string
     {
-        const patch : string | undefined = fullySpecifiedVersion.split('.')?.at(2)?.substring(1);
+        const patch : string | undefined = fullySpecifiedVersion.split('.')?.at(2)?.substring(1).split('-')?.at(0);
         if(patch === undefined || !this.isNumber(patch))
         {
             const event = new DotnetFeatureBandDoesNotExistError(new EventCancellationError('DotnetFeatureBandDoesNotExistError',

--- a/vscode-dotnet-runtime-library/src/test/unit/VersionResolver.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/VersionResolver.test.ts
@@ -85,6 +85,10 @@ suite('VersionResolver Unit Tests', () => {
         assert.equal(resolver.getFeatureBandPatchVersion(twoDigitPatchVersion), '21');
     });
 
+    test('Get Patch from SDK Preview Version', async () => {
+        assert.equal(resolver.getFeatureBandPatchVersion('8.0.400-preview.0.24324.5'), '0');
+    });
+
     test('Detects Unspecified Patch Version', async () => {
         assert.equal(resolver.isNonSpecificFeatureBandedVersion(fullySpecifiedVersion), false, 'It detects versions with patches');
         assert.equal(resolver.isNonSpecificFeatureBandedVersion(featureBandVersion), true, 'It detects versions with xx');


### PR DESCRIPTION
This issue is pointed out to me by @webreidi and became visible today.

Internal Visual Studio build 17.11.04 shipped with a preview `SDK 8,0.400-preview.0`.
This does not impact customers but impacts internal people who try to install using our tool.
Our logic worked for preview SDKs installed by users but not the ones installed by Visual Studio.

When opening up the registry to check if we needed to do this installation, we would see the version as `8.0.400-preview.0` and try to cast `400-preview` to a number. This would fail and we would not install the SDK.

We can fix this in several ways. One way is to improve some logic around parsing the preview text, but that text is not necessary to handle. So instead, we can just trim out the -preview text and cause it to work.

Before 
![image](https://github.com/user-attachments/assets/9b07e595-94b8-47e4-bbc7-dd1547fc71e6)

After
![image](https://github.com/user-attachments/assets/01474326-608a-416f-8079-35dea90313f1)

