### PR TITLE
Branding for version 2.2.0

### DIFF
--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -33,7 +33,7 @@
 		},
 		"../vscode-dotnet-runtime-extension": {
 			"name": "vscode-dotnet-runtime",
-			"version": "2.1.7",
+			"version": "2.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/chai-as-promised": "^7.1.8",

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -1830,7 +1830,7 @@ util-deprecate@^1.0.1:
     fsevents "^2.3.3"
 
 "vscode-dotnet-runtime@file:../vscode-dotnet-runtime-extension":
-  version "2.1.7"
+  version "2.2.0"
   resolved "file:../vscode-dotnet-runtime-extension"
   dependencies:
     "@types/chai-as-promised" "^7.1.8"

--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
-## [2.1.7] - 2024-09-31
+## [2.2.0] - 2024-10-15
+
+Fixes an issue parsing other regional characters with the dotnet.findPath() API.
+
+## [2.1.7] - 2024-09-30
 
 Adds the API dotnet.findPath() to see if there's an existing .NET installation on the PATH.
 

--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning].
 
 ## [2.2.0] - 2024-10-15
 
+Adds ability to install the runtime via the `package.json` file of an extension. See the documentation/commands.md section.
 Fixes an issue parsing other regional characters with the dotnet.findPath() API.
+
 
 ## [2.1.7] - 2024-09-30
 

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-dotnet-runtime",
-	"version": "2.1.7",
+	"version": "2.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-dotnet-runtime",
-			"version": "2.1.7",
+			"version": "2.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/chai-as-promised": "^7.1.8",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -13,7 +13,7 @@
 	"description": "This extension installs and manages different versions of the .NET SDK and Runtime.",
 	"connectionString": "InstrumentationKey=02dc18e0-7494-43b2-b2a3-18ada5fcb522;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/;ApplicationId=e8e56970-a18a-4101-b7d1-1c5dd7c29eeb",
 	"icon": "images/dotnetIcon.png",
-	"version": "2.1.7",
+	"version": "2.2.0",
 	"publisher": "ms-dotnettools",
 	"engines": {
 		"vscode": "^1.81.1"


### PR DESCRIPTION
Bumping to a new minor version considering the stabilization of the new dotnet find path API and introduction of JSON parsing https://github.com/dotnet/vscode-dotnet-runtime/pull/1976.

The branch name is wrong; we should do a new minor version, considering we've made minor changes following semver policy to add a new API.

https://www.geeksforgeeks.org/introduction-semantic-versioning/