### PR TITLE
Exclude Microbuild from scanner

### DIFF
--- a/1es-azure-pipeline.yml
+++ b/1es-azure-pipeline.yml
@@ -24,6 +24,8 @@ variables:
   value: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/SDK-v')]
 - name: Codeql.Enabled
   value: true
+- name: MicroBuildOutputFolderOverride
+  value: '$(Agent.TempDirectory)'
 
 resources:
   repositories:


### PR DESCRIPTION
Microbuild is failing credscan following TSA upload. It has several issues and the pipeline is publishing artifacts to the root artifacts staging directory and CredScan is considering everything under that path as part of the pipeline output. MicroBuild is being installed there, so it is incorrectly being brought into the scan.

This repo does not own microbuild, we only do it for signing.

See that cred scan no longer shows up in internal
![image](https://github.com/user-attachments/assets/9d1a092e-04d4-4ef4-8092-4ed297e9589c)
