### PR TITLE
Converted architecture and requirement input to lowercase 

### DIFF
--- a/sample/src/extension.ts
+++ b/sample/src/extension.ts
@@ -200,17 +200,21 @@ ${stderr}`);
             prompt: 'The .NET runtime version.',
         });
 
-        const arch = await vscode.window.showInputBox({
+        let arch = await vscode.window.showInputBox({
             placeHolder: 'x64',
             value: 'x64',
             prompt: 'The .NET runtime architecture.',
         });
 
-        const requirement = await vscode.window.showInputBox({
+        arch = arch?.toLowerCase();
+
+        let requirement = await vscode.window.showInputBox({
             placeHolder: 'greater_than_or_equal',
             value: 'greater_than_or_equal',
             prompt: 'The condition to search for a requirement.',
         });
+
+        requirement = requirement?.toLowerCase();
 
         let commandContext : IDotnetFindPathContext = { acquireContext: {version: version, requestingExtensionId: requestingExtensionId, architecture : arch, mode : 'runtime'} as IDotnetAcquireContext,
         versionSpecRequirement: requirement as DotnetVersionSpecRequirement};


### PR DESCRIPTION
Description

If the value of the .NET runtime architecture or the condition to search for a requirement contains uppercase letters, it results in discovery of undefined .NET path 

Fix

Both inputs are converted to lowercase before searching the .net path
Now, extension working as expected