### PR TITLE
Test for Vendors: Don't acquire 2.X ASPNET Runtimes

### DIFF
--- a/sample/package.json
+++ b/sample/package.json
@@ -53,7 +53,7 @@
 			},
 			{
 				"command": "sample.dotnet.concurrentASPNETTest",
-				"title": "Concurrently acquire all 2.X ASPNET Core runtimes",
+				"title": "Concurrently acquire ASPNET Core runtimes",
 				"category": "Sample"
 			},
 			{

--- a/sample/src/extension.ts
+++ b/sample/src/extension.ts
@@ -158,7 +158,8 @@ ${stderr}`);
     });
 
     const sampleConcurrentASPNETTest = vscode.commands.registerCommand('sample.dotnet.concurrentASPNETTest', async () => {
-        await acquireConcurrent(['2.0', '2.1', '2.2'], 'aspnetcore');
+        acquireConcurrent(['6.0', '8.0', '7.0'], 'runtime') // start this so we test concurrent types of runtime installs
+        await acquireConcurrent(['6.0', '8.0', '7.0'], 'aspnetcore');
     });
 
     const sampleShowAcquisitionLogRegistration = vscode.commands.registerCommand('sample.dotnet.showAcquisitionLog', async () => {


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1850

2.0, 2.1, etc were never available on the server hosting download files for .NET and we don't need to support that. This updates the sample test for vendors to run to use versions of aspnet that are supported so this test actually functions properly.