### PR TITLE
OS emojis idea

### DIFF
--- a/1pr-azure-pipeline.yml
+++ b/1pr-azure-pipeline.yml
@@ -30,15 +30,15 @@ parameters:
   - name: NetCore-Public
     vmImage: windows-latest
     os: windows
-    emoji: ⚪
+    emoji: 🪟
   - name: NetCore-Public
     vmImage: ubuntu-latest
     os: linux
-    emoji: 🟣
+    emoji: 🐧
   - name: NetCore-Public
     vmImage: macOS-latest
     os: macOS
-    emoji: ⚫
+    emoji: 🍎
 
 stages:
 - stage: o # o is just used so it looks like a bullet point in the output of devops


### PR DESCRIPTION
## Summary
I saw that your build use emojis to identify things. I was talking to Jacques and mentioned it, and he made a joke that you could use the actual emojis that associate with the OS's.  So, this just changes the different OS jobs to use the 🪟 for Windows, 🐧 for Linux, and 🍎 for macOS.