### PR TITLE
Update Linux Tests

### DIFF
--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -574,7 +574,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     }
     else
     {
-      assert.equal(result[0].version, '8.0.1xx', 'The SDK did not recommend the version it was supposed to, which should be N.0.1xx based on surface level distro knowledge. If a new version is available, this test may need to be updated to the newest version.');
+      assert.equal(result[0].version, '9.0.1xx', 'The SDK did not recommend the version it was supposed to, which should be N.0.1xx based on surface level distro knowledge. If a new version is available, this test may need to be updated to the newest version.');
 
     }
   }).timeout(standardTimeoutTime);

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -39,7 +39,7 @@ suite('Linux Distro Logic Unit Tests', () =>
             assert.equal(mockExecutor.attemptedCommand,
 'apt-cache -o DPkg::Lock::Timeout=180 search --names-only ^dotnet-sdk-9.0$', 'Searched for the newest package last with regex'); // this may fail if test not exec'd first
             // the data is cached so --version may not be executed.
-            assert.equal(recVersion, '8.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
+            assert.equal(recVersion, '9.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
@@ -131,7 +131,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
             assert.equal(mockExecutor.attemptedCommand, 'dotnet --version', 'Correct command run to get recommended version, uses newest package in distro json');
-            assert.equal(recVersion, '8.0.1xx', 'The most in support version is suggested : will eventually break if not updated');
+            assert.equal(recVersion, '9.0.1xx', 'The most in support version is suggested : will eventually break if not updated');
         }
     }).timeout(standardTimeoutTime);
 


### PR DESCRIPTION
9.0 Shipped on Linux so we should update the tests. These tests do test the live availability of what's available and it's good that they do so they actually test the functionality and not some mock data, which wouldnt be a relevant test. That does mean they need to get updated, but I think the messaging is pretty clear and the impacts aren't so bad.