### PR TITLE
Add Hostfxr Discovery Logic in place of Bad PATH from VS Code

### DIFF
--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -2207,7 +2207,7 @@ uuid@^8.3.0:
     fsevents "^2.3.3"
 
 "vscode-dotnet-runtime@file:../vscode-dotnet-runtime-extension":
-  version "2.2.3"
+  version "2.2.4"
   resolved "file:../vscode-dotnet-runtime-extension"
   dependencies:
     "@types/chai-as-promised" "^7.1.8"

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -517,7 +517,7 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
         for(const dotnetPath of dotnetOnHostfxrRecord ?? [])
         {
             const validatedHostfxr = await getPathIfValid(dotnetPath, validator, commandContext);
-            if(validatedHostfxr)
+            if(validatedHostfxr && process.env.DOTNET_INSTALL_TOOL_SKIP_HOSTFXR !== 'true')
             {
                 loggingObserver.dispose();
                 return { dotnetPath: validatedHostfxr };

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -208,7 +208,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
   }
 
   async function findPathWithRequirementAndInstall(version : string, iMode : DotnetInstallMode, arch : string, condition : DotnetVersionSpecRequirement, shouldFind : boolean, contextToLookFor? : IDotnetAcquireContext, setPath = true,
-    blockNoArch = false)
+    blockNoArch = false, dontCheckNonPaths = true)
   {
     const installPath = await installRuntime(version, iMode, arch);
 
@@ -232,6 +232,11 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
         process.env.DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH = '1';
     }
 
+    if(dontCheckNonPaths)
+    {
+        process.env.DOTNET_INSTALL_TOOL_SKIP_HOSTFXR = 'true';
+    }
+
     const result : IDotnetAcquireResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath',
         { acquireContext : contextToLookFor ?? { version, requestingExtensionId : requestingExtensionId, mode: iMode, architecture : arch } as IDotnetAcquireContext,
         versionSpecRequirement : condition} as IDotnetFindPathContext
@@ -239,6 +244,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
 
     extensionContext.environmentVariableCollection.replace('DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH', '0');
     process.env.DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH = '0';
+    process.env.DOTNET_INSTALL_TOOL_SKIP_HOSTFXR = '0';
 
     if(shouldFind)
     {

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -32,6 +32,8 @@ import {
   EnvironmentVariableIsDefined,
   MockEnvironmentVariableCollection,
   getPathSeparator,
+  LinuxVersionResolver,
+  getMockUtilityContext,
 } from 'vscode-dotnet-runtime-library';
 import * as extension from '../../extension';
 import { warn } from 'console';
@@ -580,8 +582,8 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     }
     else
     {
-      assert.equal(result[0].version, '9.0.1xx', 'The SDK did not recommend the version it was supposed to, which should be N.0.1xx based on surface level distro knowledge. If a new version is available, this test may need to be updated to the newest version.');
-
+      const distroVersion = await new LinuxVersionResolver(mockAcquisitionContext, getMockUtilityContext()).getRunningDistro();
+      assert.equal(result[0].version, Number(distroVersion) > 22.04 ? '9.0.1xx' : '8.0.1xx', 'The SDK did not recommend the version it was supposed to, which should be N.0.1xx based on surface level distro knowledge. If a new version is available, this test may need to be updated to the newest version.');
     }
   }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -255,7 +255,7 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
 
     private getPathsFromEtc(etcLoc : string) : Array<string>
     {
-        let paths : string[] = [];
+        const paths : string[] = [];
         if(existsSync(etcLoc))
         {
             try
@@ -267,7 +267,8 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
             catch(error : any) // eslint-disable-line @typescript-eslint/no-explicit-any
             {
                 // readfile throws if the file gets deleted in between the existing check and now
-                this.workerContext.eventStream.post(new FileDoesNotExist(`The host was deleted after checking in the file system. ${error.message} ${etcLoc}`));
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                this.workerContext.eventStream.post(new FileDoesNotExist(`The host was deleted after checking in the file system. ${error?.message} ${etcLoc}`));
             }
         }
         else

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -150,7 +150,7 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
                 const dotnetExecutable = getDotnetExecutable();
                 for (const pathOnPATH of pathsOnPATH)
                 {
-                    const resolvedDotnetPath = path.resolve(pathOnPATH, dotnetExecutable);
+                    const resolvedDotnetPath = path.join(pathOnPATH, dotnetExecutable);
                     if (existsSync(resolvedDotnetPath))
                     {
                         this.workerContext.eventStream.post(new DotnetFindPathLookupPATH(`Looking up .NET on the path by processing PATH string. resolved: ${resolvedDotnetPath}.`));
@@ -213,7 +213,7 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
         {
             const registryReader = new RegistryReader(this.workerContext, this.utilityContext, this.executor);
             const hostPathWin = await registryReader.getHostLocation(requestedArchitecture);
-            const paths = hostPathWin ? [path.resolve(hostPathWin, getDotnetExecutable()), path.resolve(realpathSync(hostPathWin), getDotnetExecutable())] : [];
+            const paths = hostPathWin ? [path.join(hostPathWin, getDotnetExecutable()), path.join(realpathSync(hostPathWin), getDotnetExecutable())] : [];
             if(paths.length > 0)
             {
                 this.workerContext.eventStream.post(new DotnetFindPathOnRegistry(`The host could be found in the registry. ${JSON.stringify(paths)}`));
@@ -238,8 +238,8 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
             if(existsSync(netSixAndAboveHostInstallSaveLocation))
             {
                 const installPath = readFileSync(netSixAndAboveHostInstallSaveLocation).toString().trim();
-                paths.push(path.join(installPath), getDotnetExecutable());
-                paths.push(path.join(realpathSync(installPath)), getDotnetExecutable());
+                paths.push(path.join(installPath, getDotnetExecutable()));
+                paths.push(path.join(realpathSync(installPath)), getDotnetExecutable()));
             }
             else if(existsSync(netFiveAndNetSixAboveFallBackInstallSaveLocation))
             {

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -239,7 +239,7 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
             {
                 const installPath = readFileSync(netSixAndAboveHostInstallSaveLocation).toString().trim();
                 paths.push(path.join(installPath, getDotnetExecutable()));
-                paths.push(path.join(realpathSync(installPath)), getDotnetExecutable()));
+                paths.push(path.join(realpathSync(installPath), getDotnetExecutable()));
             }
             else if(existsSync(netFiveAndNetSixAboveFallBackInstallSaveLocation))
             {

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -213,7 +213,7 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
         {
             const registryReader = new RegistryReader(this.workerContext, this.utilityContext, this.executor);
             const hostPathWin = await registryReader.getHostLocation(requestedArchitecture);
-            const paths = hostPathWin ? [hostPathWin, realpathSync(hostPathWin)] : [];
+            const paths = hostPathWin ? [path.resolve(hostPathWin, getDotnetExecutable()), path.resolve(realpathSync(hostPathWin), getDotnetExecutable())] : [];
             if(paths.length > 0)
             {
                 this.workerContext.eventStream.post(new DotnetFindPathOnRegistry(`The host could be found in the registry. ${JSON.stringify(paths)}`));
@@ -238,14 +238,14 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
             if(existsSync(netSixAndAboveHostInstallSaveLocation))
             {
                 const installPath = readFileSync(netSixAndAboveHostInstallSaveLocation).toString().trim();
-                paths.push(installPath);
-                paths.push(realpathSync(installPath))
+                paths.push(path.resolve(installPath), getDotnetExecutable());
+                paths.push(path.resolve(realpathSync(installPath)), getDotnetExecutable());
             }
             else if(existsSync(netFiveAndNetSixAboveFallBackInstallSaveLocation))
             {
                 const installPath = readFileSync(netFiveAndNetSixAboveFallBackInstallSaveLocation).toString().trim();
-                paths.push(installPath);
-                paths.push(realpathSync(installPath))
+                paths.push(path.resolve(installPath), getDotnetExecutable());
+                paths.push(path.resolve(realpathSync(installPath)), getDotnetExecutable());
             }
 
             if(paths.length > 0)

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -238,14 +238,14 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
             if(existsSync(netSixAndAboveHostInstallSaveLocation))
             {
                 const installPath = readFileSync(netSixAndAboveHostInstallSaveLocation).toString().trim();
-                paths.push(path.resolve(installPath), getDotnetExecutable());
-                paths.push(path.resolve(realpathSync(installPath)), getDotnetExecutable());
+                paths.push(path.join(installPath), getDotnetExecutable());
+                paths.push(path.join(realpathSync(installPath)), getDotnetExecutable());
             }
             else if(existsSync(netFiveAndNetSixAboveFallBackInstallSaveLocation))
             {
                 const installPath = readFileSync(netFiveAndNetSixAboveFallBackInstallSaveLocation).toString().trim();
-                paths.push(path.resolve(installPath, getDotnetExecutable()));
-                paths.push(path.resolve(realpathSync(installPath), getDotnetExecutable()));
+                paths.push(path.join(installPath, getDotnetExecutable()));
+                paths.push(path.join(realpathSync(installPath), getDotnetExecutable()));
             }
 
             if(paths.length > 0)

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -244,8 +244,8 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
             else if(existsSync(netFiveAndNetSixAboveFallBackInstallSaveLocation))
             {
                 const installPath = readFileSync(netFiveAndNetSixAboveFallBackInstallSaveLocation).toString().trim();
-                paths.push(path.resolve(installPath), getDotnetExecutable());
-                paths.push(path.resolve(realpathSync(installPath)), getDotnetExecutable());
+                paths.push(path.resolve(installPath, getDotnetExecutable()));
+                paths.push(path.resolve(realpathSync(installPath), getDotnetExecutable()));
             }
 
             if(paths.length > 0)

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -33,13 +33,16 @@ import {
     FileDoesNotExist
 } from '../EventStream/EventStreamEvents';
 import { RegistryReader } from './RegistryReader';
+import { FileUtilities } from '../Utils/FileUtilities';
+import { IFileUtilities } from '../Utils/IFileUtilities';
 
 export class DotnetPathFinder implements IDotnetPathFinder
 {
 
-    public constructor(private readonly workerContext : IAcquisitionWorkerContext, private readonly utilityContext : IUtilityContext, private executor? : ICommandExecutor)
+    public constructor(private readonly workerContext : IAcquisitionWorkerContext, private readonly utilityContext : IUtilityContext, private executor? : ICommandExecutor, private file? : IFileUtilities)
     {
         this.executor ??= new CommandExecutor(this.workerContext, this.utilityContext);
+        this.file ??= new FileUtilities();
     }
 
     /**
@@ -256,11 +259,11 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
     private getPathsFromEtc(etcLoc : string) : Array<string>
     {
         const paths : string[] = [];
-        if(existsSync(etcLoc))
+        if(this.file!.existsSync(etcLoc))
         {
             try
             {
-                const installPath = readFileSync(etcLoc).toString().trim();
+                const installPath = this.file!.readSync(etcLoc).toString().trim();
                 paths.push(path.join(installPath, getDotnetExecutable()));
                 paths.push(path.join(realpathSync(installPath), getDotnetExecutable()));
             }

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDotnetPathFinder.ts
@@ -8,4 +8,5 @@ export interface IDotnetPathFinder
     findDotnetRootPath(requestedArchitecture : string): Promise<string | undefined>;
     findRawPathEnvironmentSetting(tryUseTrueShell : boolean): Promise<string[] | undefined>;
     findRealPathEnvironmentSetting(tryUseTrueShell : boolean): Promise<string[] | undefined>;
+    findHostInstallPaths(requestedArchitecture : string): Promise<string[] | undefined>;
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/IGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IGlobalInstaller.ts
@@ -26,8 +26,6 @@ export abstract class IGlobalInstaller {
 
     public abstract getExpectedGlobalSDKPath(specificSDKVersionInstalled : string, installedArch : string, macPathShouldExist? : boolean) : Promise<string>
 
-    public abstract getGlobalSdkVersionsInstalledOnMachine() : Promise<Array<string>>;
-
     /**
      *
      * @returns The folder where global sdk installers will be downloaded onto the disk.

--- a/vscode-dotnet-runtime-library/src/Acquisition/IRegistryReader.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IRegistryReader.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+
+import { IEventStream } from '../EventStream/EventStream';
+import { IVSCodeExtensionContext } from '../IVSCodeExtensionContext';
+
+export abstract class IRegistryReader
+{
+    constructor() {}
+
+    public abstract getGlobalSdkVersionsInstalledOnMachine() : Promise<Array<string>>;
+}

--- a/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
@@ -32,6 +32,7 @@ export class RegistryReader extends IRegistryReader
     public async getHostLocation(architecture : string) : Promise<string | undefined>
     {
         // InstallLocation vs sharedhost:
+
         // The sharedhost registry key stores the path of dotnet that gets put on the PATH.
         // The InstallLocation stores other paths to the host that might not be on the PATH, such as an x64 host on an arm64 machine.
         // The InstallLocation is always under the 32 bit reg node for our purposes, and the sharedhost is always on the native node.

--- a/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
@@ -27,6 +27,28 @@ export class RegistryReader extends IRegistryReader
     }
 
     /**
+     * @remarks architecture values accepted: x64, arm64. x86, arm32 possible on linux but 32 bit vscode is not supported.
+     */
+    public async getHostLocation(architecture : string) : Promise<string | undefined>
+    {
+        // TODO: Verify on ARM 64, the x64 path in paths and also reg.
+
+        "%programfiles%";
+
+        // InstallLocation vs sharedhost:
+        // See https://github.com/dotnet/runtime/issues/109974
+        const query = `HKEY_LOCAL_MACHINE\\SOFTWARE\\dotnet\\Setup\\InstalledVersions\\${architecture}\\sharedhost`;
+        const result = await this.queryRegistry(query, false);
+
+        if(result?.status === '0')
+        {
+
+        }
+
+        return undefined;
+    }
+
+    /**
      *
      * @returns an array containing fully specified / specific versions of all globally installed sdks on the machine in windows for 32 and 64 bit sdks.
     */

--- a/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
@@ -59,7 +59,12 @@ export class RegistryReader extends IRegistryReader
 
         if(result?.status === '0')
         {
-            return result.stdout.trim().split(' ')[2]; // Output is of the type Key   REG_SZ    C:\path\to\dotnet
+            // Output is of the type
+            // REGISTRY_KEY
+            // Key   REG_SZ    C:\path\to\dotnet
+            const keyRow = result.stdout?.trim()?.split("\n")?.at(1)?.trim(); // Get the line that contains Key REG_SZ Path
+            const finalPath = keyRow?.split(' ')?.filter((x : any) => x !== '')?.slice(2)?.join(' ');
+            return finalPath
         }
 
         return undefined;

--- a/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
@@ -46,7 +46,7 @@ export class RegistryReader extends IRegistryReader
         const queryForPATHLocationNotViaPATH = `HKEY_LOCAL_MACHINE\\SOFTWARE\\dotnet\\Setup\\InstalledVersions\\${architecture}\\sharedhost`;
         const queryForInstallLocationNotPATH = `HKEY_LOCAL_MACHINE\\SOFTWARE\\dotnet\\Setup\\InstalledVersions\\${architecture}\\InstallLocation`;
 
-        let queryForPATH = os.arch() === architecture;
+        const queryForPATH = os.arch() === architecture;
         let queriedInstallationLocation = false;
         let result = null;
         if(queryForPATH)
@@ -80,7 +80,7 @@ export class RegistryReader extends IRegistryReader
     /**
      *
      * @returns an array containing fully specified / specific versions of all globally installed sdks on the machine in windows for 32 and 64 bit sdks.
-    */
+     */
     public async getGlobalSdkVersionsInstalledOnMachine() : Promise<Array<string>>
     {
         let sdks: string[] = [];

--- a/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
@@ -8,11 +8,22 @@ import * as path from 'path';
 
 import { IEventStream } from "../EventStream/EventStream";
 import { IRegistryReader } from "./IRegistryReader";
+import { CommandExecutor } from '../Utils/CommandExecutor';
+import { ICommandExecutor } from '../Utils/ICommandExecutor';
+import { IUtilityContext } from '../Utils/IUtilityContext';
+import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 export class RegistryReader extends IRegistryReader
 {
+    protected commandRunner : ICommandExecutor;
+
+    constructor(context : IAcquisitionWorkerContext, utilContext : IUtilityContext, executor : ICommandExecutor | null = null)
+    {
+        super();
+        this.commandRunner = executor ?? new CommandExecutor(context, utilContext);
+    }
     /**
      *
      * @returns an array containing fully specified / specific versions of all globally installed sdks on the machine in windows for 32 and 64 bit sdks.

--- a/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { IEventStream } from "../EventStream/EventStream";
+import { IRegistryReader } from "./IRegistryReader";
+
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+export class RegistryReader extends IRegistryReader
+{
+    /**
+     *
+     * @returns an array containing fully specified / specific versions of all globally installed sdks on the machine in windows for 32 and 64 bit sdks.
+    */
+    public async getGlobalSdkVersionsInstalledOnMachine() : Promise<Array<string>>
+    {
+        let sdks: string[] = [];
+
+
+        if (os.platform() === 'win32')
+        {
+            const sdkInstallRecords64Bit = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\dotnet\\Setup\\InstalledVersions\\x64\\sdk';
+            const sdkInstallRecords32Bit = sdkInstallRecords64Bit.replace('x64', 'x86');
+            const sdkInstallRecordsArm64 = sdkInstallRecords64Bit.replace('x64', 'arm64');
+
+            const queries = [sdkInstallRecords32Bit, sdkInstallRecords64Bit, sdkInstallRecordsArm64];
+            for ( const query of queries )
+            {
+                try
+                {
+                    const registryQueryCommand = path.join(`${process.env.SystemRoot}`, `System32\\reg.exe`);
+                    // /reg:32 is added because all keys on 64 bit machines are all put into the WOW node. They won't be on the WOW node on a 32 bit machine.
+                    const command = CommandExecutor.makeCommand(registryQueryCommand, [`query`, `${query}`, `\/reg:32`]);
+
+                    let installRecordKeysOfXBit = '';
+                    const registryLookup = (await this.commandRunner.execute(command));
+
+                    if(registryLookup.status === '0')
+                    {
+                        installRecordKeysOfXBit = registryLookup.stdout;
+                    }
+
+                    const installedSdks = this.extractVersionsOutOfRegistryKeyStrings(installRecordKeysOfXBit);
+                    // Append any newly found sdk versions
+                    sdks = sdks.concat(installedSdks.filter((item) => sdks.indexOf(item) < 0));
+                }
+                catch(e)
+                {
+                    // There are no "X" bit sdks on the machine.
+                }
+            }
+        }
+
+        return sdks;
+    }
+
+    /**
+     *
+     * @param registryQueryResult the raw output of a registry query converted into a string
+     * @returns
+     */
+    private extractVersionsOutOfRegistryKeyStrings(registryQueryResult : string) : string[]
+    {
+        if(registryQueryResult === '')
+        {
+                return [];
+        }
+        else
+        {
+            return registryQueryResult.split(' ')
+            .filter
+            (
+                function(value : string, i : number) { return value !== '' && i !== 0; } // Filter out the whitespace & query as the query return value starts with the query.
+            )
+            .filter
+            (
+                function(value : string, i : number) { return i % 3 === 0; } // Every 0th, 4th, etc item will be a value name AKA the SDK version. The rest will be REGTYPE and REGHEXVALUE.
+            );
+        }
+    }
+}

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -332,9 +332,20 @@ Permissions: ${JSON.stringify(await this.commandRunner.execute(CommandExecutor.m
         {
             // The program files should always be set, but in the off chance they are wiped, we can try to use the default as backup.
             // Both ia32 and x64 machines will use 'Program Files'
-            // TODO: what about x64 on arm?
-            // We don't anticipate a user would need to install the x86 SDK, and we don't have any routes that support that yet.
-            return process.env.programfiles ? path.resolve(path.join(process.env.programfiles, 'dotnet', 'dotnet.exe')) : path.resolve(`C:\\Program Files\\dotnet\\dotnet.exe`);
+            if(process.env.programfiles)
+            {
+                if(os.arch() === 'arm64' && installedArch === 'x64')
+                {
+                    return path.resolve(path.join(process.env.programfiles, 'dotnet', 'x64', 'dotnet.exe'));
+                }
+                return path.resolve(path.join(process.env.programfiles, 'dotnet', 'dotnet.exe'))
+            }
+
+            if(os.arch() === 'arm64' && installedArch === 'x64')
+            {
+                return path.resolve(`C:\\Program Files\\dotnet\\x64\\dotnet.exe`);
+            }
+            return path.resolve(`C:\\Program Files\\dotnet\\dotnet.exe`);
         }
         else if(os.platform() === 'darwin')
         {

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -332,6 +332,7 @@ Permissions: ${JSON.stringify(await this.commandRunner.execute(CommandExecutor.m
         {
             // The program files should always be set, but in the off chance they are wiped, we can try to use the default as backup.
             // Both ia32 and x64 machines will use 'Program Files'
+            // TODO: what about x64 on arm?
             // We don't anticipate a user would need to install the x86 SDK, and we don't have any routes that support that yet.
             return process.env.programfiles ? path.resolve(path.join(process.env.programfiles, 'dotnet', 'dotnet.exe')) : path.resolve(`C:\\Program Files\\dotnet\\dotnet.exe`);
         }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -899,6 +899,26 @@ export class DotnetFindPathRealPATHFound extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
+export class DotnetFindPathHostFxrResolutionLookup extends DotnetCustomMessageEvent {
+    public readonly eventName = 'DotnetFindPathHostFxrResolutionLookup';
+}
+
+export class DotnetFindPathOnRegistry extends DotnetCustomMessageEvent {
+    public readonly eventName = 'DotnetFindPathOnRegistry';
+}
+
+export class DotnetFindPathNoHostOnRegistry extends DotnetCustomMessageEvent {
+    public readonly eventName = 'DotnetFindPathNoHostOnRegistry';
+}
+
+export class DotnetFindPathOnFileSystem extends DotnetCustomMessageEvent {
+    public readonly eventName = 'DotnetFindPathOnFileSystem';
+}
+
+export class DotnetFindPathNoHostOnFileSystem extends DotnetCustomMessageEvent {
+    public readonly eventName = 'DotnetFindPathNoHostOnFileSystem';
+}
+
 export class DotnetFindPathNoRuntimesOnHost extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathNoRuntimesOnHost';
 }
@@ -921,6 +941,10 @@ export class DotnetFindPathRootPATHFound extends DotnetCustomMessageEvent {
 
 export class DotnetFindPathMetCondition extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathMetCondition';
+}
+
+export class DotnetFindPathNoPathMetCondition extends DotnetCustomMessageEvent {
+    public readonly eventName = 'DotnetFindPathNoPathMetCondition';
 }
 
 export class DotnetFindPathDidNotMeetCondition extends DotnetCustomMessageEvent {

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -783,6 +783,10 @@ export class FeatureBandDoesNotExist extends DotnetCustomMessageEvent {
     public readonly eventName = 'FeatureBandDoesNotExist';
 }
 
+export class FileDoesNotExist extends DotnetCustomMessageEvent {
+    public readonly eventName = 'FileDoesNotExist';
+}
+
 export class DotnetUninstallStarted extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetUninstallStarted';
     public type = EventType.DotnetUninstallMessage;

--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -127,6 +127,16 @@ export class FileUtilities extends IFileUtilities
        });
    }
 
+   public readSync(filePath: string): string
+   {
+       return fs.readFileSync(filePath).toString();
+   }
+
+   public existsSync(filePath: string): boolean
+   {
+       return fs.existsSync(filePath);
+   }
+
    /**
     *
     * @param nodeArchitecture the architecture in node style string of what to install

--- a/vscode-dotnet-runtime-library/src/Utils/IFileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/IFileUtilities.ts
@@ -21,4 +21,8 @@ export abstract class IFileUtilities
     public abstract isElevated(eventStream? : IEventStream) : boolean;
 
     public abstract getFileHash(filePath : string) : Promise<string | null>;
+
+    public abstract existsSync(filePath : string) : boolean;
+
+    public abstract readSync(filePath : string) : string;
 };

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -385,6 +385,8 @@ export class MockCommandExecutor extends ICommandExecutor
 export class MockFileUtilities extends IFileUtilities
 {
     private trueUtilities = new FileUtilities();
+    public filePathsAndExistValues : { [filePath: string]: boolean; } = {};
+    public filePathsAndReadValues :  { [filePath: string]: string; } = {};
 
     public writeFileOntoDisk(content : string, filePath : string, alreadyHoldingLock = false)
     {
@@ -404,6 +406,16 @@ export class MockFileUtilities extends IFileUtilities
     public async getFileHash(filePath : string)
     {
         return '';
+    }
+
+    public existsSync(filePath : string)
+    {
+        return this.filePathsAndExistValues[filePath] || false;
+    }
+
+    public readSync(filePath: string): string
+    {
+        return this.filePathsAndReadValues[filePath] || '';
     }
 
 }

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
@@ -29,12 +29,12 @@ suite('DotnetPathFinder Unit Tests', function ()
 
     this.afterEach(async () =>
     {
-        if(madeFakeDotnetInstallRecord)
+        if(madeFakeDotnetInstallRecord && fs.existsSync(installRecordPath))
         {
             fs.rmSync(installRecordPath, { recursive: true });
         }
 
-        if(madeFakeDotnetDir)
+        if(madeFakeDotnetDir && fs.existsSync(madeFakeDotnetDir))
         {
             fs.rmdirSync(madeFakeDotnetDir, { recursive: true });
         }

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
@@ -40,7 +40,7 @@ suite('DotnetPathFinder Unit Tests', function ()
             const result = await finder.findHostInstallPaths(os.arch());
 
             assert.isTrue(result !== undefined, 'The dotnet path finder found a dotnet path');
-            assert.equal(result?.at(0), fakeDotnetPath, 'The correct path is found');
+            assert.equal(result?.at(0), path.join(fakeDotnetPath, 'dotnet'), 'The correct path is found');
         } // Windows and other lookup is covered in the registryReader or the runtime extension functional test
     }).timeout(10000 * 2);
 
@@ -59,7 +59,7 @@ suite('DotnetPathFinder Unit Tests', function ()
             const result = await finder.findHostInstallPaths(os.arch());
 
             assert.isTrue(result !== undefined, 'The dotnet path finder found a dotnet path');
-            assert.equal(result?.at(0), fakeDotnetPath, 'The correct path is found');
+            assert.equal(result?.at(0), path.join(fakeDotnetPath, 'dotnet'), 'The correct path is found');
         }
     });
 });

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
@@ -50,6 +50,10 @@ suite('DotnetPathFinder Unit Tests', function ()
             if (!fs.existsSync(installRecordPath))
             {
                 madeFakeDotnetInstallRecord = true;
+                if(!fs.existsSync(path.dirname(installRecordPath)))
+                {
+                    fs.mkdirSync(path.dirname(installRecordPath), { recursive: true });
+                }
                 fs.writeFileSync(path.join(installRecordPath), fakeDotnetPath);
             }
 
@@ -76,6 +80,10 @@ suite('DotnetPathFinder Unit Tests', function ()
             if (!fs.existsSync(installRecordPathNoArch))
             {
                 madeFakeDotnetInstallRecord = true;
+                if(!fs.existsSync(path.dirname(installRecordPathNoArch)))
+                {
+                    fs.mkdirSync(path.dirname(installRecordPathNoArch), { recursive: true });
+                }
                 fs.writeFileSync(path.join(installRecordPathNoArch), fakeDotnetPath);
             }
 

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { DotnetPathFinder } from '../../Acquisition/DotnetPathFinder';
+import { getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
+import { MockCommandExecutor } from '../mocks/MockObjects';
+
+const assert = chai.assert;
+chai.use(chaiAsPromised);
+
+suite('DotnetPathFinder Unit Tests', function ()
+{
+    const installRecordPath = `/etc/dotnet/install_location_${os.arch()}`;
+    const installRecordPathNoArch = `/etc/dotnet/install_location`;
+    const fakeDotnetPath = 'fake/dotnet';
+
+    let madeFakeDotnetInstallRecord = false;
+    let madeFakeDotnetDir = false;
+
+    const mockContext = getMockAcquisitionContext('sdk', '8.0');
+    const mockUtility = getMockUtilityContext();
+    const mockExecutor = new MockCommandExecutor(mockContext, mockUtility);
+
+    this.afterEach(async () =>
+    {
+        if(madeFakeDotnetInstallRecord)
+        {
+            fs.rmSync(installRecordPath, { recursive: true });
+        }
+
+        if(madeFakeDotnetDir)
+        {
+            fs.rmdirSync(madeFakeDotnetDir, { recursive: true });
+        }
+    });
+
+
+    test('It can find the hostfxr record on mac/linux', async () =>
+    {
+        // Make it look like theres an 8.0 install on the host in case we want to validate it if we ever want to add win32 test like so
+        // mockExecutor.fakeReturnValue = { stdout: '8.0.101 [C:\\Program Files\\dotnet\\sdk]', stderr: '', status: '0' };
+        if(os.platform() !== 'win32')
+        {
+            if (!fs.existsSync(installRecordPath))
+            {
+                madeFakeDotnetInstallRecord = true;
+                fs.writeFileSync(path.join(installRecordPath), fakeDotnetPath);
+            }
+
+            const finder = new DotnetPathFinder(mockContext, mockUtility, mockExecutor);
+            const result = await finder.findHostInstallPaths(os.arch());
+
+            assert.isTrue(result !== undefined, 'The dotnet path finder found a dotnet path');
+
+            if(madeFakeDotnetInstallRecord)
+            {
+                assert.equal(result?.at(0), fakeDotnetPath, 'The correct path is found');
+            }
+            else
+            {
+                console.warn('Cannot verify the correct install path is used since a legitimate install exists')
+            }
+        } // Windows and other lookup is covered in the registryReader or the runtime extension functional test
+    }).timeout(10000 * 2);
+
+    test('It can find the hostfxr record on mac/linux without arch', async () =>
+    {
+        if(os.platform() !== 'win32')
+        {
+            if (!fs.existsSync(installRecordPathNoArch))
+            {
+                madeFakeDotnetInstallRecord = true;
+                fs.writeFileSync(path.join(installRecordPathNoArch), fakeDotnetPath);
+            }
+
+            const finder = new DotnetPathFinder(mockContext, mockUtility, mockExecutor);
+            const result = await finder.findHostInstallPaths(os.arch());
+
+            assert.isTrue(result !== undefined, 'The dotnet path finder found a dotnet path');
+
+            if(!fs.existsSync(installRecordPath) && madeFakeDotnetInstallRecord)
+            {
+                assert.equal(result?.at(0), fakeDotnetPath, 'The correct path is found');
+            }
+            else
+            {
+                console.warn('Since there is a legitimate install native record, the test to validate finding a legacy non-native record will not be accurate');
+            }
+        }
+    });
+});

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -39,7 +39,7 @@ suite('Linux Distro Logic Unit Tests', () =>
             assert.equal(mockExecutor.attemptedCommand,
 'apt-cache -o DPkg::Lock::Timeout=180 search --names-only ^dotnet-sdk-9.0$', 'Searched for the newest package last with regex'); // this may fail if test not exec'd first
             // the data is cached so --version may not be executed.
-            assert.equal(recVersion, '8.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
+            assert.equal(recVersion, '9.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -7,7 +7,7 @@ import * as chai from 'chai';
 import * as os from 'os';
 import { GenericDistroSDKProvider } from '../../Acquisition/GenericDistroSDKProvider';
 import { MockCommandExecutor, MockEventStream } from '../mocks/MockObjects';
-import { DistroVersionPair, DotnetDistroSupportStatus } from '../../Acquisition/LinuxVersionResolver';
+import { DistroVersionPair, DotnetDistroSupportStatus, LinuxVersionResolver } from '../../Acquisition/LinuxVersionResolver';
 import { getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
 import { DotnetInstallMode } from '../../Acquisition/DotnetInstallMode';
 const assert = chai.assert;
@@ -39,7 +39,8 @@ suite('Linux Distro Logic Unit Tests', () =>
             assert.equal(mockExecutor.attemptedCommand,
 'apt-cache -o DPkg::Lock::Timeout=180 search --names-only ^dotnet-sdk-9.0$', 'Searched for the newest package last with regex'); // this may fail if test not exec'd first
             // the data is cached so --version may not be executed.
-            assert.equal(recVersion, '9.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
+            const distroVersion = await new LinuxVersionResolver(acquisitionContext, getMockUtilityContext()).getRunningDistro();
+            assert.equal(recVersion, Number(distroVersion) > 22.04 ? '9.0.1xx' : '8.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/test/unit/RegistryReader.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/RegistryReader.test.ts
@@ -1,0 +1,71 @@
+/* --------------------------------------------------------------------------------------------
+ *  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as chai from 'chai';
+import * as os from 'os';
+import { MockCommandExecutor } from '../mocks/MockObjects';
+import { getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
+import { RegistryReader } from '../../Acquisition/RegistryReader';
+const assert = chai.assert;
+const standardTimeoutTime = 100000;
+
+
+suite('RegistryReader Tests', () =>
+{
+    const mockVersion = '7.0.306';
+    const mockExecutor = new MockCommandExecutor(getMockAcquisitionContext('sdk', mockVersion), getMockUtilityContext());
+    const reader : RegistryReader = new RegistryReader(getMockAcquisitionContext('sdk', mockVersion), getMockUtilityContext(), mockExecutor);
+
+    test('It reads SDK registry entries correctly on windows', async () =>
+    {
+        if(os.platform() === 'win32')
+        {
+            // 32 and 64 bit sdks exist
+            mockExecutor.fakeReturnValue = {
+                stdout: `
+            5.0.416    REG_DWORD    0x1
+            8.0.100-preview.5.23265.7    REG_DWORD    0x1
+            7.0.301    REG_DWORD    0x1
+            6.0.416    REG_DWORD    0x1
+            7.0.109    REG_DWORD    0x1
+            7.0.304    REG_DWORD    0x1
+
+        `,
+                status: '0',
+                stderr: ''
+            };
+
+            let foundVersions = await reader.getGlobalSdkVersionsInstalledOnMachine();
+            assert.deepStrictEqual(foundVersions, ['5.0.416', '8.0.100-preview.5.23265.7', '7.0.301', '6.0.416', '7.0.109', '7.0.304']);
+            assert.include(mockExecutor.attemptedCommand, 'query HKEY', 'it finds sdks on the machine');
+
+            // only 1 64 bit sdks exist
+            mockExecutor.fakeReturnValue = {
+                stdout: `
+            7.0.301    REG_DWORD    0x1
+        `,
+                status: '0',
+                stderr: ''
+            };
+            mockExecutor.otherCommandPatternsToMock = ['x86'] // make the 32 bit query error / have no result
+            mockExecutor.otherCommandsReturnValues = [{stderr: `ERROR: The system was unable to find the specified registry key or value.`, status: '1', stdout: ''}];
+            foundVersions = await reader.getGlobalSdkVersionsInstalledOnMachine();
+            assert.deepStrictEqual(foundVersions, ['7.0.301'], 'it handles 32 bit sdk not found');
+
+            // no sdks exist
+            // Try throwing for  64 bit, and returning empty for 32 bit
+            mockExecutor.fakeReturnValue = {stdout: `ERROR: The system was unable to find the specified registry key or value.`, status: '1', stderr: ''};
+            mockExecutor.otherCommandsReturnValues = [{stdout: '', status: '0', stderr: ''}];
+            foundVersions = await reader.getGlobalSdkVersionsInstalledOnMachine();
+            assert.deepStrictEqual(foundVersions, [], 'it finds nothing with empty string and or error status');
+
+            mockExecutor.resetReturnValues();
+            // Assert that it passes when running the command for real
+            foundVersions = await reader.getGlobalSdkVersionsInstalledOnMachine();
+            assert.exists(foundVersions);
+        }
+    });
+});

--- a/vscode-dotnet-runtime-library/src/test/unit/RegistryReader.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/RegistryReader.test.ts
@@ -93,7 +93,7 @@ suite('RegistryReader Tests', () =>
 
             mockExecutor.fakeReturnValue = {
                 stdout: `
-
+HKEY_LOCAL_MACHINE\\SOFTWARE\\dotnet\\Setup\\InstalledVersions\\x64
     InstallLocation    REG_SZ    ${mockNotThisArchHostPath}
 
         `,
@@ -117,7 +117,7 @@ suite('RegistryReader Tests', () =>
             const correctPath = 'C:\\Program Files\\foo\\dotnet.exe';
             // only 1 64 bit sdks exist
             mockExecutor.fakeReturnValue = {
-                stdout: `
+                stdout: `HKEY_LOCAL_MACHINE\\SOFTWARE\\dotnet\\Setup\\InstalledVersions\\x64
     Path    REG_SZ    C:\\Program Files\\dotnet\\dotnet.exe
         `,
                 status: '1',


### PR DESCRIPTION
# What This Does 🤘 

This improves the detection of .NET installs to rely on the installation records containing paths to the dotnet host instead of just the PATH as a backup option for locating dotnet.

What I will describe below is documented here:
See https://github.com/dotnet/runtime/issues/109974
See https://github.com/dotnet/designs/blob/main/accepted/2021/install-location-per-architecture.md

Thank you to @elinor-fung for help understanding these docs.
We've had confirmation from internal folks who were blocked that this fixed the issues for them and I did lots of manual testing. 

## Windows 🪟 

For Windows, the registry includes records written by various installers. Anyone who makes an installer for .NET is supposed to follow the logic which is documented above.

Within `HKEY_LOCAL_MACHINE\\SOFTWARE\\dotnet\\Setup\\InstalledVersions\\${architecture}\\`:
The `sharedhost` registry key stores the path of dotnet that gets put on the PATH. As we want to mimic the terminal behavior as much as possible, we first check this location. For non native installs: sharedhost nodes may exist, but there will be no path key, so we can't use it in this case.

The `InstallLocation` key stores other paths to the host that might not be on the PATH, such as an x64 host on an arm64 machine. The InstallLocation is always under the 32 bit reg node for our purposes, and the sharedhost is always on the native node. You can't install arm64 SDK or Runtime on x64, but you can do vice versa and they follow the same methodology and they follow the same rules.

## Unix 🐧 

For Linux and Mac, installers are supposed to write to `/etc/dotnet/install_location_${requestedArchitecture}` a file which contains only the path. I confirmed various mac installers do that. The ubuntu installer via feeds does this at least in `--classic` mode. The snap installer does as well but does so incorrectly, as it writes /usr/lib/dotnet/ to it, which is not actually where dotnet gets installed via snap. We might wanna alert them to that. Our existing code seems to do a good job with snap, vscode has not given us incorrect information here to my knowledge, so I am not too concerned.

Prior to .NET 6, installers wrote to `/etc/dotnet/install_location`. We use this as a backup and so does .NET 6+.

Thank you to @richlander for coming up with this idea with me.

# Context ❓ 

For years now, the `C#` extension, `Unity` Extension, `MAUI`, etc, and now, `C# DevKit`, have been plagued by issues trying to find the .NET Installation on the PATH environment variable.

Our team did a thorough analysis as to the methods in which .NET is installed across many operating systems and architectures, how to check the PATH, spawning a node.js process with different shells, resolving `realpaths`, `symlinks`, and polymorphic executables (`snap`) etc., and released an API for PATH lookup.

However, we still are facing issues with the PATH. Upon final conclusion, it seems no matter what we call, the PATH information we get as an extension calling into node's `child_process` library, or `process.env`, or any other method we could think of, the environment information is not complete. There is also the `vscode.environmentVariableCollection`, which we do leverage, but my understanding is that this is only for editing the terminal / getting workspace preferences. Using the process explorer, it seems that there are some subprocesses in VS Code that have access to more environment variables than others (presumably electron main vs subprocesses), but I believe the whatever runs the extension host is not one of them.

I asked the VS Code team if we all been taking the incorrect approach here to try `process.env`, `vscode.environmentVariableCollection`, `child_process`, etc. They confirmed our approach is correct.

# When does this cause problems? 🔍 

Here is one such example [[BUG] Cannot find .NET SDK installation from PATH environment (macOS) · Issue #1471 · microsoft/vscode-dotnettools (github.com)](https://github.com/microsoft/vscode-dotnettools/issues/1471). 
The most recent example is from an internal member. There are like 20 to 60+ more. I'm not going to link them all. Many of those are because the PATH API has not been adopted in general, not just a problem with the PATH API, because it is not being called by either extension in RTM prod yet.

In a terminal with bin/bash, his PATH looks like:


```
PATH=/opt/anaconda3/bin:/opt/anaconda3/condabin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/usr/local/share/dotnet:~/.dotnet/tools

```

When we call from our extension, using node: `child_process.spawnSync('env', [], { env: process.env, shell: '/bin/bash')`

```
PATH=/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin
```

Note that the environment pretends that it doesn't have dotnet or anaconda installed, amongst others. There is no alternative correct source of truth to get the actual env, from within vscode. This statement is not coming from just me, it is also coming from the VS Code team.

# How VS Code Gets Env 💥  🐛 

In VS Code, there is a file called [shellEnv.ts](https://github.com/microsoft/vscode/blob/28030eb6be98ab8d92e3883d83bfafeeece17cd3/src/vs/platform/shell/node/shellEnv.ts). I discused this file with them as well. After further discussion with the VS Code team, the VS Code bootstrapping code changes whether vscode is launched in dock mode or from the terminal. In the dock, this`shellEnv.ts` logic kicks in to try to correct and find the environment. It appears there is a problem with that code's ability to determine the environment. It is challenging to get a repro environment, and their logs are not sufficient to diagnose the problem without building from source on a customer's machine, which I am not going to pester someone to do. 

I may drive an effort for a fix in the vscode team, but this approach seemed like the fastest way to get to a resolution.

# Interested Individuals 📲 
cc @arunchndr @dibarbet @adrianvmsft @lifenglu @webreidi @baronfel 
This is not a blocker to the PATH API but a further improvement for when VS Code gives incorrect information. No action is required from those who are adapting the API.