### PR TITLE
Expose Mode Property on Sample Command for Testing

### DIFF
--- a/sample/src/extension.ts
+++ b/sample/src/extension.ts
@@ -208,6 +208,14 @@ ${stderr}`);
 
         arch = arch?.toLowerCase();
 
+        let searchMode = await vscode.window.showInputBox({
+            placeHolder: 'runtime',
+            value: 'runtime',
+            prompt: 'look for an sdk, runtime, aspnetcore runtime, etc',
+        });
+
+        searchMode = searchMode?.toLowerCase() ?? 'runtime';
+
         let requirement = await vscode.window.showInputBox({
             placeHolder: 'greater_than_or_equal',
             value: 'greater_than_or_equal',
@@ -216,7 +224,7 @@ ${stderr}`);
 
         requirement = requirement?.toLowerCase();
 
-        let commandContext : IDotnetFindPathContext = { acquireContext: {version: version, requestingExtensionId: requestingExtensionId, architecture : arch, mode : 'runtime'} as IDotnetAcquireContext,
+        let commandContext : IDotnetFindPathContext = { acquireContext: {version: version, requestingExtensionId: requestingExtensionId, architecture : arch, mode : searchMode} as IDotnetAcquireContext,
         versionSpecRequirement: requirement as DotnetVersionSpecRequirement};
 
         const result = await vscode.commands.executeCommand('dotnet.findPath', commandContext);


### PR DESCRIPTION
The sample command provides a UI pop up to our internal APIs only available to other extensions.
This popup allows you to enter the architecture, version, etc when calling our findPath API.
But it did not allow you to manually test the 'mode' which is to find the sdk path, runtime path, or aspnetcore runtime path. This has been added in this very simple PR.

No tests are added since this is not user facing code and is a simple change.