### PR TITLE
Fix MicroBuild Staging

### DIFF
--- a/1pr-azure-pipeline.yml
+++ b/1pr-azure-pipeline.yml
@@ -55,6 +55,12 @@ stages:
       useOneEngineeringPool: false
   - template: pipeline-templates/lint.yaml
     parameters:
+    pool:
+      vmImage: windows-latest
+      os: windows
+    useOneEngineeringPool: false
+  - template: pipeline-templates/package-vsix.yaml
+    parameters:
       pool:
         vmImage: windows-latest
         os: windows

--- a/1pr-azure-pipeline.yml
+++ b/1pr-azure-pipeline.yml
@@ -55,10 +55,10 @@ stages:
       useOneEngineeringPool: false
   - template: pipeline-templates/lint.yaml
     parameters:
-    pool:
-      vmImage: windows-latest
-      os: windows
-    useOneEngineeringPool: false
+      pool:
+        vmImage: windows-latest
+        os: windows
+      useOneEngineeringPool: false
   - template: pipeline-templates/package-vsix.yaml
     parameters:
       pool:

--- a/pipeline-templates/install-node.yaml
+++ b/pipeline-templates/install-node.yaml
@@ -3,3 +3,5 @@ steps:
   inputs:
     version: '20.x'
   displayName: '⚛️ Install Node.js'
+  templateContext:
+  outputs:

--- a/pipeline-templates/install-node.yaml
+++ b/pipeline-templates/install-node.yaml
@@ -3,5 +3,3 @@ steps:
   inputs:
     version: '20.x'
   displayName: '⚛️ Install Node.js'
-  templateContext:
-  outputs:

--- a/pipeline-templates/package-vsix.yaml
+++ b/pipeline-templates/package-vsix.yaml
@@ -42,7 +42,7 @@ jobs:
     name: GetVersion
     displayName: '❓ Get Version'
     workingDirectory: $(dir-name)
-  - ${{ if and(succeeded(), eq('${{ parameters.useOneEngineeringPool }}', 'true')) }}:
+  - ${{ if eq('${{ parameters.useOneEngineeringPool }}', 'true') }}:
     - template: prepare-signing.yaml
       parameters:
         SignType: ${{ parameters.SignType }}

--- a/pipeline-templates/package-vsix.yaml
+++ b/pipeline-templates/package-vsix.yaml
@@ -45,6 +45,7 @@ jobs:
   - template: prepare-signing.yaml
     parameters:
       SignType: ${{ parameters.SignType }}
+    condition: and(succeeded(), eq('${{ parameters.useOneEngineeringPool }}', 'true'))
   - bash: |
       npm install rimraf --reg https://registry.npmjs.org/ --verbose
       npm install @vscode/vsce@latest -g --reg https://registry.npmjs.org/ --verbose

--- a/pipeline-templates/package-vsix.yaml
+++ b/pipeline-templates/package-vsix.yaml
@@ -42,10 +42,10 @@ jobs:
     name: GetVersion
     displayName: '❓ Get Version'
     workingDirectory: $(dir-name)
-  - template: prepare-signing.yaml
-    parameters:
-      SignType: ${{ parameters.SignType }}
-    condition: and(succeeded(), eq('${{ parameters.useOneEngineeringPool }}', 'true'))
+  - ${{ if and(succeeded(), eq('${{ parameters.useOneEngineeringPool }}', 'true')) }}:
+    - template: prepare-signing.yaml
+      parameters:
+        SignType: ${{ parameters.SignType }}
   - bash: |
       npm install rimraf --reg https://registry.npmjs.org/ --verbose
       npm install @vscode/vsce@latest -g --reg https://registry.npmjs.org/ --verbose

--- a/pipeline-templates/package-vsix.yaml
+++ b/pipeline-templates/package-vsix.yaml
@@ -42,24 +42,9 @@ jobs:
     name: GetVersion
     displayName: '❓ Get Version'
     workingDirectory: $(dir-name)
-  - task: UseDotNet@2
-    displayName: 🔮 Use .NET SDK
-    inputs:
-      packageType: sdk
-      useGlobalJson: true
-  # This is necessary whenever we want to publish/restore to an AzDO private feed
-  # otherwise it'll complain about accessing a private feed.
-  - task: NuGetAuthenticate@1
-    displayName: '🔏 Authenticate to AzDO Feeds'
-  - task: MicroBuildSigningPlugin@4
-    displayName: 🔧 Install MicroBuild Signing Plugin
-    inputs:
-      signType: ${{ parameters.SignType }}
-      zipSources: false
-      feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-    env:
+  - template: prepare-signing.yaml
+    parameters:
       SignType: ${{ parameters.SignType }}
-      TeamName: DotNetCore
   - bash: |
       npm install rimraf --reg https://registry.npmjs.org/ --verbose
       npm install @vscode/vsce@latest -g --reg https://registry.npmjs.org/ --verbose

--- a/pipeline-templates/prepare-signing.yaml
+++ b/pipeline-templates/prepare-signing.yaml
@@ -1,0 +1,19 @@
+steps:
+  - task: UseDotNet@2
+    displayName: 🔮 Use .NET SDK
+    inputs:
+      packageType: sdk
+      useGlobalJson: true
+  # This is necessary whenever we want to publish/restore to an AzDO private feed
+  # otherwise it'll complain about accessing a private feed.
+  - task: NuGetAuthenticate@1
+    displayName: '🔏 Authenticate to AzDO Feeds'
+  - task: MicroBuildSigningPlugin@4
+    displayName: 🔧 Install MicroBuild Signing Plugin
+    inputs:
+      signType: ${{ parameters.SignType }}
+      zipSources: false
+      feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+    env:
+      SignType: ${{ parameters.SignType }}
+      TeamName: DotNetCore


### PR DESCRIPTION
Microbuild is not signed correctly. It is getting pushed to staging and failing out build internally after https://github.com/dotnet/vscode-dotnet-runtime/pull/1885. Our signing is working. Microbuild team is aware and working on a fix.

We need to isolate these steps out and put the pack back into public. Then we can not stage microbuild to not trigger their problems in our repo.