### PR TITLE
Don't add -signed

### DIFF
--- a/pipeline-templates/package-vsix.yaml
+++ b/pipeline-templates/package-vsix.yaml
@@ -62,7 +62,8 @@ jobs:
   - task: CmdLine@2
     displayName: 🤌 Rename Signed VSIX
     inputs:
-      script: rename ".\packages\$(package-name)-$(GetVersion.version).vsix" $(package-name)-$(GetVersion.version)-signed.vsix
+      script: rename "$(package-name)-$(GetVersion.version).vsix" $(package-name)-$(GetVersion.version)-unsigned.vsix
+    workingDirectory: $(dir-name)
   - task: CopyFiles@2
     displayName: '📩 Copy Artifact'
     inputs:

--- a/pipeline-templates/publish.yaml
+++ b/pipeline-templates/publish.yaml
@@ -49,7 +49,7 @@ jobs:
           $basePublishArgs = , "publish"
           $basePublishArgs += '--azure-credential'
           $basePublishArgs += '--packagePath'
-          $publishArgs = $basePublishArgs + 'vscode-dotnet-runtime-$(GetVersion.version)-signed.vsix'
+          $publishArgs = $basePublishArgs + 'vscode-dotnet-runtime-$(GetVersion.version).vsix'
           If ("${{ parameters.SignType }}" -ne "Real") {
             Write-Host "With a test-signed build, the command to publish is printed instead of run."
             Write-Host "##[command]vsce $publishArgs"


### PR DESCRIPTION
This appears to cause some issues with loading external libraries due to new signature checks (?) added in October