### PR TITLE
Make all mkdirSync calls use the recursive option

### DIFF
--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -132,7 +132,7 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
     // Reading Extension Configuration
     const timeoutValue = extensionConfiguration.get<number>(configKeys.installTimeoutValue);
     if (!fs.existsSync(vsCodeContext.globalStoragePath)) {
-        fs.mkdirSync(vsCodeContext.globalStoragePath);
+        fs.mkdirSync(vsCodeContext.globalStoragePath, {recursive: true});
     }
     const resolvedTimeoutSeconds = timeoutValue === undefined ? defaultTimeoutValue : timeoutValue;
     const proxyLink = extensionConfiguration.get<string>(configKeys.proxyUrl);

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamRegistration.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamRegistration.ts
@@ -39,7 +39,7 @@ export function registerEventStream(context: IEventStreamContext, extensionConte
     const outputChannel = vscode.window.createOutputChannel(context.displayChannelName);
     if (!fs.existsSync(context.logPath))
     {
-        fs.mkdirSync(context.logPath);
+        fs.mkdirSync(context.logPath, {recursive: true});
     }
 
     const logFile = path.join(context.logPath, `DotNetAcquisition-${context.extensionId}-${ new Date().getTime() }.txt`);

--- a/vscode-dotnet-sdk-extension/src/extension.ts
+++ b/vscode-dotnet-sdk-extension/src/extension.ts
@@ -118,7 +118,7 @@ export function activate(context: vscode.ExtensionContext, extensionContext?: IE
     } else {
         storagePath = path.join(os.homedir(), '.vscode-dotnet-sdk');
         if (!fs.existsSync(storagePath)) {
-            fs.mkdirSync(storagePath);
+            fs.mkdirSync(storagePath, {recursive: true});
         }
     }
 


### PR DESCRIPTION
By passing recursive:true to all mkdirSync calls we protected against issues that may arise from parent directories not already existing.

Fix #1985