### PR TITLE
Add back output for uninstall in the terminal

### DIFF
--- a/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
@@ -15,6 +15,7 @@ import {
     DotnetInstallExpectedAbort,
     DotnetOfflineInstallUsed,
     DotnetOfflineWarning,
+    DotnetUninstallStarted,
     DotnetUpgradedEvent,
     DotnetVisibleWarningEvent,
 } from './EventStreamEvents';
@@ -133,6 +134,9 @@ export class OutputChannelObserver implements IEventStreamObserver {
             case EventType.OfflineWarning:
                 const offlineWarning = event as DotnetOfflineWarning;
                 this.outputChannel.appendLine(offlineWarning.eventMessage);
+            case EventType.DotnetUninstallMessage:
+                const uninstallMessage = event as DotnetCustomMessageEvent;
+                this.outputChannel.appendLine(uninstallMessage.eventMessage);
         }
     }
 

--- a/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
@@ -15,7 +15,6 @@ import {
     DotnetInstallExpectedAbort,
     DotnetOfflineInstallUsed,
     DotnetOfflineWarning,
-    DotnetUninstallStarted,
     DotnetUpgradedEvent,
     DotnetVisibleWarningEvent,
 } from './EventStreamEvents';


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1920

There used to be this code to print a message to the terminal when an uninstall is going on. It got deleted at some point.

![image](https://github.com/user-attachments/assets/04c37f56-ace2-4a43-94ed-a92d02970965)
It's working now.