### PR TITLE
Improve SDK lookup in PATH API

### DIFF
--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -470,8 +470,10 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
         const workerContext = getAcquisitionWorkerContext(commandContext.acquireContext.mode, commandContext.acquireContext);
         const existingPath = await resolveExistingPathIfExists(existingPathConfigWorker, commandContext.acquireContext, workerContext, utilContext, commandContext.versionSpecRequirement);
 
-        if(existingPath)
+        // The setting is not intended to be used as the SDK, only the runtime for extensions to run on. Ex: PowerShell policy doesn't allow us to install the runtime, let users set the path manually.
+        if(existingPath && commandContext.acquireContext.mode !== 'sdk')
         {
+            // We don't need to validate the existing path as it gets validated in the lookup logic already.
             globalEventStream.post(new DotnetFindPathSettingFound(`Found vscode setting.`));
             loggingObserver.dispose();
             return existingPath;

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -517,10 +517,15 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
 
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
 
-
     assert.exists(result);
     assert.exists(result!.dotnetPath);
     assert.equal(result!.dotnetPath, pathWithIncorrectVersionForTest); // this is set for the alternative.extension in the settings
+
+    const findPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, {mode: 'aspnetcore'}), versionSpecRequirement: 'equal' });
+    assert.equal(findPath!.dotnetPath, pathWithIncorrectVersionForTest, 'findPath uses vscode setting for aspnetcore runtime'); // this is set for the alternative.extension in the settings
+
+    const findSDKPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, {mode: 'sdk'}), versionSpecRequirement: 'equal' });
+    assert.equal(result?.dotnetPath ?? null, pathWithIncorrectVersionForTest, 'findPath does not find path setting for the SDK');
   }).timeout(standardTimeoutTime);
 
   test('List Sdks & Runtimes', async () => {

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -508,7 +508,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     // The runtime setting on the path needs to be a match for a runtime but also a different folder name
     // so that we can tell the setting was used. We cant tell it to install an older  besides latest,
     // but we can rename the folder then re-acquire for latest and see that it uses the existing 'older' runtime path
-    assert.notEqual(path.dirname(resultForAcquiringPathSettingRuntime.dotnetPath), path.dirname(pathWithIncorrectVersionForTest));
+    assert.notEqual(path.dirname(resultForAcquiringPathSettingRuntime.dotnetPath), path.dirname(pathWithIncorrectVersionForTest), 'Test setup: path setting is different from the real path');
     fs.cpSync(path.dirname(resultForAcquiringPathSettingRuntime.dotnetPath), path.dirname(pathWithIncorrectVersionForTest), {recursive: true});
     assert.isTrue(fs.existsSync(path.dirname(pathWithIncorrectVersionForTest)), 'The copy of the real dotnet to the new wrong-versioned path succeeded');
 
@@ -517,9 +517,9 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
 
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
 
-    assert.exists(result);
-    assert.exists(result!.dotnetPath);
-    assert.equal(result!.dotnetPath, pathWithIncorrectVersionForTest); // this is set for the alternative.extension in the settings
+    assert.exists(result, 'returns a result with path setting');
+    assert.exists(result!.dotnetPath, 'path setting has a path');
+    assert.equal(result!.dotnetPath, pathWithIncorrectVersionForTest, 'path setting is used'); // this is set for the alternative.extension in the settings
 
     const findPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, {mode: 'aspnetcore'}), versionSpecRequirement: 'equal' });
     assert.equal(findPath!.dotnetPath, pathWithIncorrectVersionForTest, 'findPath uses vscode setting for aspnetcore runtime'); // this is set for the alternative.extension in the settings

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -512,7 +512,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
   }).timeout(standardTimeoutTime);
 
   test('Install Local Runtime Command With Path Setting', async () => {
-    const context: IDotnetAcquireContext = { version: '5.0', requestingExtensionId: 'alternative.extension' };
+    const context: IDotnetAcquireContext = { version: '5.0', requestingExtensionId: 'alternative.extension', architecture: os.platform() };
     const resultForAcquiringPathSettingRuntime = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
     assert.exists(resultForAcquiringPathSettingRuntime!.dotnetPath, 'Basic acquire works');
 
@@ -532,11 +532,11 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.exists(result!.dotnetPath, 'path setting has a path');
     assert.equal(result!.dotnetPath, pathWithIncorrectVersionForTest, 'path setting is used'); // this is set for the alternative.extension in the settings
 
-    const findPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, {mode: 'aspnetcore'}), versionSpecRequirement: 'equal' });
-    assert.equal(findPath!.dotnetPath, pathWithIncorrectVersionForTest, 'findPath uses vscode setting for aspnetcore runtime'); // this is set for the alternative.extension in the settings
+    const findPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, {mode: 'runtime'}), versionSpecRequirement: 'equal' });
+    assert.equal(findPath!.dotnetPath, pathWithIncorrectVersionForTest, 'findPath uses vscode setting for runtime'); // this is set for the alternative.extension in the settings
 
     const findSDKPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, {mode: 'sdk'}), versionSpecRequirement: 'equal' });
-    assert.equal(findSDKPath?.dotnetPath ?? null, pathWithIncorrectVersionForTest, 'findPath does not find path setting for the SDK');
+    assert.equal(findSDKPath?.dotnetPath ?? undefined, undefined, 'findPath does not find path setting for the SDK');
   }).timeout(standardTimeoutTime);
 
   test('List Sdks & Runtimes', async () => {

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -525,7 +525,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.equal(findPath!.dotnetPath, pathWithIncorrectVersionForTest, 'findPath uses vscode setting for aspnetcore runtime'); // this is set for the alternative.extension in the settings
 
     const findSDKPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, {mode: 'sdk'}), versionSpecRequirement: 'equal' });
-    assert.equal(result?.dotnetPath ?? null, pathWithIncorrectVersionForTest, 'findPath does not find path setting for the SDK');
+    assert.equal(findSDKPath?.dotnetPath ?? null, pathWithIncorrectVersionForTest, 'findPath does not find path setting for the SDK');
   }).timeout(standardTimeoutTime);
 
   test('List Sdks & Runtimes', async () => {

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -25,7 +25,7 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
 
     public async dotnetMeetsRequirement(dotnetExecutablePath: string, requirement : IDotnetFindPathContext) : Promise<boolean>
     {
-        const availableRuntimes = await this.getRuntimes(dotnetExecutablePath);
+        const availableRuntimes = requirement.acquireContext.mode === 'sdk' ? [] : await this.getRuntimes(dotnetExecutablePath);
         const requestedMajorMinor = versionUtils.getMajorMinor(requirement.acquireContext.version, this.workerContext.eventStream, this.workerContext);
         const hostArch = await this.getHostArchitecture(dotnetExecutablePath, requirement);
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -147,7 +147,7 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
                     const resolvedDotnetPath = path.resolve(pathOnPATH, dotnetExecutable);
                     if (existsSync(resolvedDotnetPath))
                     {
-                        this.workerContext.eventStream.post(new DotnetFindPathLookupPATH(`Looking up .NET on the path by processing PATH string. resolved: ${resolvedDotnetPath}.`);
+                        this.workerContext.eventStream.post(new DotnetFindPathLookupPATH(`Looking up .NET on the path by processing PATH string. resolved: ${resolvedDotnetPath}.`));
                         validPathsOnPATH.push(resolvedDotnetPath);
                     }
                 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -142,11 +142,12 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
             if (pathsOnPATH && pathsOnPATH.length > 0)
             {
                 const dotnetExecutable = getDotnetExecutable();
-                for (let i = 0; i < pathsOnPATH.length; i++)
+                for (const pathOnPATH of pathsOnPATH)
                 {
-                    const resolvedDotnetPath = path.resolve(pathsOnPATH[i], dotnetExecutable);
+                    const resolvedDotnetPath = path.resolve(pathOnPATH, dotnetExecutable);
                     if (existsSync(resolvedDotnetPath))
                     {
+                        this.workerContext.eventStream.post(new DotnetFindPathLookupPATH(`Looking up .NET on the path by processing PATH string. resolved: ${resolvedDotnetPath}.`);
                         validPathsOnPATH.push(resolvedDotnetPath);
                     }
                 }


### PR DESCRIPTION
# Summary 

The vscode setting we have is meant for runtime lookup but it currently gets used under sdk mode. When looking for an sdk, we also dont need to scan --list-runtimes since it has no sdk.

We also add code here to check the path string manually if which or where does not exist, which happens more often than I'd prefer with customers.

The rest of the logic is relatively the same. I looked again at the code across our codebases. 

# Misc 

2 things of note compared to their code:
workingWithTestSignedSdk is not respected. This is a C# devkit property used when finding an sdk on mac to support adhoc signed sdks. Their logic can handle this separately and is already isolated so we don't need to couple this logic.

This doesnt use workspace folders first folder for cwd, just uses __dirname via the command executor class, unlike C# DevKIt. but it shouldnt matter because it uses the full path, not just 'dotnet' which is what they use to call into the host.
 