### PR TITLE
Record information about which files are wiped

### DIFF
--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -759,6 +759,14 @@ export class DuplicateInstallDetected extends DotnetCustomMessageEvent {
     public readonly eventName = 'DuplicateInstallDetected';
 }
 
+export class EmptyDirectoryToWipe extends DotnetCustomMessageEvent {
+    public readonly eventName = 'EmptyDirectoryToWipe';
+}
+
+export class FileToWipe extends DotnetCustomMessageEvent {
+    public readonly eventName = 'FileToWipe';
+}
+
 export class TriedToExitMasterSudoProcess extends DotnetCustomMessageEvent {
     public readonly eventName = 'TriedToExitMasterSudoProcess';
 }

--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -19,6 +19,8 @@ import { DotnetCommandFallbackArchitectureEvent,
    DotnetLockAttemptingAcquireEvent,
    DotnetLockErrorEvent,
    DotnetLockReleasedEvent,
+   EmptyDirectoryToWipe,
+   FileToWipe,
    SuppressedAcquisitionError
 } from '../EventStream/EventStreamEvents';
 
@@ -105,6 +107,7 @@ export class FileUtilities extends IFileUtilities
    {
        if(!fs.existsSync(directoryToWipe))
        {
+           eventStream?.post(new EmptyDirectoryToWipe(`The directory ${directoryToWipe} did not exist, so it was not wiped.`))
            return;
        }
 
@@ -113,6 +116,7 @@ export class FileUtilities extends IFileUtilities
        {
            try
            {
+               eventStream?.post(new FileToWipe(`The file ${f} is being deleted.`))
                if(!fileExtensionsToDelete || path.extname(f).toLocaleLowerCase() in fileExtensionsToDelete)
                fs.rmSync(path.join(directoryToWipe, f));
            }


### PR DESCRIPTION
This will be helpful for investigating any possible race conditions when removing the ok.txt file for intra-process communication.