### PR TITLE
Consider Runtime Patch Versions in PATH API

### DIFF
--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -379,6 +379,14 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     }
   }).timeout(standardTimeoutTime);
 
+  test('Find dotnet PATH Command Unmet Runtime Patch Condition', async () => {
+    // Install 8.0.{LATEST, which will be < 99}, look for 8.0.99 with accepting dotnet gr than or eq to 8.0.99
+    // No tests for SDK since that's harder to replicate with a global install and different machine states
+    await findPathWithRequirementAndInstall('8.0', 'runtime', os.arch(), 'greater_than_or_equal', true,
+        {version : '8.0.99', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
+    );
+  }).timeout(standardTimeoutTime);
+
   test('Install SDK Globally E2E (Requires Admin)', async () => {
     // We only test if the process is running under ADMIN because non-admin requires user-intervention.
     if(new FileUtilities().isElevated())

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -247,7 +247,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     }
     else
     {
-        assert.equal(result, undefined, 'find path command returned no undefined if no path matches condition');
+        assert.equal(result?.dotnetPath, undefined, 'find path command returned no undefined if no path matches condition');
     }
   }
 
@@ -382,9 +382,12 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
   test('Find dotnet PATH Command Unmet Runtime Patch Condition', async () => {
     // Install 8.0.{LATEST, which will be < 99}, look for 8.0.99 with accepting dotnet gr than or eq to 8.0.99
     // No tests for SDK since that's harder to replicate with a global install and different machine states
-    await findPathWithRequirementAndInstall('8.0', 'runtime', os.arch(), 'greater_than_or_equal', false,
-        {version : '8.0.99', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
-    );
+    if(os.platform() !== 'darwin')
+    {
+        await findPathWithRequirementAndInstall('8.0', 'runtime', os.arch(), 'greater_than_or_equal', false,
+            {version : '8.0.99', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
+        );
+    }
   }).timeout(standardTimeoutTime);
 
   test('Install SDK Globally E2E (Requires Admin)', async () => {

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -382,7 +382,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
   test('Find dotnet PATH Command Unmet Runtime Patch Condition', async () => {
     // Install 8.0.{LATEST, which will be < 99}, look for 8.0.99 with accepting dotnet gr than or eq to 8.0.99
     // No tests for SDK since that's harder to replicate with a global install and different machine states
-    await findPathWithRequirementAndInstall('8.0', 'runtime', os.arch(), 'greater_than_or_equal', true,
+    await findPathWithRequirementAndInstall('8.0', 'runtime', os.arch(), 'greater_than_or_equal', false,
         {version : '8.0.99', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
     );
   }).timeout(standardTimeoutTime);

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -487,6 +487,10 @@ export class DotnetFeatureBandDoesNotExistError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetFeatureBandDoesNotExistError';
 }
 
+export class DotnetInvalidRuntimePatchVersion extends DotnetAcquisitionError {
+    public readonly eventName = 'DotnetInvalidRuntimePatchVersion';
+}
+
 export class DotnetWSLSecurityError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetWSLSecurityError';
 }

--- a/vscode-dotnet-runtime-library/src/test/unit/VersionUtilities.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/VersionUtilities.test.ts
@@ -59,6 +59,19 @@ suite('Version Utilities Unit Tests', () => {
         assert.equal(resolver.getFeatureBandPatchVersion(twoDigitPatchVersion, mockEventStream, mockCtx), '21');
     });
 
+    test('Get Band+Patch from SDK Version', async () => {
+        assert.equal(resolver.getSDKCompleteBandAndPatchVersionString(fullySpecifiedVersion, mockEventStream, mockCtx), '201');
+        assert.equal(resolver.getSDKCompleteBandAndPatchVersionString(uniqueMajorMinorVersion, mockEventStream, mockCtx), '300');
+        assert.equal(resolver.getSDKCompleteBandAndPatchVersionString(twoDigitMajorVersion, mockEventStream, mockCtx), '102');
+        assert.equal(resolver.getSDKCompleteBandAndPatchVersionString(twoDigitPatchVersion, mockEventStream, mockCtx), '221');
+    });
+
+    test('Get Patch from Runtime Version', async () => {
+        assert.equal(resolver.getRuntimePatchVersionString(majorMinorOnly, mockEventStream, mockCtx), null);
+        assert.equal(resolver.getRuntimePatchVersionString('8.0.10', mockEventStream, mockCtx), '10');
+        assert.equal(resolver.getRuntimePatchVersionString('8.0.9-rc.2.24502.A', mockEventStream, mockCtx), '9');
+    });
+
     test('Get Patch from SDK Preview Version', async () => {
         assert.equal(resolver.getFeatureBandPatchVersion('8.0.400-preview.0.24324.5', mockEventStream, mockCtx), '0');
     });


### PR DESCRIPTION
The C# extension will now fail if the runtime is not 8.0.10 or higher on mac so we need to support patch version lookup.

~~Sadly we cannot migrate to semver as described in https://github.com/dotnet/vscode-dotnet-runtime/issues/2003 because semver rejects strings such as 8.0 which are allowable in many parts of our code and APIs.~~ (Thank you to @baronfel for seeing this comment and telling me about semver.coerce. Except, I dont really want to rewrite the code again now after writing it once already, gah)

This also adds code for SDK lookup but no test since that's harder to test, like remarked in the code.