### PR TITLE
Add await that eslint asked to remove

### DIFF
--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -54,6 +54,7 @@
 				"@types/vscode": "1.74.0",
 				"@vscode/extension-telemetry": "^0.9.7",
 				"@vscode/sudo-prompt": "^9.3.1",
+				"@vscode/test-electron": "^2.4.1",
 				"axios": "^1.7.4",
 				"axios-cache-interceptor": "^1.5.3",
 				"axios-retry": "^3.4.0",
@@ -69,8 +70,7 @@
 				"run-script-os": "^1.1.6",
 				"semver": "^7.6.2",
 				"shelljs": "^0.8.5",
-				"typescript": "^5.5.4",
-				"vscode-test": "^1.6.1"
+				"typescript": "^5.5.4"
 			},
 			"devDependencies": {
 				"@types/chai": "4.2.22",

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -337,7 +337,7 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
     });
 
     const dotnetAcquireStatusRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquireStatus}`, async (commandContext: IDotnetAcquireContext) => {
-        const pathResult = callWithErrorHandling(async () =>
+        const pathResult = await callWithErrorHandling(async () =>
         {
             const mode = commandContext.mode ?? 'runtime' as DotnetInstallMode;
             const worker = getAcquisitionWorker();

--- a/vscode-dotnet-runtime-extension/yarn.lock
+++ b/vscode-dotnet-runtime-extension/yarn.lock
@@ -1933,6 +1933,7 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
     "@types/vscode" "1.74.0"
     "@vscode/extension-telemetry" "^0.9.7"
     "@vscode/sudo-prompt" "^9.3.1"
+    "@vscode/test-electron" "^2.4.1"
     axios "^1.7.4"
     axios-cache-interceptor "^1.5.3"
     axios-retry "^3.4.0"
@@ -1949,7 +1950,6 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
     semver "^7.6.2"
     shelljs "^0.8.5"
     typescript "^5.5.4"
-    vscode-test "^1.6.1"
   optionalDependencies:
     fsevents "^2.3.3"
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/ExistingPathResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/ExistingPathResolver.ts
@@ -127,18 +127,18 @@ export class ExistingPathResolver
 
     private async getSDKs(existingPath : string) : Promise<IDotnetListInfo[]>
     {
-        const findSDKsCommand = CommandExecutor.makeCommand(existingPath, ['--list-sdks']);
+        const findSDKsCommand = CommandExecutor.makeCommand(`"${existingPath}"`, ['--list-sdks']);
 
         const sdkInfo = await (this.executor!).execute(findSDKsCommand).then((result) =>
             {
-                const runtimes = result.stdout.split('\n').map((line) => line.trim()).filter((line) => line.length > 0);
-                const runtimeInfos : IDotnetListInfo[] = runtimes.map((sdk) =>
+                const sdks = result.stdout.split('\n').map((line) => line.trim()).filter((line) => line.length > 0);
+                const sdkInfos : IDotnetListInfo[] = sdks.map((sdk) =>
                 {
                     if(sdk === '') // new line in output that got trimmed
                     {
                         return null;
                     }
-                    const parts = sdk.split(' ', 2); // account for spaces in PATH, no space should appear before then and luckily path is last
+                    const parts = sdk.split(' ', 2); // account for spaces in PATH, no space should appear before then
                     return {
                         mode: 'sdk',
                         version: parts[0],
@@ -146,7 +146,7 @@ export class ExistingPathResolver
                     } as IDotnetListInfo;
                 }).filter(x => x !== null) as IDotnetListInfo[];
 
-                return runtimeInfos;
+                return sdkInfos;
             });
 
             return sdkInfo;
@@ -154,7 +154,7 @@ export class ExistingPathResolver
 
     private async getRuntimes(existingPath : string) : Promise<IDotnetListInfo[]>
     {
-        const findRuntimesCommand = CommandExecutor.makeCommand(existingPath, ['--list-runtimes']);
+        const findRuntimesCommand = CommandExecutor.makeCommand(`"${existingPath}"`, ['--list-runtimes']);
 
         const windowsDesktopString = 'Microsoft.WindowsDesktop.App';
         const aspnetCoreString = 'Microsoft.AspNetCore.App';
@@ -169,7 +169,7 @@ export class ExistingPathResolver
                 {
                     return null;
                 }
-                const parts = runtime.split(' ', 3); // account for spaces in PATH, no space should appear before then and luckily path is last
+                const parts = runtime.split(' ', 3); // account for spaces in PATH, no space should appear before then
                 return {
                     mode: parts[0] === aspnetCoreString ? 'aspnetcore' : parts[0] === runtimeString ? 'runtime' : 'sdk', // sdk is a placeholder for windows desktop, will never match since this is for runtime search only
                     version: parts[1],

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDotnetInstallationContext.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDotnetInstallationContext.ts
@@ -15,4 +15,3 @@ export interface IDotnetInstallationContext {
     installType : DotnetInstallType;
     architecture: string;
 }
-7

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDotnetInstallationContext.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDotnetInstallationContext.ts
@@ -15,3 +15,4 @@ export interface IDotnetInstallationContext {
     installType : DotnetInstallType;
     architecture: string;
 }
+7

--- a/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
@@ -53,11 +53,12 @@ Our CDN may be blocked in China or experience significant slowdown, in which cas
 
 let showMessage = true;
 
-export function callWithErrorHandling<T>(callback: () => T, context: IIssueContext, requestingExtensionId?: string, acquireContext? : IAcquisitionWorkerContext): T | undefined {
+export async function callWithErrorHandling<T>(callback: () => T, context: IIssueContext, requestingExtensionId?: string, acquireContext? : IAcquisitionWorkerContext): Promise<T | undefined> {
     const isAcquisitionError = acquireContext ? true : false;
     try
     {
-        const result = callback();
+        /* eslint-disable @typescript-eslint/await-thenable */
+        const result = await callback();
         context.eventStream.post(new DotnetCommandSucceeded(context.commandName));
         return result;
     }

--- a/vscode-dotnet-sdk-extension/src/extension.ts
+++ b/vscode-dotnet-sdk-extension/src/extension.ts
@@ -141,7 +141,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
         const acquisitionContext = getContext(commandContext);
         const versionResolver = new VersionResolver(acquisitionContext);
 
-        const pathResult = callWithErrorHandling(async () => {
+        const pathResult = await callWithErrorHandling(async () => {
             eventStream.post(new DotnetSDKAcquisitionStarted(commandContext.requestingExtensionId));
 
             eventStream.post(new DotnetAcquisitionRequested(commandContext.version, commandContext.requestingExtensionId ?? 'notProvided', 'sdk', 'local'));
@@ -185,7 +185,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
     });
 
     const dotnetAcquireStatusRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.acquireStatus}`, async (commandContext: IDotnetAcquireContext) => {
-        const pathResult = callWithErrorHandling(async () => {
+        const pathResult = await callWithErrorHandling(async () => {
             eventStream.post(new DotnetAcquisitionStatusRequested(commandContext.version, commandContext.requestingExtensionId));
             const fakeContext = getContext(null);
             const versionResolver = new VersionResolver(fakeContext);


### PR DESCRIPTION
# Change 1 
TS Lint failed this await because `Unexpected `await` of a non-Promise (non-"Thenable") value`.
But the callback can be a promise type. Its just not smart enough to realize that.
The callback can be any function. Which can be async. So it needs to be awaited.

This causes : https://github.com/dotnet/vscode-dotnet-runtime/issues/1956
Fixed and tested before and after. Will confirm with vendors.

# Change 2 
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1953
We need to encase the path in quotes. I forgot to do this again 🙄 