### PR TITLE
Handle .NET Failed: Undefined

### DIFF
--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorker.ts
@@ -225,7 +225,7 @@ export class WebRequestWorker
         }
         catch(error : any)
         {
-            if(error && error?.message && (error?.message as string)?.includes('ENOSPC'))
+            if(error?.message && (error?.message as string)?.includes('ENOSPC'))
             {
                 const err = new DiskIsFullError(new EventBasedError('DiskIsFullError',
 `You don't have enough space left on your disk to install the .NET SDK. Please clean up some space.`), getInstallFromContext(this.context));

--- a/vscode-dotnet-runtime.code-workspace
+++ b/vscode-dotnet-runtime.code-workspace
@@ -16,7 +16,8 @@
     "settings": {
         "cSpell.words": [
             "DOTNETINSTALLMODELIST",
-            "Republisher"
+            "Republisher",
+            "unlocalized"
         ]
     }
 }


### PR DESCRIPTION
Rejecting a promise with a rejected promise as a return value from a function does not reject with the object the inner promise rejected with. Instead it rejects with an undefined value.

This means if the SDK installer fails or we fail to elevate, that counts as .NET Install failed: undefined. This fixes this. It also adds a check for the string error as this seems to happen sometimes if the password prompt is rejected.

How to test this? Set a break point in win mac global installer on the execute install and edit the command to point to a non existent file. It will then fail and you can see it works now.