### PR TITLE
Show Cancellation Style Errors

### DIFF
--- a/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
@@ -98,7 +98,7 @@ export async function callWithErrorHandling<T>(callback: () => T, context: IIssu
                         }
                     }, timeoutConstants.moreInfoOption);
             }
-            else if (!isCancellationStyleError(error) && showMessage)
+            else if (showMessage)
             {
                 let errorOptions = [errorConstants.reportOption, errorConstants.hideOption, errorConstants.moreInfoOption];
                 if (requestingExtensionId)


### PR DESCRIPTION
I made a change a while back such that 'cancelled request' style errors dont cause a pop up because I figured they were not useful. The vendors reported it as a bug. Do you think we should keep a pop up for those types of errors?

The types of errors include: entered a bad version, you cancelled the password prompt or admin prompt, you have a custom linux install or conflicting feeds, your distro is not supported, etc

Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1826

If this is closed, close this issue.
Waiting for PM feedback on @baronfel. I think we can display it.

Extensions can set errorConfiguration in the acquire context
```ts
export declare enum AcquireErrorConfiguration {
    DisplayAllErrorPopups = 0,
    DisableErrorPopups = 1
}
```
to ignore this. I believe @dibarbet may have asked for this at some point?

Before 
![image](https://github.com/user-attachments/assets/aeb23857-0343-4dfc-a489-8b80471f1414)

After
![image](https://github.com/user-attachments/assets/bcbdde6d-5d0d-444c-97a1-f0ca152c5e63)
