### PR TITLE
Quote the Installer Path

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -385,7 +385,7 @@ Please correct your PATH variable or make sure the 'open' utility is installed s
             }
             else if(workingCommand.commandRoot === 'command')
             {
-                workingCommand = CommandExecutor.makeCommand(`open`, [`-W`, `${path.resolve(installerPath)}`]);
+                workingCommand = CommandExecutor.makeCommand(`open`, [`-W`, `"${path.resolve(installerPath)}"`]);
             }
 
             this.acquisitionContext.eventStream.post(new NetInstallerBeginExecutionEvent(`The OS X .NET Installer has been launched.`));
@@ -399,7 +399,7 @@ Please correct your PATH variable or make sure the 'open' utility is installed s
         }
         else
         {
-            const command = `${path.resolve(installerPath)}`;
+            const command = `"${path.resolve(installerPath)}"`;
             let commandOptions : string[] = [];
             if(this.file.isElevated(this.acquisitionContext.eventStream))
             {

--- a/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
@@ -143,12 +143,15 @@ suite('Windows & Mac Global Installer Tests', () =>
 
         if(os.platform() === 'darwin')
         {
-            assert.isTrue(mockExecutor.attemptedCommand.startsWith('open'), `It ran the right mac command, open. Command found: ${mockExecutor.attemptedCommand}`)
-            assert.isTrue(mockExecutor.attemptedCommand.includes('-W'), 'It used the -W flag')
+            assert.isTrue(mockExecutor.attemptedCommand.startsWith('open'), `It ran the right mac command, open. Command found: ${mockExecutor.attemptedCommand}`);
+            assert.isTrue(mockExecutor.attemptedCommand.includes('-W'), 'It used the -W flag');
+            assert.isTrue(mockExecutor.attemptedCommand.includes('"'), 'It put the installer in quotes for username with space in it');
         }
         else if(os.platform() === 'win32')
         {
-            assert.isTrue(fs.existsSync(mockExecutor.attemptedCommand.split(' ')[0]), 'It ran a command to an executable that exists');
+            const path = mockExecutor.attemptedCommand.split(' ')[0].slice(1, -1);
+            assert.isTrue(fs.existsSync(path), `It ran a command to an executable that exists: ${path}`);
+            assert.isTrue(mockExecutor.attemptedCommand.includes('"'), 'It put the installer in quotes for username with space in it');
             if(new FileUtilities().isElevated())
             {
                 assert.include(mockExecutor.attemptedCommand, ' /quiet /install /norestart', 'It ran under the hood if it had privileges already');

--- a/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
@@ -149,8 +149,8 @@ suite('Windows & Mac Global Installer Tests', () =>
         }
         else if(os.platform() === 'win32')
         {
-            const path = mockExecutor.attemptedCommand.split(' ')[0].slice(1, -1);
-            assert.isTrue(fs.existsSync(path), `It ran a command to an executable that exists: ${path}`);
+            const returnedPath = mockExecutor.attemptedCommand.split(' ')[0].slice(1, -1);
+            assert.isTrue(fs.existsSync(returnedPath), `It ran a command to an executable that exists: ${returnedPath}`);
             assert.isTrue(mockExecutor.attemptedCommand.includes('"'), 'It put the installer in quotes for username with space in it');
             if(new FileUtilities().isElevated())
             {


### PR DESCRIPTION
Resolves https://github.com/microsoft/vscode-dotnettools/issues/1429

Encase the installer path in quotes to protect against spaces in usernames etc being parsed poorly, and other path issues. Don't know why we didnt do this before.