### PR TITLE
Consider when the user Cancels the SDK Installer on Mac

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -505,35 +505,8 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
         dotnetPath = await installer.getExpectedGlobalSDKPath(installingVersion,
             context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture));
 
-        try
-        {
-            context.installationValidator.validateDotnetInstall(install, dotnetPath, os.platform() !== 'win32');
-        }
-        catch(error : any)
-        {
-            if(os.platform() === 'darwin')
-            {
-                    const executor = new CommandExecutor(context, this.utilityContext);
-                    const result = await executor.execute(CommandExecutor.makeCommand('which', ['dotnet']));
-                    if(result?.status === '0')
-                    {
-                        context.eventStream.post(new DotnetInstallationValidated(install));
-                        dotnetPath = result.stdout;
-                    }
-                    else
-                    {
-                        // Remove this when https://github.com/typescript-eslint/typescript-eslint/issues/2728 is done
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                        error.message ??= 'The .NET SDK installer did not install the SDK correctly.';
-                        // Remove this when https://github.com/typescript-eslint/typescript-eslint/issues/2728 is done
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                        error.message += `Which dotnet returned ${result?.stdout} and ${result?.stderr}.`;
-                        throw error;
-                    }
-            }
 
-            throw error;
-        }
+        context.installationValidator.validateDotnetInstall(install, dotnetPath, os.platform() !== 'win32', os.platform() !== 'darwin', context.acquisitionContext, this.extensionContext);
 
         context.eventStream.post(new DotnetAcquisitionCompleted(install, dotnetPath, installingVersion));
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -505,8 +505,7 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
         dotnetPath = await installer.getExpectedGlobalSDKPath(installingVersion,
             context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture));
 
-
-        context.installationValidator.validateDotnetInstall(install, dotnetPath, os.platform() !== 'win32', os.platform() !== 'darwin', context.acquisitionContext, this.extensionContext);
+        context.installationValidator.validateDotnetInstall(install, dotnetPath, os.platform() !== 'win32', os.platform() !== 'darwin');
 
         context.eventStream.post(new DotnetAcquisitionCompleted(install, dotnetPath, installingVersion));
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/IInstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IInstallationValidator.ts
@@ -3,11 +3,13 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
 
+import { IDotnetAcquireContext, IVSCodeExtensionContext } from '..';
 import { IEventStream } from '../EventStream/EventStream';
 import { DotnetInstall } from './DotnetInstall';
 
 export abstract class IInstallationValidator {
     constructor(protected readonly eventStream: IEventStream) {}
 
-    public abstract validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder? : boolean, failOnErr? : boolean): void;
+    public abstract validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder? : boolean, failOnErr? : boolean,
+        sdkInstallationToRetry? : IDotnetAcquireContext, vscodeContext? : IVSCodeExtensionContext): void;
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/IInstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IInstallationValidator.ts
@@ -10,6 +10,5 @@ import { DotnetInstall } from './DotnetInstall';
 export abstract class IInstallationValidator {
     constructor(protected readonly eventStream: IEventStream) {}
 
-    public abstract validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder? : boolean, failOnErr? : boolean,
-        sdkInstallationToRetry? : IDotnetAcquireContext, vscodeContext? : IVSCodeExtensionContext): void;
+    public abstract validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder? : boolean, failOnErr? : boolean): void;
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
@@ -63,7 +63,7 @@ export class InstallationValidator extends IInstallationValidator {
 ${message}`;
         }
 
-        else if(!passedValidation)
+        if(!passedValidation && !failOnErr)
         {
             this.eventStream?.post(new DotnetInstallationValidationMissed(new Error(message), message))
         }

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
@@ -12,30 +12,63 @@ import {
 } from '../EventStream/EventStreamEvents';
 import { IInstallationValidator } from './IInstallationValidator';
 import { DotnetInstall } from './DotnetInstall';
+import { IVSCodeExtensionContext } from '../IVSCodeExtensionContext';
+import { IDotnetAcquireContext } from '..';
 
 export class InstallationValidator extends IInstallationValidator {
-    public validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder = false, failOnErr = true): void {
+    public validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder = false, failOnErr = true, sdkInstallationToRetry = undefined, vscodeAccessor = undefined): void {
         const dotnetValidationFailed = `Validation of .dotnet installation for version ${JSON.stringify(install)} failed:`;
         const folder = path.dirname(dotnetPath);
 
         if(!isDotnetFolder)
         {
-            this.assertOrThrowError(failOnErr, fs.existsSync(folder),
-            `${dotnetValidationFailed} Expected installation folder ${folder} does not exist.`, install, dotnetPath);
+            try
+            {
+                this.assertOrThrowError(failOnErr, fs.existsSync(folder),
+                `${dotnetValidationFailed} Expected installation folder ${folder} does not exist.`, install, dotnetPath);
 
-            this.assertOrThrowError(failOnErr, fs.existsSync(dotnetPath),
-                `${dotnetValidationFailed} Expected executable does not exist at "${dotnetPath}"`, install, dotnetPath);
+                this.assertOrThrowError(failOnErr, fs.existsSync(dotnetPath),
+                    `${dotnetValidationFailed} Expected executable does not exist at "${dotnetPath}"`, install, dotnetPath);
 
-            this.assertOrThrowError(failOnErr, fs.lstatSync(dotnetPath).isFile(),
-                `${dotnetValidationFailed} Expected executable file exists but is not a file: "${dotnetPath}"`, install, dotnetPath);
+                this.assertOrThrowError(failOnErr, fs.lstatSync(dotnetPath).isFile(),
+                    `${dotnetValidationFailed} Expected executable file exists but is not a file: "${dotnetPath}"`, install, dotnetPath);
+            }
+            catch(error : any)
+            {
+                if(sdkInstallationToRetry && vscodeAccessor)
+                {
+                    const yes = validationPromptConstants.allowOption;
+                    const no = validationPromptConstants.cancelOption;
+                    const message = validationPromptConstants.noSignatureMessage;
+
+                    const pick = await this.utilityContext.ui.getModalWarningResponse(message, no, yes);
+                    const userConsentsToContinue = pick === yes;
+                    if(userConsentsToContinue)
+                    {
+                        (vscodeAccessor as IVSCodeExtensionContext).executeCommand('dotnet.acquireGlobalSDK', (sdkInstallationToRetry as IDotnetAcquireContext));
+                    }
+                    return;
+                }
+                else
+                {
+                    throw error;
+                }
+            }
         }
         else
         {
-            this.assertOrThrowError(failOnErr, fs.existsSync(folder),
-            `${dotnetValidationFailed} Expected dotnet folder ${dotnetPath} does not exist.`, install, dotnetPath);
+            try
+            {
+                this.assertOrThrowError(failOnErr, fs.existsSync(folder),
+                `${dotnetValidationFailed} Expected dotnet folder ${dotnetPath} does not exist.`, install, dotnetPath);
 
-            this.assertOrThrowError(failOnErr, fs.readdirSync(folder).length !== 0,
-            `${dotnetValidationFailed} The dotnet folder is empty "${dotnetPath}"`, install, dotnetPath);
+                this.assertOrThrowError(failOnErr, fs.readdirSync(folder).length !== 0,
+                `${dotnetValidationFailed} The dotnet folder is empty "${dotnetPath}"`, install, dotnetPath);
+            }
+            catch(error : any)
+            {
+
+            }
         }
 
         this.eventStream.post(new DotnetInstallationValidated(install));

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
@@ -35,8 +35,16 @@ export class InstallationValidator extends IInstallationValidator {
             this.assertOrThrowError(failOnErr, fs.existsSync(folder),
             `${dotnetValidationFailed} Expected dotnet folder ${dotnetPath} does not exist.`, install, dotnetPath);
 
-            this.assertOrThrowError(failOnErr, fs.readdirSync(folder).length !== 0,
-            `${dotnetValidationFailed} The dotnet folder is empty "${dotnetPath}"`, install, dotnetPath);
+            try
+            {
+                this.assertOrThrowError(failOnErr, fs.readdirSync(folder).length !== 0,
+                `${dotnetValidationFailed} The dotnet folder is empty "${dotnetPath}"`, install, dotnetPath);
+            }
+            catch(error : any) // fs.readdirsync throws ENOENT so we need to recall the function
+            {
+                this.assertOrThrowError(failOnErr, false,
+                `${dotnetValidationFailed} The dotnet file dne "${dotnetPath}"`, install, dotnetPath);
+            }
         }
 
         this.eventStream.post(new DotnetInstallationValidated(install));


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1572 

# Background 

When installing via Mac, our biggest failure right now is 'Validation of Installation' failed. This is because we use `open` which returns 0 even if someone closes the installer, cancels the installation, or fails the password prompt in the .NET installer, so we assume it has succeeded and then check to make sure .NET was installed and fail because it was not
 
We could
A - Assume that someone cancelled if the install isnt there and open on the installer returned 0
B - Move to `sudo installer -pkg Path -target LocalSystem`
 
Unfortunately to use installer you need to use sudo first so we need to use this joyous password prompt every single time if we do that:

![image](https://github.com/user-attachments/assets/d1020ad7-5eb3-417b-9112-8746a026e598)

I consulted our PM to decide how to handle this and he suggested:

 > we could pop up a question notification? "hey, it looks like SDK installation failed - would you like to retry the installation? Y/N/Shut up and go away forever"

I started the implementation of this but it is very ugly and the telemetry logic/counting of where we are in the install gets jank and it would take a lot of effort. In addition, we would want a 'yes' and 'no' button with distinct categories to solve what we are trying to solve -- yes, I want to retry and I had cancelled it; yes, I want to retry because it failed; no with either or the above.

So what I decided to do:

# What's in the PR

When the Mac installation for SDKs fails but the installer returned 0, we add a message asking the user if they had cancelled the installation request, and if so and they want the SDK to be installed, to please try again.