### PR TITLE
Don't set HOME environment variable

### DIFF
--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -17,6 +17,8 @@ Adds API for extensions to uninstall a singular runtime rather than all runtimes
 
 Adds offline support so existing installations can be found when offline.
 
+Prevents a dependency from setting HOME environment variable causing git and git related extensions to no longer work.
+
 Adds additional signatures to the release.
 
 Fixes 'Lock' acquisition issues.

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -5,7 +5,18 @@
 import Axios, { AxiosError, isAxiosError } from 'axios';
 import axiosRetry from 'axios-retry';
 import { HttpsProxyAgent } from 'https-proxy-agent';
+
+process.env.VSCODE_DOTNET_INSTALL_TOOL_ORIGINAL_HOME = process.env.HOME
+// IMPORTING THIS LIBRARY SETS 'HOME' VARIABLE
+// Causing Git to BREAK!
 import { getProxySettings } from 'get-proxy-settings';
+// NODE JS CASTS UNDEFINED ENV VAR TO STRING 'undefined'
+process.env.HOME = process.env.VSCODE_DOTNET_INSTALL_TOOL_ORIGINAL_HOME === 'undefined' ? '' : process.env.VSCODE_DOTNET_INSTALL_TOOL_ORIGINAL_HOME
+if(process.env.HOME === '')
+{
+    delete process.env.HOME
+}
+
 import { AxiosCacheInstance, buildMemoryStorage, setupCache } from 'axios-cache-interceptor';
 import * as dns from 'dns';
 import * as fs from 'fs';

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -11,10 +11,13 @@ process.env.VSCODE_DOTNET_INSTALL_TOOL_ORIGINAL_HOME = process.env.HOME
 // Causing Git to BREAK!
 import { getProxySettings } from 'get-proxy-settings';
 // NODE JS CASTS UNDEFINED ENV VAR TO STRING 'undefined'
-process.env.HOME = process.env.VSCODE_DOTNET_INSTALL_TOOL_ORIGINAL_HOME === 'undefined' ? '' : process.env.VSCODE_DOTNET_INSTALL_TOOL_ORIGINAL_HOME
-if(process.env.HOME === '')
+if (process.env.VSCODE_DOTNET_INSTALL_TOOL_ORIGINAL_HOME === 'undefined')
 {
     delete process.env.HOME
+}
+else
+{
+    process.env.HOME = process.env.VSCODE_DOTNET_INSTALL_TOOL_ORIGINAL_HOME
 }
 
 import { AxiosCacheInstance, buildMemoryStorage, setupCache } from 'axios-cache-interceptor';


### PR DESCRIPTION
On Activation our Extension sets the HOME variable causing Git to no longer function.

Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1795 
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1400
Resolves  https://github.com/dotnet/vscode-dotnet-runtime/issues/1686 
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1707
Resolves  https://github.com/dotnet/vscode-dotnet-runtime/issues/1916

This import statement in our code on `WebRequestWorker.ts` sets HOME.

```js
const get_proxy_settings_1 = require("get-proxy-settings");
```

How do I know? I used the SysInternals Process Explorer to read the environment for every vscode sub process and went through the decompiled JS line by line in a binary search to see which line of code causes HOME to change 🥱 

![image](https://github.com/user-attachments/assets/589927c4-7226-4306-b779-c0b07fc640fe)

HOME is no longer changed.

This is definitely one of the weirdest bugs Ive had to solve.... seriously. We checked the source code this library and they dont edit HOME either, probably their 1 of dependencies does. But it doesn't really matter. 