### PR TITLE
Suppress Noisy Telemetry Events

### DIFF
--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -748,6 +748,11 @@ export class DotnetFileIntegrityFailureEvent extends DotnetVisibleWarningEvent {
 
 export class DotnetVersionCategorizedEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetVersionCategorizedEvent';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class DuplicateInstallDetected extends DotnetCustomMessageEvent {
@@ -782,17 +787,37 @@ export class ConvertingLegacyInstallRecord extends DotnetCustomMessageEvent {
 }
 export class FoundTrackingVersions extends DotnetCustomMessageEvent {
     public readonly eventName = 'FoundTrackingVersions';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 export class RemovingVersionFromExtensionState extends DotnetCustomMessageEvent {
     public readonly eventName = 'RemovingVersionFromExtensionState';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class RemovingExtensionFromList extends DotnetCustomMessageEvent {
     public readonly eventName = 'RemovingExtensionFromList';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class RemovingOwnerFromList extends DotnetCustomMessageEvent {
     public readonly eventName = 'RemovingOwnerFromList';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class SkipAddingInstallEvent extends DotnetCustomMessageEvent {
@@ -801,10 +826,20 @@ export class SkipAddingInstallEvent extends DotnetCustomMessageEvent {
 
 export class AddTrackingVersions extends DotnetCustomMessageEvent {
     public readonly eventName = 'AddTrackingVersions';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class DotnetWSLCheckEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetWSLCheckEvent';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class DotnetWSLOperationOutputEvent extends DotnetCustomMessageEvent {
@@ -878,6 +913,11 @@ export class DotnetTelemetrySettingEvent extends DotnetCustomMessageEvent {
 
 export class DotnetVSCodeExtensionFound extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetVSCodeExtensionFound';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class DotnetVSCodeExtensionHasInstallRequest extends DotnetCustomMessageEvent {
@@ -886,6 +926,11 @@ export class DotnetVSCodeExtensionHasInstallRequest extends DotnetCustomMessageE
 
 export class DotnetVSCodeExtensionChange extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetVSCodeExtensionChange';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class DotnetCommandNotFoundEvent extends DotnetCustomMessageEvent {
@@ -957,6 +1002,11 @@ export class DotnetGlobalAcquisitionCompletionEvent extends DotnetCustomMessageE
 }
 export class DotnetInstallGraveyardEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetInstallGraveyardEvent';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class DotnetAlternativeCommandFoundEvent extends DotnetCustomMessageEvent {
@@ -973,6 +1023,11 @@ export class DotnetCommandFallbackOSEvent extends DotnetCustomMessageEvent {
 
 export class DotnetInstallIdCreatedEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetInstallIdCreatedEvent';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class DotnetLegacyInstallDetectedEvent extends DotnetCustomMessageEvent {
@@ -1111,10 +1166,20 @@ export abstract class DotnetLockEvent extends DotnetFileEvent
 
 export class DotnetLockAcquiredEvent extends DotnetLockEvent {
     public readonly eventName = 'DotnetLockAcquiredEvent';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class DotnetLockReleasedEvent extends DotnetLockEvent {
     public readonly eventName = 'DotnetLockReleasedEvent';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class DotnetLockErrorEvent extends DotnetLockEvent {
@@ -1130,10 +1195,20 @@ export class DotnetLockErrorEvent extends DotnetLockEvent {
 
 export class DotnetLockAttemptingAcquireEvent extends DotnetLockEvent {
     public readonly eventName = 'DotnetLockAttemptingAcquireEvent';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class DotnetFileWriteRequestEvent extends DotnetFileEvent {
     public readonly eventName = 'DotnetFileWriteRequestEvent';
+
+    public getProperties()
+    {
+        return {suppressTelemetry : 'true', ...super.getProperties()};
+    }
 }
 
 export class DotnetAcquisitionPartialInstallation extends DotnetAcquisitionMessage {

--- a/vscode-dotnet-runtime-library/src/EventStream/TelemetryObserver.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/TelemetryObserver.ts
@@ -69,6 +69,14 @@ export class TelemetryObserver implements IEventStreamObserver {
         if(TelemetryUtilities.isTelemetryEnabled(this.isExtensionTelemetryEnabled, this.utilityContext))
         {
             const properties = event.getSanitizedProperties(); // Get properties that don't contain personally identifiable data
+
+            // Certain events get sent way too often (ex: 700 million locks acquired over a few months which is causing problems for the data team) and aren't useful for telemetry.
+            // We allow suppressing certain events before even hitting the data ingestion service by doing a check here.
+            if(properties && properties?.suppressTelemetry === 'true')
+            {
+                return;
+            }
+
             if (!properties) {
                 this.telemetryReporter.sendTelemetryEvent(event.eventName);
             } else if (event.isError) {


### PR DESCRIPTION
Certain events get sent way too often (ex: 700 million locks acquired over a few months which is causing problems for the data team) and aren't useful for telemetry.

We allow suppressing certain events before even hitting the data ingestion service by doing a check here.

![image](https://github.com/user-attachments/assets/732a4ce3-b18d-458f-8a33-6886779532ad)

As you can see in the prod dev build, the correct events are ignored.