### PR TITLE
Improve ARM Mac Path Check

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -360,7 +360,7 @@ If you were waiting for the install to succeed, please extend the timeout settin
         const arm64EmulationHostPath = path.resolve(`/usr/local/share/dotnet/x64/dotnet`);
 
         const findTrueArchCommand = CommandExecutor.makeCommand(`uname`, [`-p`]);
-        if((os.arch() === 'x64' || os.arch() === 'ia32') && (await this.commandRunner.execute(findTrueArchCommand, null, false)).stdout.toLowerCase().includes('arm'))
+        if((os.arch() === 'x64' || os.arch() === 'ia32') && (await this.commandRunner.execute(findTrueArchCommand, null, false)).stdout.toLowerCase().includes('arm') && (fs.existsSync(arm64EmulationHostPath) || !macPathShouldExist))
         {
             // VS Code runs on an emulated version of node which will return x64 or use x86 emulation for ARM devices.
             // os.arch() returns the architecture of the node binary, not the system architecture, so it will not report arm on an arm device.

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -359,7 +359,8 @@ If you were waiting for the install to succeed, please extend the timeout settin
         const standardHostPath = path.resolve(`/usr/local/share/dotnet/dotnet`);
         const arm64EmulationHostPath = path.resolve(`/usr/local/share/dotnet/x64/dotnet`);
 
-        if((os.arch() === 'x64' || os.arch() === 'ia32') && (await this.commandRunner.execute(CommandExecutor.makeCommand(`uname`, [`-p`]), null, false)).stdout.includes('arm'))
+        const findTrueArchCommand = CommandExecutor.makeCommand(`uname`, [`-p`]);
+        if((os.arch() === 'x64' || os.arch() === 'ia32') && (await this.commandRunner.execute(findTrueArchCommand, null, false)).stdout.toLowerCase().includes('arm'))
         {
             // VS Code runs on an emulated version of node which will return x64 or use x86 emulation for ARM devices.
             // os.arch() returns the architecture of the node binary, not the system architecture, so it will not report arm on an arm device.


### PR DESCRIPTION
Just as https://github.com/dotnet/vscode-dotnet-runtime/pull/1932 automerged I got some help getting a Mac. 

Here is the conclusion:
VS Code runs on an emulated version of node which will return x64 or use x86 emulation for ARM devices.
os.arch() returns the architecture of the node binary, not the system architecture, so it will not report arm on an arm device.

This is why I've added the additional check below using `uname` which will report the correct architecture that's not being emulated on.

`uname` is a bit costly so we don't need to use it everywhere. Btw, if this command fails because someone removed `uname` from their system, it will just use the existing fallback logic, which is why I've kept it in place. (Believe me, people do some weird system alterations like that...)

Final note:

The .NET SDK can be not under emulation when node is. That is an important caveat, even though all installs this extension makes will be under emulation since node will be, that does not mean existing installs from other sources will be. We can deal with this by checking if the path exists, if we'd expect it to exist when looking for existing installs.