### PR TITLE
Fix Powershell Execution Policy & Language Mode Logic

### DIFF
--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -42,6 +42,7 @@
   version "1.17.0"
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.17.0.tgz"
   integrity sha1-Vdr6EJNVPFSe1tjbymmqUFx7OqM=
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.17.0.tgz"
   dependencies:
     "@azure/abort-controller" "^2.0.0"
     "@azure/core-auth" "^1.8.0"

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -9,33 +9,33 @@ import * as path from 'path';
 import * as rimraf from 'rimraf';
 import * as vscode from 'vscode';
 import
-  {
-    FileUtilities,
-    IDotnetAcquireContext,
-    IDotnetAcquireResult,
-    IExistingPaths,
-    IDotnetListVersionsContext,
-    IDotnetListVersionsResult,
-    getInstallIdCustomArchitecture,
-    ITelemetryEvent,
-    MockExtensionConfiguration,
-    MockExtensionContext,
-    MockTelemetryReporter,
-    MockWebRequestWorker,
-    MockWindowDisplayWorker,
-    getMockAcquisitionContext,
-    DotnetInstallMode,
-    DotnetInstallType,
-    MockEventStream,
-    IDotnetFindPathContext,
-    getDotnetExecutable,
-    DotnetVersionSpecRequirement,
-    EnvironmentVariableIsDefined,
-    MockEnvironmentVariableCollection,
-    getPathSeparator,
-    LinuxVersionResolver,
-    getMockUtilityContext,
-  } from 'vscode-dotnet-runtime-library';
+{
+  FileUtilities,
+  IDotnetAcquireContext,
+  IDotnetAcquireResult,
+  IExistingPaths,
+  IDotnetListVersionsContext,
+  IDotnetListVersionsResult,
+  getInstallIdCustomArchitecture,
+  ITelemetryEvent,
+  MockExtensionConfiguration,
+  MockExtensionContext,
+  MockTelemetryReporter,
+  MockWebRequestWorker,
+  MockWindowDisplayWorker,
+  getMockAcquisitionContext,
+  DotnetInstallMode,
+  DotnetInstallType,
+  MockEventStream,
+  IDotnetFindPathContext,
+  getDotnetExecutable,
+  DotnetVersionSpecRequirement,
+  EnvironmentVariableIsDefined,
+  MockEnvironmentVariableCollection,
+  getPathSeparator,
+  LinuxVersionResolver,
+  getMockUtilityContext,
+} from 'vscode-dotnet-runtime-library';
 import * as extension from '../../extension';
 import { warn } from 'console';
 import { InstallTrackerSingleton } from 'vscode-dotnet-runtime-library/dist/Acquisition/InstallTrackerSingleton';
@@ -619,7 +619,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function ()
     else
     {
       const distroVersion = await new LinuxVersionResolver(mockAcquisitionContext, getMockUtilityContext()).getRunningDistro();
-      assert.equal(result[0].version, Number(distroVersion) >= 22.04 ? '9.0.1xx' : '8.0.1xx', 'The SDK did not recommend the version it was supposed to, which should be N.0.1xx based on surface level distro knowledge. If a new version is available, this test may need to be updated to the newest version.');
+      assert.equal(result[0].version, Number(distroVersion) >= 22.04 ? '9.0.1xx' : '8.0.1xx', `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${distroVersion}. If a new version is available, this test may need to be updated to the newest version.`);
     }
   }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -619,7 +619,15 @@ suite('DotnetCoreAcquisitionExtension End to End', function ()
     else
     {
       const distroVersion = await new LinuxVersionResolver(mockAcquisitionContext, getMockUtilityContext()).getRunningDistro();
-      assert.equal(result[0].version, Number(distroVersion) >= 22.04 ? '9.0.1xx' : '8.0.1xx', `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${distroVersion}. If a new version is available, this test may need to be updated to the newest version.`);
+      if (Number(distroVersion) === 22.04)
+      {
+        // certain versions have 9 support but others do not
+        assert.include(['9.0.1xx', '8.0.1xx'], result[0].version, `${result[0].version} is 9 or 8 : special check for ubuntu 22.04`);
+      }
+      else
+      {
+        assert.equal(result[0].version, Number(distroVersion) >= 22.04 ? '9.0.1xx' : '8.0.1xx', `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${distroVersion.version}. If a new version is available, this test may need to be updated to the newest version.`);
+      }
     }
   }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -8,42 +8,43 @@ import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
 import * as vscode from 'vscode';
-import {
-  FileUtilities,
-  IDotnetAcquireContext,
-  IDotnetAcquireResult,
-  IExistingPaths,
-  IDotnetListVersionsContext,
-  IDotnetListVersionsResult,
-  getInstallIdCustomArchitecture,
-  ITelemetryEvent,
-  MockExtensionConfiguration,
-  MockExtensionContext,
-  MockTelemetryReporter,
-  MockWebRequestWorker,
-  MockWindowDisplayWorker,
-  getMockAcquisitionContext,
-  DotnetInstallMode,
-  DotnetInstallType,
-  MockEventStream,
-  IDotnetFindPathContext,
-  getDotnetExecutable,
-  DotnetVersionSpecRequirement,
-  EnvironmentVariableIsDefined,
-  MockEnvironmentVariableCollection,
-  getPathSeparator,
-  LinuxVersionResolver,
-  getMockUtilityContext,
-} from 'vscode-dotnet-runtime-library';
+import
+  {
+    FileUtilities,
+    IDotnetAcquireContext,
+    IDotnetAcquireResult,
+    IExistingPaths,
+    IDotnetListVersionsContext,
+    IDotnetListVersionsResult,
+    getInstallIdCustomArchitecture,
+    ITelemetryEvent,
+    MockExtensionConfiguration,
+    MockExtensionContext,
+    MockTelemetryReporter,
+    MockWebRequestWorker,
+    MockWindowDisplayWorker,
+    getMockAcquisitionContext,
+    DotnetInstallMode,
+    DotnetInstallType,
+    MockEventStream,
+    IDotnetFindPathContext,
+    getDotnetExecutable,
+    DotnetVersionSpecRequirement,
+    EnvironmentVariableIsDefined,
+    MockEnvironmentVariableCollection,
+    getPathSeparator,
+    LinuxVersionResolver,
+    getMockUtilityContext,
+  } from 'vscode-dotnet-runtime-library';
 import * as extension from '../../extension';
 import { warn } from 'console';
 import { InstallTrackerSingleton } from 'vscode-dotnet-runtime-library/dist/Acquisition/InstallTrackerSingleton';
 
-const assert : any = chai.assert;
+const assert: any = chai.assert;
 const standardTimeoutTime = 40000;
 const originalPATH = process.env.PATH;
 
-suite('DotnetCoreAcquisitionExtension End to End', function()
+suite('DotnetCoreAcquisitionExtension End to End', function ()
 {
   this.retries(1);
   const storagePath = path.join(__dirname, 'tmp');
@@ -59,7 +60,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
   const pathWithIncorrectVersionForTest = path.join(__dirname, `/.dotnet/${existingPathVersionToFake}/dotnet`);
 
   const mockExistingPathsWithGlobalConfig: IExistingPaths = {
-    individualizedExtensionPaths: [{extensionId: 'alternative.extension', path: pathWithIncorrectVersionForTest}],
+    individualizedExtensionPaths: [{ extensionId: 'alternative.extension', path: pathWithIncorrectVersionForTest }],
     sharedExistingPath: undefined
   }
 
@@ -85,7 +86,8 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
       ]
   }`;
 
-  this.beforeAll(async () => {
+  this.beforeAll(async () =>
+  {
     extensionContext = {
       subscriptions: [],
       globalStoragePath: storagePath,
@@ -104,7 +106,8 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     });
   });
 
-  this.afterEach(async () => {
+  this.afterEach(async () =>
+  {
     // Tear down tmp storage for fresh run
     process.env.PATH = originalPATH;
 
@@ -115,18 +118,19 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     InstallTrackerSingleton.getInstance(new MockEventStream(), new MockExtensionContext()).clearPromises();
   }).timeout(standardTimeoutTime);
 
-  test('Activate', async () => {
+  test('Activate', async () =>
+  {
     // Commands should now be registered
     assert.exists(extensionContext);
     assert.isAbove(extensionContext.subscriptions.length, 0);
   }).timeout(standardTimeoutTime);
 
-  async function installRuntime(dotnetVersion : string, installMode : DotnetInstallMode, arch? : string)
+  async function installRuntime(dotnetVersion: string, installMode: DotnetInstallMode, arch?: string)
   {
     let context: IDotnetAcquireContext = { version: dotnetVersion, requestingExtensionId, mode: installMode };
-    if(arch)
+    if (arch)
     {
-        context.architecture = arch;
+      context.architecture = arch;
     }
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
     assert.exists(result, 'Command results a result');
@@ -138,25 +142,28 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
   }
 
 
-  async function installMultipleVersions(versions : string[], installMode : DotnetInstallMode)
+  async function installMultipleVersions(versions: string[], installMode: DotnetInstallMode)
   {
     let dotnetPaths: string[] = [];
-    for (const version of versions) {
+    for (const version of versions)
+    {
       const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', { version, requestingExtensionId, mode: installMode });
       assert.exists(result, 'acquire command returned a result/success');
       assert.exists(result!.dotnetPath, 'the result has a path');
       assert.include(result!.dotnetPath, version, 'the path includes the version');
-      if (result!.dotnetPath) {
+      if (result!.dotnetPath)
+      {
         dotnetPaths = dotnetPaths.concat(result!.dotnetPath);
       }
     }
     // All versions are still there after all installs are completed
-    for (const dotnetPath of dotnetPaths) {
+    for (const dotnetPath of dotnetPaths)
+    {
       assert.isTrue(fs.existsSync(dotnetPath));
     }
   }
 
-  async function installUninstallOne(dotnetVersion : string, versionToKeep : string, installMode : DotnetInstallMode, type : DotnetInstallType)
+  async function installUninstallOne(dotnetVersion: string, versionToKeep: string, installMode: DotnetInstallMode, type: DotnetInstallType)
   {
     const context: IDotnetAcquireContext = { version: dotnetVersion, requestingExtensionId, mode: installMode, installType: type };
     const contextToKeep: IDotnetAcquireContext = { version: versionToKeep, requestingExtensionId, mode: installMode, installType: type };
@@ -172,7 +179,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.isTrue(fs.existsSync(resultToKeep!.dotnetPath), 'Only one thing is uninstalled.');
   }
 
-  async function installUninstallAll(dotnetVersion : string, installMode : DotnetInstallMode)
+  async function installUninstallAll(dotnetVersion: string, installMode: DotnetInstallMode)
   {
     const context: IDotnetAcquireContext = { version: dotnetVersion, requestingExtensionId, mode: installMode };
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
@@ -184,7 +191,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.isFalse(fs.existsSync(result!.dotnetPath), 'the dotnet path result does not exist after uninstall');
   }
 
-  async function uninstallWithMultipleOwners(dotnetVersion : string, installMode : DotnetInstallMode, type : DotnetInstallType)
+  async function uninstallWithMultipleOwners(dotnetVersion: string, installMode: DotnetInstallMode, type: DotnetInstallType)
   {
     const context: IDotnetAcquireContext = { version: dotnetVersion, requestingExtensionId, mode: installMode, installType: type };
     const contextFromOtherId: IDotnetAcquireContext = { version: dotnetVersion, requestingExtensionId: 'fake.extension.two', mode: installMode, installType: type };
@@ -203,59 +210,61 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.isFalse(fs.existsSync(result!.dotnetPath), 'the dotnet path result does not exist after uninstalling from all owners');
   }
 
-  function includesPathWithLikelyDotnet(pathToCheck : string) : boolean
+  function includesPathWithLikelyDotnet(pathToCheck: string): boolean
   {
     const lowerPath = pathToCheck.toLowerCase();
     return lowerPath.includes('dotnet') || lowerPath.includes('program') || lowerPath.includes('share') || lowerPath.includes('bin') || lowerPath.includes('snap') || lowerPath.includes('homebrew');
   }
 
-  async function findPathWithRequirementAndInstall(version : string, iMode : DotnetInstallMode, arch : string, condition : DotnetVersionSpecRequirement, shouldFind : boolean, contextToLookFor? : IDotnetAcquireContext, setPath = true,
+  async function findPathWithRequirementAndInstall(version: string, iMode: DotnetInstallMode, arch: string, condition: DotnetVersionSpecRequirement, shouldFind: boolean, contextToLookFor?: IDotnetAcquireContext, setPath = true,
     blockNoArch = false, dontCheckNonPaths = true)
   {
     const installPath = await installRuntime(version, iMode, arch);
 
     // use path.dirname : the dotnet.exe cant be on the PATH
-    if(setPath)
+    if (setPath)
     {
-        process.env.PATH = `${path.dirname(installPath)}${getPathSeparator()}${process.env.PATH?.split(getPathSeparator()).filter((x : string) => !(includesPathWithLikelyDotnet(x))).join(getPathSeparator())}`;
+      process.env.PATH = `${path.dirname(installPath)}${getPathSeparator()}${process.env.PATH?.split(getPathSeparator()).filter((x: string) => !(includesPathWithLikelyDotnet(x))).join(getPathSeparator())}`;
     }
     else
     {
-        // remove dotnet so the test will work on machines with dotnet installed
-        process.env.PATH = `${process.env.PATH?.split(getPathSeparator()).filter((x : string) => !(includesPathWithLikelyDotnet(x))).join(getPathSeparator())}`;
-        process.env.DOTNET_ROOT = path.dirname(installPath);
+      // remove dotnet so the test will work on machines with dotnet installed
+      process.env.PATH = `${process.env.PATH?.split(getPathSeparator()).filter((x: string) => !(includesPathWithLikelyDotnet(x))).join(getPathSeparator())}`;
+      process.env.DOTNET_ROOT = path.dirname(installPath);
     }
 
     extensionContext.environmentVariableCollection.replace('PATH', process.env.PATH ?? '');
 
-    if(blockNoArch)
+    if (blockNoArch)
     {
-        extensionContext.environmentVariableCollection.replace('DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH', '1');
-        process.env.DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH = '1';
+      extensionContext.environmentVariableCollection.replace('DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH', '1');
+      process.env.DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH = '1';
     }
 
-    if(dontCheckNonPaths)
+    if (dontCheckNonPaths)
     {
-        process.env.DOTNET_INSTALL_TOOL_SKIP_HOSTFXR = 'true';
+      process.env.DOTNET_INSTALL_TOOL_SKIP_HOSTFXR = 'true';
     }
 
-    const result : IDotnetAcquireResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath',
-        { acquireContext : contextToLookFor ?? { version, requestingExtensionId : requestingExtensionId, mode: iMode, architecture : arch } as IDotnetAcquireContext,
-        versionSpecRequirement : condition} as IDotnetFindPathContext
+    const result: IDotnetAcquireResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath',
+      {
+        acquireContext: contextToLookFor ?? { version, requestingExtensionId: requestingExtensionId, mode: iMode, architecture: arch } as IDotnetAcquireContext,
+        versionSpecRequirement: condition
+      } as IDotnetFindPathContext
     );
 
     extensionContext.environmentVariableCollection.replace('DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH', '0');
     process.env.DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH = '0';
     process.env.DOTNET_INSTALL_TOOL_SKIP_HOSTFXR = '0';
 
-    if(shouldFind)
+    if (shouldFind)
     {
-        assert.exists(result.dotnetPath, 'find path command returned a result');
-        assert.equal(result.dotnetPath.toLowerCase(), installPath.toLowerCase(), 'The path returned by findPath is correct');
+      assert.exists(result.dotnetPath, 'find path command returned a result');
+      assert.equal(result.dotnetPath.toLowerCase(), installPath.toLowerCase(), 'The path returned by findPath is correct');
     }
     else
     {
-        assert.equal(result?.dotnetPath, undefined, 'find path command returned no undefined if no path matches condition');
+      assert.equal(result?.dotnetPath, undefined, 'find path command returned no undefined if no path matches condition');
     }
   }
 
@@ -269,147 +278,166 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     await installRuntime('7.0', 'aspnetcore');
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall One Local Runtime Command', async () => {
+  test('Uninstall One Local Runtime Command', async () =>
+  {
     await installUninstallOne('2.2', '7.0', 'runtime', 'local');
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall One Local ASP.NET Runtime Command', async () => {
+  test('Uninstall One Local ASP.NET Runtime Command', async () =>
+  {
     await installUninstallOne('2.2', '6.0', 'aspnetcore', 'local');
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall All Local Runtime Command', async () => {
+  test('Uninstall All Local Runtime Command', async () =>
+  {
     await installUninstallAll('2.2', 'runtime')
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall All Local ASP.NET Runtime Command', async () => {
+  test('Uninstall All Local ASP.NET Runtime Command', async () =>
+  {
     await installUninstallAll('2.2', 'aspnetcore')
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall Runtime Only Once No Owners Exist', async () => {
+  test('Uninstall Runtime Only Once No Owners Exist', async () =>
+  {
     await uninstallWithMultipleOwners('8.0', 'runtime', 'local');
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall ASP.NET Runtime Only Once No Owners Exist', async () => {
+  test('Uninstall ASP.NET Runtime Only Once No Owners Exist', async () =>
+  {
     await uninstallWithMultipleOwners('8.0', 'aspnetcore', 'local');
   }).timeout(standardTimeoutTime);
 
-  test('Install and Uninstall Multiple Local Runtime Versions', async () => {
+  test('Install and Uninstall Multiple Local Runtime Versions', async () =>
+  {
     await installMultipleVersions(['2.2', '3.0', '3.1'], 'runtime');
   }).timeout(standardTimeoutTime * 2);
 
-  test('Install and Uninstall Multiple Local ASP.NET Runtime Versions', async () => {
+  test('Install and Uninstall Multiple Local ASP.NET Runtime Versions', async () =>
+  {
     await installMultipleVersions(['2.2', '3.0', '3.1'], 'aspnetcore');
   }).timeout(standardTimeoutTime * 2);
 
-  test('Find dotnet PATH Command Met Condition', async () => {
+  test('Find dotnet PATH Command Met Condition', async () =>
+  {
     // install 5.0 then look for 5.0 path
     await findPathWithRequirementAndInstall('5.0', 'runtime', os.arch(), 'greater_than_or_equal', true);
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Met ROOT Condition', async () => {
+  test('Find dotnet PATH Command Met ROOT Condition', async () =>
+  {
     // install 7.0, set dotnet_root and not path, then look for root
     const oldROOT = process.env.DOTNET_ROOT;
 
     await findPathWithRequirementAndInstall('7.0', 'runtime', os.arch(), 'equal', true,
-        {version : '7.0', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}, false
+      { version: '7.0', mode: 'runtime', architecture: os.arch(), requestingExtensionId: requestingExtensionId }, false
     );
 
-    if(EnvironmentVariableIsDefined(oldROOT))
+    if (EnvironmentVariableIsDefined(oldROOT))
     {
-        process.env.DOTNET_ROOT = oldROOT;
+      process.env.DOTNET_ROOT = oldROOT;
     }
     else
     {
-        delete process.env.DOTNET_ROOT;
+      delete process.env.DOTNET_ROOT;
     }
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Met Version Condition', async () => {
+  test('Find dotnet PATH Command Met Version Condition', async () =>
+  {
     // Install 8.0, look for 3.1 with accepting dotnet gr than or eq to 3.1
 
     await findPathWithRequirementAndInstall('8.0', 'runtime', os.arch(), 'greater_than_or_equal', true,
-        {version : '3.1', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
+      { version: '3.1', mode: 'runtime', architecture: os.arch(), requestingExtensionId: requestingExtensionId }
     );
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Met Version Condition with Double Digit Major', async () => {
+  test('Find dotnet PATH Command Met Version Condition with Double Digit Major', async () =>
+  {
     await findPathWithRequirementAndInstall('9.0', 'runtime', os.arch(), 'less_than_or_equal', true,
-        {version : '11.0', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
+      { version: '11.0', mode: 'runtime', architecture: os.arch(), requestingExtensionId: requestingExtensionId }
     );
   }).timeout(standardTimeoutTime);
 
 
-  test('Find dotnet PATH Command Unmet Version Condition', async () => {
+  test('Find dotnet PATH Command Unmet Version Condition', async () =>
+  {
     // Install 9.0, look for 90.0 which is not equal to 9.0
     await findPathWithRequirementAndInstall('9.0', 'runtime', os.arch(), 'equal', false,
-        {version : '90.0', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
+      { version: '90.0', mode: 'runtime', architecture: os.arch(), requestingExtensionId: requestingExtensionId }
     );
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Unmet Mode Condition', async () => {
+  test('Find dotnet PATH Command Unmet Mode Condition', async () =>
+  {
     // look for 3.1 runtime but install 3.1 aspnetcore
     await findPathWithRequirementAndInstall('3.1', 'runtime', os.arch(), 'equal', false,
-        {version : '3.1', mode : 'aspnetcore', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
+      { version: '3.1', mode: 'aspnetcore', architecture: os.arch(), requestingExtensionId: requestingExtensionId }
     );
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Unmet Arch Condition', async () => {
+  test('Find dotnet PATH Command Unmet Arch Condition', async () =>
+  {
     // look for a different architecture of 3.1
-    if(os.platform() !== 'darwin')
+    if (os.platform() !== 'darwin')
     {
-        // The CI Machines are running on ARM64 for OS X.
-        // They also have an x64 HOST. We can't set DOTNET_MULTILEVEL_LOOKUP to 0 because it will break the ability to find the host on --info
-        // As a 3.1 runtime host does not provide the architecture, but we try to use 3.1 because CI machines won't have it.
-        //
-        await findPathWithRequirementAndInstall('3.1', 'runtime', os.arch() == 'arm64' ? 'x64' : os.arch(), 'greater_than_or_equal', false,
-            {version : '3.1', mode : 'runtime', architecture : 'arm64', requestingExtensionId : requestingExtensionId}, true, true
-        );
+      // The CI Machines are running on ARM64 for OS X.
+      // They also have an x64 HOST. We can't set DOTNET_MULTILEVEL_LOOKUP to 0 because it will break the ability to find the host on --info
+      // As a 3.1 runtime host does not provide the architecture, but we try to use 3.1 because CI machines won't have it.
+      //
+      await findPathWithRequirementAndInstall('3.1', 'runtime', os.arch() == 'arm64' ? 'x64' : os.arch(), 'greater_than_or_equal', false,
+        { version: '3.1', mode: 'runtime', architecture: 'arm64', requestingExtensionId: requestingExtensionId }, true, true
+      );
     }
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Unmet Arch Condition With Host that prints Arch', async () => {
-    if(os.platform() !== 'darwin')
+  test('Find dotnet PATH Command Unmet Arch Condition With Host that prints Arch', async () =>
+  {
+    if (os.platform() !== 'darwin')
     {
-        await findPathWithRequirementAndInstall('9.0', 'runtime', os.arch() == 'arm64' ? 'x64' : os.arch(), 'greater_than_or_equal', false,
-            {version : '9.0', mode : 'runtime', architecture : 'arm64', requestingExtensionId : requestingExtensionId}
-        );
+      await findPathWithRequirementAndInstall('9.0', 'runtime', os.arch() == 'arm64' ? 'x64' : os.arch(), 'greater_than_or_equal', false,
+        { version: '9.0', mode: 'runtime', architecture: 'arm64', requestingExtensionId: requestingExtensionId }
+      );
     }
   }).timeout(standardTimeoutTime);
 
 
-  test('Find dotnet PATH Command No Arch Available But Accept By Default', async () => {
+  test('Find dotnet PATH Command No Arch Available But Accept By Default', async () =>
+  {
     // look for a different architecture of 3.1
-    if(os.platform() !== 'darwin')
+    if (os.platform() !== 'darwin')
     {
-        await findPathWithRequirementAndInstall('3.1', 'runtime', os.arch() == 'arm64' ? 'x64' : os.arch(), 'greater_than_or_equal', true,
-            {version : '3.1', mode : 'runtime', architecture : 'arm64', requestingExtensionId : requestingExtensionId}
-        );
+      await findPathWithRequirementAndInstall('3.1', 'runtime', os.arch() == 'arm64' ? 'x64' : os.arch(), 'greater_than_or_equal', true,
+        { version: '3.1', mode: 'runtime', architecture: 'arm64', requestingExtensionId: requestingExtensionId }
+      );
     }
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Unmet Runtime Patch Condition', async () => {
+  test('Find dotnet PATH Command Unmet Runtime Patch Condition', async () =>
+  {
     // Install 8.0.{LATEST, which will be < 99}, look for 8.0.99 with accepting dotnet gr than or eq to 8.0.99
     // No tests for SDK since that's harder to replicate with a global install and different machine states
-    if(os.platform() !== 'darwin')
+    if (os.platform() !== 'darwin')
     {
-        await findPathWithRequirementAndInstall('8.0', 'runtime', os.arch(), 'greater_than_or_equal', false,
-            {version : '8.0.99', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
-        );
+      await findPathWithRequirementAndInstall('8.0', 'runtime', os.arch(), 'greater_than_or_equal', false,
+        { version: '8.0.99', mode: 'runtime', architecture: os.arch(), requestingExtensionId: requestingExtensionId }
+      );
     }
   }).timeout(standardTimeoutTime);
 
-  test('Install SDK Globally E2E (Requires Admin)', async () => {
+  test('Install SDK Globally E2E (Requires Admin)', async () =>
+  {
     // We only test if the process is running under ADMIN because non-admin requires user-intervention.
-    if(new FileUtilities().isElevated())
+    if (new FileUtilities().isElevated())
     {
       const originalPath = process.env.PATH;
       const sdkVersion = '7.0.103';
-      const context : IDotnetAcquireContext = { version: sdkVersion, requestingExtensionId: 'sample-extension', installType: 'global' };
+      const context: IDotnetAcquireContext = { version: sdkVersion, requestingExtensionId: 'sample-extension', installType: 'global' };
 
       // We cannot use the describe pattern to restore the environment variables using vscode's extension testing infrastructure.
       // So we must set and unset it ourselves, which isn't ideal as this variable could remain.
-      let result : IDotnetAcquireResult;
-      let error : any;
+      let result: IDotnetAcquireResult;
+      let error: any;
       let pathAfterInstall;
 
       // We cannot test much as we don't want to leave global installs on dev boxes. But we do want to make sure the e-2-e goes through the right path. Vendors can test the rest.
@@ -419,7 +447,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
       {
         result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquireGlobalSDK', context);
       }
-      catch(err)
+      catch (err)
       {
         error = err;
       }
@@ -429,9 +457,9 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
         process.env.VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH = undefined;
         process.env.PATH = originalPath;
 
-        if(error)
+        if (error)
         {
-          throw(new Error(`The test failed to run the acquire command successfully. Error: ${error}`));
+          throw (new Error(`The test failed to run the acquire command successfully. Error: ${error}`));
         }
       }
 
@@ -447,10 +475,11 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
       // And we wouldn't be able to kill the process so the test would leave a lot of hanging processes on the machine
       warn('The Global SDK E2E Install test cannot run as the machine is unprivileged.');
     }
-  }).timeout(standardTimeoutTime*1000);
+  }).timeout(standardTimeoutTime * 1000);
 
-  test('Telemetry Sent During Install and Uninstall', async () => {
-    if(!vscode.env.isTelemetryEnabled)
+  test('Telemetry Sent During Install and Uninstall', async () =>
+  {
+    if (!vscode.env.isTelemetryEnabled)
     {
       console.warn('The telemetry test cannot run as VS Code Telemetry is disabled in user settings.');
       return;
@@ -493,24 +522,28 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.isEmpty(errors, `No error events were reported in telemetry reporting. ${JSON.stringify(errors)}`);
   }).timeout(standardTimeoutTime);
 
-  test('Telemetry Sent on Error', async () => {
-    if(!vscode.env.isTelemetryEnabled)
+  test('Telemetry Sent on Error', async () =>
+  {
+    if (!vscode.env.isTelemetryEnabled)
     {
       console.warn('The telemetry test cannot run as VS Code Telemetry is disabled in user settings.');
       return;
     }
 
     const context: IDotnetAcquireContext = { version: 'foo', requestingExtensionId };
-    try {
+    try
+    {
       await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
       assert.isTrue(false); // An error should have been thrown
-    } catch (error) {
+    } catch (error)
+    {
       const versionError = MockTelemetryReporter.telemetryEvents.find((event: ITelemetryEvent) => event.eventName === '[ERROR]:DotnetVersionResolutionError');
       assert.exists(versionError, 'The version resolution error appears in telemetry');
     }
-  }).timeout(standardTimeoutTime/2);
+  }).timeout(standardTimeoutTime / 2);
 
-  test('Install Local Runtime Command Passes With Warning With No RequestingExtensionId', async () => {
+  test('Install Local Runtime Command Passes With Warning With No RequestingExtensionId', async () =>
+  {
     const context: IDotnetAcquireContext = { version: '3.1' };
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
     assert.exists(result, 'A result from the API exists');
@@ -519,7 +552,8 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.include(mockDisplayWorker.warningMessage, 'Ignoring existing .NET paths');
   }).timeout(standardTimeoutTime);
 
-  test('Install Local Runtime Command With Path Setting', async () => {
+  test('Install Local Runtime Command With Path Setting', async () =>
+  {
     const context: IDotnetAcquireContext = { version: '5.0', requestingExtensionId: 'alternative.extension', architecture: os.platform() };
     const resultForAcquiringPathSettingRuntime = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
     assert.exists(resultForAcquiringPathSettingRuntime!.dotnetPath, 'Basic acquire works');
@@ -528,7 +562,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     // so that we can tell the setting was used. We cant tell it to install an older  besides latest,
     // but we can rename the folder then re-acquire for latest and see that it uses the existing 'older' runtime path
     assert.notEqual(path.dirname(resultForAcquiringPathSettingRuntime.dotnetPath), path.dirname(pathWithIncorrectVersionForTest), 'Test setup: path setting is different from the real path');
-    fs.cpSync(path.dirname(resultForAcquiringPathSettingRuntime.dotnetPath), path.dirname(pathWithIncorrectVersionForTest), {recursive: true});
+    fs.cpSync(path.dirname(resultForAcquiringPathSettingRuntime.dotnetPath), path.dirname(pathWithIncorrectVersionForTest), { recursive: true });
     assert.isTrue(fs.existsSync(path.dirname(pathWithIncorrectVersionForTest)), 'The copy of the real dotnet to the new wrong-versioned path succeeded');
 
     fs.rmSync(resultForAcquiringPathSettingRuntime.dotnetPath);
@@ -540,14 +574,15 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.exists(result!.dotnetPath, 'path setting has a path');
     assert.equal(result!.dotnetPath, pathWithIncorrectVersionForTest, 'path setting is used'); // this is set for the alternative.extension in the settings
 
-    const findPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, {mode: 'runtime'}), versionSpecRequirement: 'equal' });
+    const findPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, { mode: 'runtime' }), versionSpecRequirement: 'equal' });
     assert.equal(findPath!.dotnetPath, pathWithIncorrectVersionForTest, 'findPath uses vscode setting for runtime'); // this is set for the alternative.extension in the settings
 
-    const findSDKPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, {mode: 'sdk'}), versionSpecRequirement: 'equal' });
+    const findSDKPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, { mode: 'sdk' }), versionSpecRequirement: 'equal' });
     assert.equal(findSDKPath?.dotnetPath ?? undefined, undefined, 'findPath does not find path setting for the SDK');
   }).timeout(standardTimeoutTime);
 
-  test('List Sdks & Runtimes', async () => {
+  test('List Sdks & Runtimes', async () =>
+  {
     const mockAcquisitionContext = getMockAcquisitionContext('sdk', '');
     const webWorker = new MockWebRequestWorker(mockAcquisitionContext, '');
     webWorker.response = JSON.parse(mockReleasesData);
@@ -557,37 +592,38 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     const result = await vscode.commands.executeCommand<IDotnetListVersionsResult>('dotnet.listVersions', apiContext, webWorker);
     assert.exists(result);
     assert.equal(result?.length, 2, `It can find both versions of the SDKs. Found: ${result}`);
-    assert.equal(result?.filter((sdk : any) => sdk.version === '7.0.202').length, 1, 'The mock SDK with the expected version {7.0.200} was not found by the API parsing service.');
-    assert.equal(result?.filter((sdk : any) => sdk.channelVersion === '7.0').length, 1, 'The mock SDK with the expected channel version {7.0} was not found by the API parsing service.');
-    assert.equal(result?.filter((sdk : any) => sdk.supportPhase === 'active').length, 1, 'The mock SDK with the expected support phase of {active} was not found by the API parsing service.');
+    assert.equal(result?.filter((sdk: any) => sdk.version === '7.0.202').length, 1, 'The mock SDK with the expected version {7.0.200} was not found by the API parsing service.');
+    assert.equal(result?.filter((sdk: any) => sdk.channelVersion === '7.0').length, 1, 'The mock SDK with the expected channel version {7.0} was not found by the API parsing service.');
+    assert.equal(result?.filter((sdk: any) => sdk.supportPhase === 'active').length, 1, 'The mock SDK with the expected support phase of {active} was not found by the API parsing service.');
 
     // The API can find the available runtimes and their versions.
     apiContext.listRuntimes = true;
     const runtimeResult = await vscode.commands.executeCommand<IDotnetListVersionsResult>('dotnet.listVersions', apiContext, webWorker);
     assert.exists(runtimeResult);
-    assert.equal(runtimeResult?.length, 2,  `It can find both versions of the runtime. Found: ${result}`);
-    assert.equal(runtimeResult?.filter((runtime : any) => runtime.version === '7.0.4').length, 1, 'The mock Runtime with the expected version was not found by the API parsing service.');
+    assert.equal(runtimeResult?.length, 2, `It can find both versions of the runtime. Found: ${result}`);
+    assert.equal(runtimeResult?.filter((runtime: any) => runtime.version === '7.0.4').length, 1, 'The mock Runtime with the expected version was not found by the API parsing service.');
   }).timeout(standardTimeoutTime);
 
-  test('Get Recommended SDK Version', async () => {
+  test('Get Recommended SDK Version', async () =>
+  {
     const mockAcquisitionContext = getMockAcquisitionContext('sdk', '');
     const webWorker = new MockWebRequestWorker(mockAcquisitionContext, '');
     webWorker.response = JSON.parse(mockReleasesData);
 
     const result = await vscode.commands.executeCommand<IDotnetListVersionsResult>('dotnet.recommendedVersion', null, webWorker);
     assert.exists(result);
-    if(os.platform() !== 'linux')
+    if (os.platform() !== 'linux')
     {
       assert.equal(result[0].version, '7.0.202', 'The SDK did not recommend the version it was supposed to, which should be {7.0.200} from the mock data.');
     }
     else
     {
       const distroVersion = await new LinuxVersionResolver(mockAcquisitionContext, getMockUtilityContext()).getRunningDistro();
-      assert.equal(result[0].version, Number(distroVersion) > 22.04 ? '9.0.1xx' : '8.0.1xx', 'The SDK did not recommend the version it was supposed to, which should be N.0.1xx based on surface level distro knowledge. If a new version is available, this test may need to be updated to the newest version.');
+      assert.equal(result[0].version, Number(distroVersion) >= 22.04 ? '9.0.1xx' : '8.0.1xx', 'The SDK did not recommend the version it was supposed to, which should be N.0.1xx based on surface level distro knowledge. If a new version is available, this test may need to be updated to the newest version.');
     }
   }).timeout(standardTimeoutTime);
 
-  async function testAcquire(installMode : DotnetInstallMode)
+  async function testAcquire(installMode: DotnetInstallMode)
   {
     // Runtime is not yet installed
     const context: IDotnetAcquireContext = { version: '3.1', requestingExtensionId, mode: installMode };
@@ -620,8 +656,8 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
 
   test('acquireStatus does respect Mode', async () =>
   {
-    const runtimeContext : IDotnetAcquireContext = { version: '5.0', requestingExtensionId, mode: 'runtime' };
-    const aspNetContext : IDotnetAcquireContext =  { version: '5.0', requestingExtensionId, mode: 'aspnetcore' };
+    const runtimeContext: IDotnetAcquireContext = { version: '5.0', requestingExtensionId, mode: 'runtime' };
+    const aspNetContext: IDotnetAcquireContext = { version: '5.0', requestingExtensionId, mode: 'aspnetcore' };
 
     let result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquireStatus', runtimeContext);
     assert.notExists(result);

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -619,15 +619,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function ()
     else
     {
       const distroVersion = await new LinuxVersionResolver(mockAcquisitionContext, getMockUtilityContext()).getRunningDistro();
-      if (Number(distroVersion) === 22.04)
-      {
-        // certain versions have 9 support but others do not
-        assert.include(['9.0.1xx', '8.0.1xx'], result[0].version, `${result[0].version} is 9 or 8 : special check for ubuntu 22.04`);
-      }
-      else
-      {
-        assert.equal(result[0].version, Number(distroVersion) >= 22.04 ? '9.0.1xx' : '8.0.1xx', `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${distroVersion.version}. If a new version is available, this test may need to be updated to the newest version.`);
-      }
+      assert.equal(result[0].version, Number(distroVersion.version) >= 22.04 ? '9.0.1xx' : '8.0.1xx', `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${distroVersion.version}. If a new version is available, this test may need to be updated to the newest version.`);
     }
   }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -61,7 +61,7 @@ You will need to restart VS Code after these changes. If PowerShell is still not
         {
             try
             {
-                let windowsFullCommand = `powershell.exe -NoProfile -NonInteractive -NoLogo -ExecutionPolicy bypass -Command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; & $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"; ${installCommand} }"`;
+                let windowsFullCommand = `powershell.exe -NoProfile -NonInteractive -NoLogo -ExecutionPolicy bypass -Command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; & ${installCommand} }"`;
                 let powershellReference = 'powershell.exe';
                 if (winOS)
                 {

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -84,7 +84,7 @@ You will need to restart VS Code after these changes. If PowerShell is still not
                         if (this.looksLikeBadExecutionPolicyError(stderr))
                         {
                             const badPolicyError = new EventBasedError('PowershellBadExecutionPolicy', `Your powershell execution policy does not allow script execution, so we can't automate the installation.
-Please read more at https:/go.microsoft.com/fwlink/?LinkID=135170`);
+Please read more at https://go.microsoft.com/fwlink/?LinkID=135170`);
                             this.eventStream.post(new PowershellBadExecutionPolicy(badPolicyError, install));
                             reject(badPolicyError);
                         }

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -90,7 +90,7 @@ Please read more at https:/go.microsoft.com/fwlink/?LinkID=135170`);
                         }
                         if ((this.looksLikeBadLanguageModeError(stderr) || error?.code === 1) && this.badLanguageModeSet(powershellReference))
                         {
-                            const badModeError = new EventBasedError('PowershellBadLanguageMode', `Your Language Mode disables PowerShell language features needed to install .NET. Read more at: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7.3.
+                            const badModeError = new EventBasedError('PowershellBadLanguageMode', `Your Language Mode disables PowerShell language features needed to install .NET. Read more at: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes.
 If you cannot change this flag, try setting a custom existingDotnetPath via the instructions here: https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md.`);
                             this.eventStream.post(new PowershellBadLanguageMode(badModeError, install));
                             reject(badModeError);

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -169,9 +169,21 @@ At dotnet-install.ps1:1189 char:5
 
     private badLanguageModeSet(powershellReference: string): boolean
     {
-        const languageModeOutput = cp.spawnSync(powershellReference, [`-command`, `$ExecutionContext.SessionState.LanguageMode`], { cwd: path.resolve(__dirname), shell: true });
-        const languageMode = languageModeOutput.stdout.toString().trim();
-        return (languageMode === 'ConstrainedLanguage' || languageMode === 'NoLanguage');
+        if (os.platform() !== 'win32')
+        {
+            return false;
+        }
+
+        try
+        {
+            const languageModeOutput = cp.spawnSync(powershellReference, [`-command`, `$ExecutionContext.SessionState.LanguageMode`], { cwd: path.resolve(__dirname), shell: true });
+            const languageMode = languageModeOutput.stdout.toString().trim();
+            return (languageMode === 'ConstrainedLanguage' || languageMode === 'NoLanguage');
+        }
+        catch (e: any)
+        {
+            return true;
+        }
     }
 
     private async getInstallCommand(version: string, dotnetInstallDir: string, installMode: DotnetInstallMode, architecture: string): Promise<string>

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -88,7 +88,7 @@ Please read more at https:/go.microsoft.com/fwlink/?LinkID=135170`);
                             this.eventStream.post(new PowershellBadExecutionPolicy(badPolicyError, install));
                             reject(badPolicyError);
                         }
-                        if ((this.looksLikeBadLanguageModeError(stderr) || error?.code == 1) && this.badLanguageModeSet(powershellReference))
+                        if ((this.looksLikeBadLanguageModeError(stderr) || error?.code === 1) && this.badLanguageModeSet(powershellReference))
                         {
                             const badModeError = new EventBasedError('PowershellBadLanguageMode', `Your Language Mode disables PowerShell language features needed to install .NET. Read more at: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7.3.
 If you cannot change this flag, try setting a custom existingDotnetPath via the instructions here: https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md.`);

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -8,36 +8,37 @@ import * as path from 'path';
 import rimraf = require('rimraf');
 
 import * as versionUtils from './VersionUtilities'
-import {
-    DotnetAcquisitionAlreadyInstalled,
-    DotnetAcquisitionCompleted,
-    DotnetAcquisitionDeletion,
-    DotnetAcquisitionInProgress,
-    DotnetAcquisitionPartialInstallation,
-    DotnetAcquisitionStarted,
-    DotnetAcquisitionStatusResolved,
-    DotnetAcquisitionStatusUndefined,
-    DotnetNonZeroInstallerExitCodeError,
-    DotnetInstallGraveyardEvent,
-    DotnetInstallIdCreatedEvent,
-    DotnetLegacyInstallDetectedEvent,
-    DotnetLegacyInstallRemovalRequestEvent,
-    DotnetUninstallAllCompleted,
-    DotnetUninstallAllStarted,
-    DotnetGlobalAcquisitionCompletionEvent,
-    DotnetGlobalVersionResolutionCompletionEvent,
-    DotnetBeginGlobalInstallerExecution,
-    DotnetCompletedGlobalInstallerExecution,
-    DotnetFakeSDKEnvironmentVariableTriggered,
-    SuppressedAcquisitionError,
-    EventBasedError,
-    EventCancellationError,
-    DotnetInstallationValidated,
-    DotnetUninstallStarted,
-    DotnetUninstallCompleted,
-    DotnetUninstallFailed,
-    DotnetOfflineInstallUsed,
-} from '../EventStream/EventStreamEvents';
+import
+    {
+        DotnetAcquisitionAlreadyInstalled,
+        DotnetAcquisitionCompleted,
+        DotnetAcquisitionDeletion,
+        DotnetAcquisitionInProgress,
+        DotnetAcquisitionPartialInstallation,
+        DotnetAcquisitionStarted,
+        DotnetAcquisitionStatusResolved,
+        DotnetAcquisitionStatusUndefined,
+        DotnetNonZeroInstallerExitCodeError,
+        DotnetInstallGraveyardEvent,
+        DotnetInstallIdCreatedEvent,
+        DotnetLegacyInstallDetectedEvent,
+        DotnetLegacyInstallRemovalRequestEvent,
+        DotnetUninstallAllCompleted,
+        DotnetUninstallAllStarted,
+        DotnetGlobalAcquisitionCompletionEvent,
+        DotnetGlobalVersionResolutionCompletionEvent,
+        DotnetBeginGlobalInstallerExecution,
+        DotnetCompletedGlobalInstallerExecution,
+        DotnetFakeSDKEnvironmentVariableTriggered,
+        SuppressedAcquisitionError,
+        EventBasedError,
+        EventCancellationError,
+        DotnetInstallationValidated,
+        DotnetUninstallStarted,
+        DotnetUninstallCompleted,
+        DotnetUninstallFailed,
+        DotnetOfflineInstallUsed,
+    } from '../EventStream/EventStreamEvents';
 
 import { GlobalInstallerResolver } from './GlobalInstallerResolver';
 import { WinMacGlobalInstaller } from './WinMacGlobalInstaller';
@@ -52,14 +53,17 @@ import { IDotnetAcquireResult } from '../IDotnetAcquireResult';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IDotnetCoreAcquisitionWorker } from './IDotnetCoreAcquisitionWorker';
 import { IDotnetInstallationContext } from './IDotnetInstallationContext';
-import {
-    InstallRecord,
-} from './InstallRecord';
-import {
-    GetDotnetInstallInfo,
-    IsEquivalentInstallationFile,
-    IsEquivalentInstallation
-, DotnetInstall } from './DotnetInstall';
+import
+    {
+        InstallRecord,
+    } from './InstallRecord';
+import
+    {
+        GetDotnetInstallInfo,
+        IsEquivalentInstallationFile,
+        IsEquivalentInstallation
+        , DotnetInstall
+    } from './DotnetInstall';
 import { InstallationGraveyard } from './InstallationGraveyard';
 import { InstallTrackerSingleton } from './InstallTrackerSingleton';
 import { DotnetInstallMode } from './DotnetInstallMode';
@@ -74,19 +78,20 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
     private readonly dotnetExecutable: string;
     private globalResolver: GlobalInstallerResolver | null;
 
-    private extensionContext : IVSCodeExtensionContext;
+    private extensionContext: IVSCodeExtensionContext;
 
     // @member usingNoInstallInvoker - Only use this for test when using the No Install Invoker to fake the worker into thinking a path is on disk.
     protected usingNoInstallInvoker = false;
 
-    constructor(private readonly utilityContext : IUtilityContext, extensionContext : IVSCodeExtensionContext) {
+    constructor(private readonly utilityContext: IUtilityContext, extensionContext: IVSCodeExtensionContext)
+    {
         const dotnetExtension = os.platform() === 'win32' ? '.exe' : '';
         this.dotnetExecutable = `dotnet${dotnetExtension}`;
         this.globalResolver = null;
         this.extensionContext = extensionContext;
     }
 
-    public async uninstallAll(eventStream : IEventStream, storagePath : string, extensionState : IExtensionState): Promise<void>
+    public async uninstallAll(eventStream: IEventStream, storagePath: string, extensionState: IExtensionState): Promise<void>
     {
         eventStream.post(new DotnetUninstallAllStarted());
         InstallTrackerSingleton.getInstance(eventStream, extensionState).clearPromises();
@@ -103,7 +108,8 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
      * @remarks this is simply a wrapper around the acquire function.
      * @returns the requested dotnet path.
      */
-    public async acquireLocalSDK(context: IAcquisitionWorkerContext, invoker : IAcquisitionInvoker): Promise<IDotnetAcquireResult> {
+    public async acquireLocalSDK(context: IAcquisitionWorkerContext, invoker: IAcquisitionInvoker): Promise<IDotnetAcquireResult>
+    {
         return this.acquire(context, 'sdk', undefined, invoker);
     }
 
@@ -113,7 +119,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         return this.acquire(context, 'sdk', installerResolver);
     }
 
-    public async acquireLocalASPNET(context: IAcquisitionWorkerContext, invoker : IAcquisitionInvoker)
+    public async acquireLocalASPNET(context: IAcquisitionWorkerContext, invoker: IAcquisitionInvoker)
     {
         return this.acquire(context, 'aspnetcore', undefined, invoker);
     }
@@ -123,7 +129,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
      * @remarks this is simply a wrapper around the acquire function.
      * @returns the requested dotnet path.
      */
-    public async acquireLocalRuntime(context: IAcquisitionWorkerContext, invoker : IAcquisitionInvoker): Promise<IDotnetAcquireResult>
+    public async acquireLocalRuntime(context: IAcquisitionWorkerContext, invoker: IAcquisitionInvoker): Promise<IDotnetAcquireResult>
     {
         return this.acquire(context, 'runtime', undefined, invoker);
     }
@@ -136,18 +142,18 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
      * @returns null if no existing install matches with the same major.minor.
      * Else, returns the newest existing install that matches the major.minor.
      */
-    public async getSimilarExistingInstall(context : IAcquisitionWorkerContext) : Promise<IDotnetAcquireResult | null>
+    public async getSimilarExistingInstall(context: IAcquisitionWorkerContext): Promise<IDotnetAcquireResult | null>
     {
         const possibleInstallWithSameMajorMinor = getInstallFromContext(context);
         const installedVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls(true);
 
-        for(const install of installedVersions)
+        for (const install of installedVersions)
         {
-            if( install.dotnetInstall.installMode === possibleInstallWithSameMajorMinor.installMode &&
+            if (install.dotnetInstall.installMode === possibleInstallWithSameMajorMinor.installMode &&
                 install.dotnetInstall.architecture === possibleInstallWithSameMajorMinor.architecture &&
                 install.dotnetInstall.isGlobal === possibleInstallWithSameMajorMinor.isGlobal &&
                 versionUtils.getMajorMinor(install.dotnetInstall.version, context.eventStream, context) ===
-                    versionUtils.getMajorMinor(possibleInstallWithSameMajorMinor.version, context.eventStream, context))
+                versionUtils.getMajorMinor(possibleInstallWithSameMajorMinor.version, context.eventStream, context))
             {
                 // Requested version has already been installed.
                 const dotnetExePath = install.dotnetInstall.isGlobal ?
@@ -158,7 +164,7 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
                             install.dotnetInstall.version, install.dotnetInstall.architecture) :
                     path.join(context.installDirectoryProvider.getInstallDir(install.dotnetInstall.installId), this.dotnetExecutable);
 
-                if(( fs.existsSync(dotnetExePath) || this.usingNoInstallInvoker ))
+                if ((fs.existsSync(dotnetExePath) || this.usingNoInstallInvoker))
                 {
                     context.eventStream.post(new DotnetAcquisitionStatusResolved(possibleInstallWithSameMajorMinor,
                         possibleInstallWithSameMajorMinor.version));
@@ -179,7 +185,7 @@ To keep your .NET version up to date, please reconnect to the internet at your s
      * @param architecture The architecture of the install. Undefined means it will be the default arch, which is the node platform arch.
      * @returns The result of the install with the path to dotnet if installed, else undefined.
      */
-    public async acquireStatus(context: IAcquisitionWorkerContext, installMode: DotnetInstallMode, architecture? : string): Promise<IDotnetAcquireResult | undefined>
+    public async acquireStatus(context: IAcquisitionWorkerContext, installMode: DotnetInstallMode, architecture?: string): Promise<IDotnetAcquireResult | undefined>
     {
         const version = context.acquisitionContext.version!;
         const install = GetDotnetInstallInfo(version, installMode, 'local',
@@ -195,19 +201,19 @@ To keep your .NET version up to date, please reconnect to the internet at your s
         const dotnetPath = path.join(dotnetInstallDir, this.dotnetExecutable);
         const installedVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls(true);
 
-        if (installedVersions.some(x => IsEquivalentInstallationFile(x.dotnetInstall, install)) && (fs.existsSync(dotnetPath) || this.usingNoInstallInvoker ))
+        if (installedVersions.some(x => IsEquivalentInstallationFile(x.dotnetInstall, install)) && (fs.existsSync(dotnetPath) || this.usingNoInstallInvoker))
         {
             // Requested version has already been installed.
             context.eventStream.post(new DotnetAcquisitionStatusResolved(install, version));
             return { dotnetPath };
         }
-        else if(installedVersions.length === 0 && fs.existsSync(dotnetPath) && installMode === 'sdk')
+        else if (installedVersions.length === 0 && fs.existsSync(dotnetPath) && installMode === 'sdk')
         {
             // The education bundle already laid down a local install, add it to our managed installs
             const preinstalledVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).checkForUnrecordedLocalSDKSuccessfulInstall(
                 context, dotnetInstallDir, installedVersions);
             if (preinstalledVersions.some(x => IsEquivalentInstallationFile(x.dotnetInstall, install)) &&
-                (fs.existsSync(dotnetPath) || this.usingNoInstallInvoker ))
+                (fs.existsSync(dotnetPath) || this.usingNoInstallInvoker))
             {
                 // Requested version has already been installed.
                 context.eventStream.post(new DotnetAcquisitionStatusResolved(install, version));
@@ -228,9 +234,9 @@ To keep your .NET version up to date, please reconnect to the internet at your s
      * @returns the dotnet acquisition result.
      */
     private async acquire(context: IAcquisitionWorkerContext, mode: DotnetInstallMode,
-        globalInstallerResolver : GlobalInstallerResolver | null = null, localInvoker? : IAcquisitionInvoker): Promise<IDotnetAcquireResult>
+        globalInstallerResolver: GlobalInstallerResolver | null = null, localInvoker?: IAcquisitionInvoker): Promise<IDotnetAcquireResult>
     {
-        if(globalInstallerResolver !== null)
+        if (globalInstallerResolver !== null)
         {
             context.acquisitionContext.version = await globalInstallerResolver.getFullySpecifiedVersion();
         }
@@ -239,16 +245,16 @@ To keep your .NET version up to date, please reconnect to the internet at your s
             context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture));
 
         // Allow for the architecture to be null, which is a legacy behavior.
-        if(context.acquisitionContext.architecture === null && context.acquisitionContext.architecture !== undefined)
+        if (context.acquisitionContext.architecture === null && context.acquisitionContext.architecture !== undefined)
         {
             install =
-            {
-                installId: getInstallIdCustomArchitecture(version, context.acquisitionContext.architecture,
-                    context.acquisitionContext.mode!, globalInstallerResolver !== null ? 'global' : 'local'),
-                version: install.version,
-                isGlobal: install.isGlobal,
-                installMode: mode,
-            } as DotnetInstall
+                {
+                    installId: getInstallIdCustomArchitecture(version, context.acquisitionContext.architecture,
+                        context.acquisitionContext.mode!, globalInstallerResolver !== null ? 'global' : 'local'),
+                    version: install.version,
+                    isGlobal: install.isGlobal,
+                    installMode: mode,
+                } as DotnetInstall
         }
 
         context.eventStream.post(new DotnetInstallIdCreatedEvent(`The requested version ${version} is now marked under the install: ${JSON.stringify(install)}.`));
@@ -261,7 +267,7 @@ To keep your .NET version up to date, please reconnect to the internet at your s
         {
             // We're the only one acquiring this version of dotnet, start the acquisition process.
             let acquisitionPromise = null;
-            if(globalInstallerResolver !== null)
+            if (globalInstallerResolver !== null)
             {
                 Debugging.log(`The Acquisition Worker has Determined a Global Install was requested.`, context.eventStream);
 
@@ -298,7 +304,7 @@ To keep your .NET version up to date, please reconnect to the internet at your s
      *
      * @remarks it is called "core" because it is the meat of the actual acquisition work; this has nothing to do with .NET core vs framework.
      */
-    private async acquireLocalCore(context: IAcquisitionWorkerContext, mode: DotnetInstallMode, install : DotnetInstall, acquisitionInvoker : IAcquisitionInvoker): Promise<string>
+    private async acquireLocalCore(context: IAcquisitionWorkerContext, mode: DotnetInstallMode, install: DotnetInstall, acquisitionInvoker: IAcquisitionInvoker): Promise<string>
     {
         const version = context.acquisitionContext.version!;
         this.checkForPartialInstalls(context, install).catch(() => {});
@@ -307,14 +313,15 @@ To keep your .NET version up to date, please reconnect to the internet at your s
         const dotnetInstallDir = context.installDirectoryProvider.getInstallDir(install.installId);
         const dotnetPath = path.join(dotnetInstallDir, this.dotnetExecutable);
 
-        if (fs.existsSync(dotnetPath) && installedVersions.length === 0) {
+        if (fs.existsSync(dotnetPath) && installedVersions.length === 0)
+        {
             // The education bundle already laid down a local install, add it to our managed installs
             installedVersions = await InstallTrackerSingleton.getInstance(context.eventStream,
                 context.extensionState).checkForUnrecordedLocalSDKSuccessfulInstall(context, dotnetInstallDir, installedVersions);
         }
 
         const existingInstall = await this.getExistingInstall(context, installedVersions, install, dotnetPath);
-        if(existingInstall)
+        if (existingInstall)
         {
             return existingInstall;
         }
@@ -327,10 +334,11 @@ To keep your .NET version up to date, please reconnect to the internet at your s
             version,
             dotnetPath,
             timeoutSeconds: context.timeoutSeconds,
-            installMode : mode,
-            installType : context.acquisitionContext.installType ?? 'local', // Before this API param existed, all calls were for local types.
+            installMode: mode,
+            installType: context.acquisitionContext.installType ?? 'local', // Before this API param existed, all calls were for local types.
             architecture: context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture),
         } as IDotnetInstallationContext;
+        context.acquisitionContext.architecture = installContext.architecture;
         context.eventStream.post(new DotnetAcquisitionStarted(install, version, context.acquisitionContext.requestingExtensionId));
         await acquisitionInvoker.installDotnet(installContext, install).catch((reason) =>
         {
@@ -346,7 +354,7 @@ To keep your .NET version up to date, please reconnect to the internet at your s
         return dotnetPath;
     }
 
-    private async getExistingInstall(context: IAcquisitionWorkerContext, installedVersions : InstallRecord[], install : DotnetInstall, dotnetPath : string) : Promise<string | null>
+    private async getExistingInstall(context: IAcquisitionWorkerContext, installedVersions: InstallRecord[], install: DotnetInstall, dotnetPath: string): Promise<string | null>
     {
         if (installedVersions.some(x => IsEquivalentInstallation(x.dotnetInstall, install) && (fs.existsSync(dotnetPath) || this.usingNoInstallInvoker)))
         {
@@ -355,14 +363,14 @@ To keep your .NET version up to date, please reconnect to the internet at your s
             {
                 context.installationValidator.validateDotnetInstall(install, dotnetPath, false, false);
             }
-            catch(error : any)
+            catch (error: any)
             {
                 return null;
             }
 
-            if(context.acquisitionContext.installType === 'global')
+            if (context.acquisitionContext.installType === 'global')
             {
-                if(!(await this.sdkIsFound(context, context.acquisitionContext.version)))
+                if (!(await this.sdkIsFound(context, context.acquisitionContext.version)))
                 {
                     await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).untrackInstalledVersion(context, install);
                     return null;
@@ -371,7 +379,7 @@ To keep your .NET version up to date, please reconnect to the internet at your s
 
             context.eventStream.post(new DotnetAcquisitionAlreadyInstalled(install,
                 (context.acquisitionContext && context.acquisitionContext.requestingExtensionId)
-                ? context.acquisitionContext.requestingExtensionId : null));
+                    ? context.acquisitionContext.requestingExtensionId : null));
 
             await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).trackInstalledVersion(context, install);
             return dotnetPath;
@@ -379,13 +387,13 @@ To keep your .NET version up to date, please reconnect to the internet at your s
         return null;
     }
 
-    private async sdkIsFound(context : IAcquisitionWorkerContext, version : string) : Promise<boolean>
+    private async sdkIsFound(context: IAcquisitionWorkerContext, version: string): Promise<boolean>
     {
         const executor = new CommandExecutor(context, this.utilityContext);
         const listSDKsCommand = CommandExecutor.makeCommand('dotnet', ['--list-sdks']);
         const result = await executor.execute(listSDKsCommand, null, false);
 
-        if(result.status !== '0')
+        if (result.status !== '0')
         {
             return false;
         }
@@ -393,7 +401,7 @@ To keep your .NET version up to date, please reconnect to the internet at your s
         return result.stdout.includes(version);
     }
 
-    private async checkForPartialInstalls(context: IAcquisitionWorkerContext, installId : DotnetInstall)
+    private async checkForPartialInstalls(context: IAcquisitionWorkerContext, installId: DotnetInstall)
     {
         const installingVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls(false);
         const partialInstall = installingVersions?.some(x => x.dotnetInstall.installId === installId.installId);
@@ -410,11 +418,11 @@ To keep your .NET version up to date, please reconnect to the internet at your s
         }
     }
 
-    public async tryCleanUpInstallGraveyard(context: IAcquisitionWorkerContext) : Promise<void>
+    public async tryCleanUpInstallGraveyard(context: IAcquisitionWorkerContext): Promise<void>
     {
         const graveyard = new InstallationGraveyard(context);
         const installsToRemove = await graveyard.get();
-        for(const install of installsToRemove)
+        for (const install of installsToRemove)
         {
             context.eventStream.post(new DotnetInstallGraveyardEvent(
                 `Attempting to remove .NET at ${JSON.stringify(install)} again, as it was left in the graveyard.`));
@@ -422,27 +430,27 @@ To keep your .NET version up to date, please reconnect to the internet at your s
         }
     }
 
-    private getDefaultInternalArchitecture(existingArch : string | null | undefined)
+    private getDefaultInternalArchitecture(existingArch: string | null | undefined)
     {
-        if(existingArch !== null && existingArch !== undefined)
+        if (existingArch !== null && existingArch !== undefined)
         {
             return existingArch;
         }
-        if(existingArch === null)
+        if (existingArch === null)
         {
             return 'null';
         }
         return DotnetCoreAcquisitionWorker.defaultArchitecture();
     }
 
-    public static defaultArchitecture() : string
+    public static defaultArchitecture(): string
     {
         return os.arch();
     }
 
-    private getErrorOrStringAsEventError(error : any)
+    private getErrorOrStringAsEventError(error: any)
     {
-        if(error instanceof EventBasedError || error instanceof EventCancellationError)
+        if (error instanceof EventBasedError || error instanceof EventCancellationError)
         {
             error.message = `.NET Acquisition Failed: ${error.message}, ${error?.stack}`;
             return error;
@@ -456,7 +464,7 @@ To keep your .NET version up to date, please reconnect to the internet at your s
         }
     }
 
-    private async acquireGlobalCore(context: IAcquisitionWorkerContext, globalInstallerResolver : GlobalInstallerResolver, install : DotnetInstall): Promise<string>
+    private async acquireGlobalCore(context: IAcquisitionWorkerContext, globalInstallerResolver: GlobalInstallerResolver, install: DotnetInstall): Promise<string>
     {
         const installingVersion = await globalInstallerResolver.getFullySpecifiedVersion();
         context.eventStream.post(new DotnetGlobalVersionResolutionCompletionEvent(`The version we resolved that was requested is: ${installingVersion}.`));
@@ -464,21 +472,21 @@ To keep your .NET version up to date, please reconnect to the internet at your s
 
         const installedVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls(true);
 
-        const installer : IGlobalInstaller = os.platform() === 'linux' ?
+        const installer: IGlobalInstaller = os.platform() === 'linux' ?
             new LinuxGlobalInstaller(context, this.utilityContext, installingVersion) :
             new WinMacGlobalInstaller(context, this.utilityContext, installingVersion, await globalInstallerResolver.getInstallerUrl(), await globalInstallerResolver.getInstallerHash());
 
         // See if we should return a fake path instead of running the install
-        if(process.env.VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH && process.env.VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH === 'true')
+        if (process.env.VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH && process.env.VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH === 'true')
         {
             context.eventStream.post(new DotnetFakeSDKEnvironmentVariableTriggered(`VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH has been set.`));
             return 'fake-sdk';
         }
 
-        let dotnetPath : string = await installer.getExpectedGlobalSDKPath(installingVersion,
+        let dotnetPath: string = await installer.getExpectedGlobalSDKPath(installingVersion,
             context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture), false);
         const existingInstall = await this.getExistingInstall(context, installedVersions, install, dotnetPath);
-        if(existingInstall)
+        if (existingInstall)
         {
             return existingInstall;
         }
@@ -490,7 +498,7 @@ To keep your .NET version up to date, please reconnect to the internet at your s
         const installerResult = await installer.installSDK(install);
         context.eventStream.post(new DotnetCompletedGlobalInstallerExecution(`Completed installer for ${JSON.stringify(install)} in ${os.platform()}.`))
 
-        if(installerResult !== '0')
+        if (installerResult !== '0')
         {
             const err = new DotnetNonZeroInstallerExitCodeError(new EventBasedError('DotnetNonZeroInstallerExitCodeError',
                 `An error was raised by the .NET SDK installer. The exit code it gave us: ${installerResult}.
@@ -536,12 +544,12 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
      *
      * Note : only local installs were ever 'legacy.'
      */
-    private async removeMatchingLegacyInstall(context: IAcquisitionWorkerContext, installedVersions : InstallRecord[], version : string)
+    private async removeMatchingLegacyInstall(context: IAcquisitionWorkerContext, installedVersions: InstallRecord[], version: string)
     {
         const legacyInstalls = this.existingLegacyInstalls(context, installedVersions);
-        for(const legacyInstall of legacyInstalls)
+        for (const legacyInstall of legacyInstalls)
         {
-            if(legacyInstall.dotnetInstall.installId.includes(version))
+            if (legacyInstall.dotnetInstall.installId.includes(version))
             {
                 context.eventStream.post(new DotnetLegacyInstallRemovalRequestEvent(`Trying to remove legacy install: ${JSON.stringify(legacyInstall)} of ${version}.`));
                 await this.uninstallLocal(context, legacyInstall.dotnetInstall);
@@ -554,13 +562,13 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
      * @param allInstalls all of the existing installs.
      * @returns All existing installs made by the extension that don't include a - for the architecture. Not all of the ones which use a string type.
      */
-    private existingLegacyInstalls(context: IAcquisitionWorkerContext, allInstalls : InstallRecord[]) : InstallRecord[]
+    private existingLegacyInstalls(context: IAcquisitionWorkerContext, allInstalls: InstallRecord[]): InstallRecord[]
     {
-        let legacyInstalls : InstallRecord[] = [];
-        for(const install of allInstalls)
+        let legacyInstalls: InstallRecord[] = [];
+        for (const install of allInstalls)
         {
             // Assumption: .NET versions so far did not include ~ in them, but we do for our non-legacy ids.
-            if(!install.dotnetInstall.installId.includes('~'))
+            if (!install.dotnetInstall.installId.includes('~'))
             {
                 context.eventStream.post(new DotnetLegacyInstallDetectedEvent(`A legacy install was detected -- ${JSON.stringify(install)}.`));
                 legacyInstalls = legacyInstalls.concat(install);
@@ -570,9 +578,9 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
     }
 
 
-    public async uninstallLocal(context: IAcquisitionWorkerContext, install : DotnetInstall, force = false) : Promise<string>
+    public async uninstallLocal(context: IAcquisitionWorkerContext, install: DotnetInstall, force = false): Promise<string>
     {
-        if(install.isGlobal)
+        if (install.isGlobal)
         {
             return '0';
         }
@@ -589,7 +597,7 @@ ${WinMacGlobalInstaller.InterpretExitCode(installerResult)}`), install);
             // this is the only place where installed and installing could deal with pre existing installing id
             await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).untrackInstallingVersion(context, install, force);
 
-            if(force || await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).canUninstall(true, install))
+            if (force || await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).canUninstall(true, install))
             {
                 context.eventStream.post(new DotnetUninstallStarted(`Attempting to remove .NET ${install.installId}.`));
                 this.removeFolderRecursively(context.eventStream, dotnetInstallDir);
@@ -605,7 +613,7 @@ Other dependents remain.`));
 
             return '0';
         }
-        catch(error : any)
+        catch (error: any)
         {
             context.eventStream.post(new SuppressedAcquisitionError(error, `The attempt to uninstall .NET ${install.installId} failed - was .NET in use?`));
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -613,7 +621,7 @@ Other dependents remain.`));
         }
     }
 
-    public async uninstallGlobal(context: IAcquisitionWorkerContext, install : DotnetInstall, globalInstallerResolver : GlobalInstallerResolver, force = false) : Promise<string>
+    public async uninstallGlobal(context: IAcquisitionWorkerContext, install: DotnetInstall, globalInstallerResolver: GlobalInstallerResolver, force = false): Promise<string>
     {
         try
         {
@@ -623,16 +631,16 @@ Other dependents remain.`));
             // this is the only place where installed and installing could deal with pre existing installing id
             await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).untrackInstallingVersion(context, install, force);
 
-            if(force || await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).canUninstall(true, install))
+            if (force || await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).canUninstall(true, install))
             {
                 const installingVersion = await globalInstallerResolver.getFullySpecifiedVersion();
-                const installer : IGlobalInstaller = os.platform() === 'linux' ?
-                new LinuxGlobalInstaller(context, this.utilityContext, installingVersion) :
-                new WinMacGlobalInstaller(context, this.utilityContext, installingVersion, await globalInstallerResolver.getInstallerUrl(), await globalInstallerResolver.getInstallerHash());
+                const installer: IGlobalInstaller = os.platform() === 'linux' ?
+                    new LinuxGlobalInstaller(context, this.utilityContext, installingVersion) :
+                    new WinMacGlobalInstaller(context, this.utilityContext, installingVersion, await globalInstallerResolver.getInstallerUrl(), await globalInstallerResolver.getInstallerHash());
 
                 const ok = await installer.uninstallSDK(install);
                 await new CommandExecutor(context, this.utilityContext).endSudoProcessMaster(context.eventStream);
-                if(ok === '0')
+                if (ok === '0')
                 {
                     context.eventStream.post(new DotnetUninstallCompleted(`Uninstalled .NET ${install.installId}.`));
                     return '0';
@@ -641,7 +649,7 @@ Other dependents remain.`));
             context.eventStream.post(new DotnetUninstallFailed(`Failed to uninstall .NET ${install.installId}. Uninstall manually or delete the folder.`));
             return '117778'; // arbitrary error code to indicate uninstall failed without error.
         }
-        catch(error : any)
+        catch (error: any)
         {
             await new CommandExecutor(context, this.utilityContext).endSudoProcessMaster(context.eventStream);
             context.eventStream.post(new SuppressedAcquisitionError(error, `The attempt to uninstall .NET ${install.installId} failed - was .NET in use?`));
@@ -650,13 +658,14 @@ Other dependents remain.`));
         }
     }
 
-    private removeFolderRecursively(eventStream: IEventStream, folderPath: string) {
+    private removeFolderRecursively(eventStream: IEventStream, folderPath: string)
+    {
         eventStream.post(new DotnetAcquisitionDeletion(folderPath));
         try
         {
             fs.chmodSync(folderPath, 0o744);
         }
-        catch(error : any)
+        catch (error: any)
         {
             eventStream.post(new SuppressedAcquisitionError(error, `Failed to chmod +x on .NET folder ${folderPath} when marked for deletion.`));
         }
@@ -665,7 +674,7 @@ Other dependents remain.`));
         {
             rimraf.sync(folderPath);
         }
-        catch(error : any)
+        catch (error: any)
         {
             eventStream.post(new SuppressedAcquisitionError(error, `Failed to delete .NET folder ${folderPath} when marked for deletion.`));
         }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -650,11 +650,15 @@ export class DotnetOfflineFailure extends DotnetAcquisitionVersionError
     public readonly eventName = 'DotnetOfflineFailure';
 }
 
+export class PowershellBadLanguageMode extends DotnetAcquisitionVersionError
+{
+    public readonly eventName = 'PowershellBadLanguageMode';
+}
+
 export class PowershellBadExecutionPolicy extends DotnetAcquisitionVersionError
 {
     public readonly eventName = 'PowershellBadExecutionPolicy';
 }
-
 export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError
 {
     public readonly eventName = 'DotnetAcquisitionTimeoutError';

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -8,14 +8,14 @@ import { IDotnetInstallationContext } from '../Acquisition/IDotnetInstallationCo
 import { EventType } from './EventType';
 import { IEvent } from './IEvent';
 import { TelemetryUtilities } from './TelemetryUtilities';
-import { InstallToStrings , DotnetInstall } from '../Acquisition/DotnetInstall';
+import { InstallToStrings, DotnetInstall } from '../Acquisition/DotnetInstall';
 import { DotnetInstallMode } from '../Acquisition/DotnetInstallMode';
 import { DotnetInstallType } from '../IDotnetAcquireContext';
 import { IDotnetFindPathContext } from '../IDotnetFindPathContext';
 
 export class EventCancellationError extends Error
 {
-    constructor(public readonly eventType : string, msg : string, stack ? : string)
+    constructor(public readonly eventType: string, msg: string, stack?: string)
     {
         super(msg);
     }
@@ -23,7 +23,7 @@ export class EventCancellationError extends Error
 
 export class EventBasedError extends Error
 {
-    constructor(public readonly eventType : string, msg : string, stack? : string)
+    constructor(public readonly eventType: string, msg: string, stack?: string)
     {
         super(msg);
     }
@@ -31,60 +31,68 @@ export class EventBasedError extends Error
 
 export abstract class GenericModalEvent extends IEvent
 {
-    abstract readonly mode : DotnetInstallMode;
-    abstract readonly installType : DotnetInstallType;
+    abstract readonly mode: DotnetInstallMode;
+    abstract readonly installType: DotnetInstallType;
 }
 
 export class DotnetAcquisitionStarted extends GenericModalEvent
 {
     public readonly eventName = 'DotnetAcquisitionStarted';
     public readonly type = EventType.DotnetAcquisitionStart;
-    public readonly mode : DotnetInstallMode;
+    public readonly mode: DotnetInstallMode;
     public readonly installType: DotnetInstallType;
 
-    constructor(public readonly install: DotnetInstall, public readonly startingVersion: string, public readonly requestingExtensionId = '') {
+    constructor(public readonly install: DotnetInstall, public readonly startingVersion: string, public readonly requestingExtensionId = '')
+    {
         super();
         this.mode = install.installMode;
         this.installType = install.isGlobal ? 'global' : 'local';
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
-                ...InstallToStrings(this.install),
-                AcquisitionStartVersion : this.startingVersion,
-                AcquisitionInstallId : this.install.installId,
-                extensionId : this.requestingExtensionId
-            };
+            ...InstallToStrings(this.install),
+            AcquisitionStartVersion: this.startingVersion,
+            AcquisitionInstallId: this.install.installId,
+            extensionId: this.requestingExtensionId
+        };
     }
 }
 
 abstract class DotnetAcquisitionStartedBase extends IEvent
 {
-    constructor(public readonly requestingExtensionId = '') {
+    constructor(public readonly requestingExtensionId = '')
+    {
         super();
     }
 
-    public getProperties() {
-        return {extensionId : TelemetryUtilities.HashData(this.requestingExtensionId)};
+    public getProperties()
+    {
+        return { extensionId: TelemetryUtilities.HashData(this.requestingExtensionId) };
     }
 }
 
-export class DotnetRuntimeAcquisitionStarted extends DotnetAcquisitionStartedBase {
+export class DotnetRuntimeAcquisitionStarted extends DotnetAcquisitionStartedBase
+{
     public readonly eventName = 'DotnetRuntimeAcquisitionStarted';
     public readonly type = EventType.DotnetModalChildEvent;
 }
 
-export class DotnetSDKAcquisitionStarted extends DotnetAcquisitionStartedBase {
+export class DotnetSDKAcquisitionStarted extends DotnetAcquisitionStartedBase
+{
     public readonly eventName = 'DotnetSDKAcquisitionStarted';
     public readonly type = EventType.DotnetModalChildEvent;
 }
 
-export class DotnetGlobalSDKAcquisitionStarted extends DotnetAcquisitionStartedBase {
+export class DotnetGlobalSDKAcquisitionStarted extends DotnetAcquisitionStartedBase
+{
     public readonly eventName = 'DotnetGlobalSDKAcquisitionStarted';
     public readonly type = EventType.DotnetModalChildEvent;
 }
 
-export class DotnetASPNetRuntimeAcquisitionStarted extends DotnetAcquisitionStartedBase {
+export class DotnetASPNetRuntimeAcquisitionStarted extends DotnetAcquisitionStartedBase
+{
     public readonly eventName = 'DotnetASPNetRuntimeAcquisitionStarted';
     public readonly type = EventType.DotnetModalChildEvent;
 }
@@ -96,20 +104,22 @@ export class DotnetAcquisitionTotalSuccessEvent extends GenericModalEvent
     public readonly mode;
     public readonly installType: DotnetInstallType;
 
-    constructor(public readonly startingVersion: string, public readonly install: DotnetInstall, public readonly requestingExtensionId = '', public readonly finalPath: string) {
+    constructor(public readonly startingVersion: string, public readonly install: DotnetInstall, public readonly requestingExtensionId = '', public readonly finalPath: string)
+    {
         super();
         this.mode = install.installMode;
         this.installType = install.isGlobal ? 'global' : 'local';
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
-                AcquisitionStartVersion : this.startingVersion,
-                AcquisitionInstallId : this.install.installId,
-                ...InstallToStrings(this.install),
-                ExtensionId : TelemetryUtilities.HashData(this.requestingExtensionId),
-                FinalPath : this.finalPath,
-            };
+            AcquisitionStartVersion: this.startingVersion,
+            AcquisitionInstallId: this.install.installId,
+            ...InstallToStrings(this.install),
+            ExtensionId: TelemetryUtilities.HashData(this.requestingExtensionId),
+            FinalPath: this.finalPath,
+        };
     }
 }
 
@@ -117,14 +127,16 @@ abstract class DotnetAcquisitionTotalSuccessEventBase extends IEvent
 {
     public readonly type = EventType.DotnetModalChildEvent;
 
-    constructor(public readonly installId: DotnetInstall) {
+    constructor(public readonly installId: DotnetInstall)
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
-                ...InstallToStrings(this.installId),
-            };
+            ...InstallToStrings(this.installId),
+        };
     }
 }
 
@@ -151,16 +163,19 @@ export class DotnetAcquisitionRequested extends GenericModalEvent
     public readonly mode;
     public readonly installType: DotnetInstallType;
 
-    constructor(public readonly startingVersion: string, public readonly requestingId = '', mode : DotnetInstallMode, installType : DotnetInstallType)
+    constructor(public readonly startingVersion: string, public readonly requestingId = '', mode: DotnetInstallMode, installType: DotnetInstallType)
     {
         super();
         this.mode = mode;
         this.installType = installType;
     }
 
-    public getProperties() {
-        return {AcquisitionStartVersion : this.startingVersion,
-                RequestingExtensionId: TelemetryUtilities.HashData(this.requestingId)};
+    public getProperties()
+    {
+        return {
+            AcquisitionStartVersion: this.startingVersion,
+            RequestingExtensionId: TelemetryUtilities.HashData(this.requestingId)
+        };
     }
 }
 
@@ -169,14 +184,15 @@ abstract class DotnetAcquisitionRequestedEventBase extends IEvent
 {
     public readonly type = EventType.DotnetModalChildEvent;
 
-    constructor(public readonly startingVersion: string, public readonly requestingId = '', public readonly mode : DotnetInstallMode) {
+    constructor(public readonly startingVersion: string, public readonly requestingId = '', public readonly mode: DotnetInstallMode)
+    {
         super();
     }
 
     public getProperties()
     {
         return {
-            AcquisitionStartVersion : this.startingVersion,
+            AcquisitionStartVersion: this.startingVersion,
             RequestingExtensionId: TelemetryUtilities.HashData(this.requestingId),
             Mode: this.mode
         };
@@ -199,31 +215,40 @@ export class DotnetASPNetRuntimeAcquisitionRequested extends DotnetAcquisitionRe
 }
 
 
-export class DotnetAcquisitionCompleted extends IEvent {
+export class DotnetAcquisitionCompleted extends IEvent
+{
     public readonly eventName = 'DotnetAcquisitionCompleted';
     public readonly type = EventType.DotnetAcquisitionCompleted;
 
-    constructor(public readonly install: DotnetInstall, public readonly dotnetPath: string, public readonly version: string) {
+    constructor(public readonly install: DotnetInstall, public readonly dotnetPath: string, public readonly version: string)
+    {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        if (telemetry) {
-            return {...InstallToStrings(this.install),
-                    AcquisitionCompletedInstallId : this.install.installId,
-                    AcquisitionCompletedVersion: this.version};
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
+        if (telemetry)
+        {
+            return {
+                ...InstallToStrings(this.install),
+                AcquisitionCompletedInstallId: this.install.installId,
+                AcquisitionCompletedVersion: this.version
+            };
         }
         else
         {
-            return {...InstallToStrings(this.install),
-                    AcquisitionCompletedVersion: this.version,
-                    AcquisitionCompletedInstallId : this.install.installId,
-                    AcquisitionCompletedDotnetPath : this.dotnetPath};
+            return {
+                ...InstallToStrings(this.install),
+                AcquisitionCompletedVersion: this.version,
+                AcquisitionCompletedInstallId: this.install.installId,
+                AcquisitionCompletedDotnetPath: this.dotnetPath
+            };
         }
     }
 }
 
-export abstract class DotnetAcquisitionError extends IEvent {
+export abstract class DotnetAcquisitionError extends IEvent
+{
     public type = EventType.DotnetAcquisitionError;
     public isError = true;
 
@@ -238,12 +263,15 @@ export abstract class DotnetAcquisitionError extends IEvent {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        return {ErrorName : this.error.name,
-                ErrorMessage : this.error.message,
-                StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
-                InstallId : this.install?.installId ?? 'null',
-                ...InstallToStrings(this.install!)};
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
+        return {
+            ErrorName: this.error.name,
+            ErrorMessage: this.error.message,
+            StackTrace: this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
+            InstallId: this.install?.installId ?? 'null',
+            ...InstallToStrings(this.install!)
+        };
     }
 }
 
@@ -254,19 +282,22 @@ export class DotnetAcquisitionFinalError extends GenericModalEvent
     public readonly mode;
     public readonly installType: DotnetInstallType;
 
-    constructor(public readonly error: Error, public readonly originalEventName : string, public readonly install: DotnetInstall)
+    constructor(public readonly error: Error, public readonly originalEventName: string, public readonly install: DotnetInstall)
     {
         super();
         this.mode = install.installMode;
         this.installType = install.isGlobal ? 'global' : 'local';
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        return {ErrorName : this.error.name,
-                ErrorMessage : this.error.message,
-                StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
-                InstallId : this.install?.installId ?? 'null',
-                ...InstallToStrings(this.install!)};
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
+        return {
+            ErrorName: this.error.name,
+            ErrorMessage: this.error.message,
+            StackTrace: this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
+            InstallId: this.install?.installId ?? 'null',
+            ...InstallToStrings(this.install!)
+        };
     }
 }
 
@@ -278,21 +309,22 @@ export class DotnetAcquisitionFinalError extends GenericModalEvent
 abstract class DotnetAcquisitionFinalErrorBase extends DotnetAcquisitionError
 {
 
-    constructor(public readonly error: Error, public readonly originalEventName : string, public readonly install: DotnetInstall)
+    constructor(public readonly error: Error, public readonly originalEventName: string, public readonly install: DotnetInstall)
     {
         super(error, install);
         this.type = EventType.DotnetAcquisitionFinalError;
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
-                FailureMode: this.originalEventName,
-                ErrorName : this.error.name,
-                ErrorMessage : this.error.message,
-                StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
-                InstallId : this.install?.installId ?? 'null',
-                ...InstallToStrings(this.install!)
-            };
+            FailureMode: this.originalEventName,
+            ErrorName: this.error.name,
+            ErrorMessage: this.error.message,
+            StackTrace: this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
+            InstallId: this.install?.installId ?? 'null',
+            ...InstallToStrings(this.install!)
+        };
     }
 }
 
@@ -311,22 +343,28 @@ export class DotnetASPNetRuntimeFinalAcquisitionError extends DotnetAcquisitionF
     public eventName = 'DotnetASPNetRuntimeFinalAcquisitionError';
 }
 
-export abstract class DotnetNonAcquisitionError extends IEvent {
+export abstract class DotnetNonAcquisitionError extends IEvent
+{
     public readonly type = EventType.DotnetAcquisitionError;
     public isError = true;
 
-    constructor(public readonly error: Error) {
+    constructor(public readonly error: Error)
+    {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        return {ErrorName : this.error.name,
-                ErrorMessage : this.error.message,
-                StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : ''};
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
+        return {
+            ErrorName: this.error.name,
+            ErrorMessage: this.error.message,
+            StackTrace: this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : ''
+        };
     }
 }
 
-export abstract class DotnetInstallExpectedAbort extends IEvent {
+export abstract class DotnetInstallExpectedAbort extends IEvent
+{
     public readonly type = EventType.DotnetInstallExpectedAbort;
     public isError = true;
 
@@ -343,304 +381,385 @@ export abstract class DotnetInstallExpectedAbort extends IEvent {
 
     public getProperties(telemetry = false): { [id: string]: string } | undefined
     {
-        if(this.install)
+        if (this.install)
         {
-        return {ErrorName : this.error.name,
-                ErrorMessage : this.error.message,
-                StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
-                InstallId : this.install?.installId ?? 'null',
-                ...InstallToStrings(this.install)};
+            return {
+                ErrorName: this.error.name,
+                ErrorMessage: this.error.message,
+                StackTrace: this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
+                InstallId: this.install?.installId ?? 'null',
+                ...InstallToStrings(this.install)
+            };
         }
         else
         {
-            return {ErrorName : this.error.name,
-                    ErrorMessage : this.error.message,
-                    StackTrace : this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
-                    InstallId : 'null'};
+            return {
+                ErrorName: this.error.name,
+                ErrorMessage: this.error.message,
+                StackTrace: this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '',
+                InstallId: 'null'
+            };
         }
     }
 }
 
-export class SuppressedAcquisitionError extends IEvent {
+export class SuppressedAcquisitionError extends IEvent
+{
     public eventName = 'SuppressedAcquisitionError';
     public readonly type = EventType.SuppressedAcquisitionError;
 
-    constructor(public readonly error: Error, public readonly supplementalMessage : string) {
+    constructor(public readonly error: Error, public readonly supplementalMessage: string)
+    {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
-                SupplementMessage : this.supplementalMessage,
-                ErrorName : this.error.name,
-                ErrorMessage : telemetry ? 'redacted' : TelemetryUtilities.HashAllPaths(this.error.message),
-                StackTrace : telemetry ? 'redacted' : (this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '')};
+            SupplementMessage: this.supplementalMessage,
+            ErrorName: this.error.name,
+            ErrorMessage: telemetry ? 'redacted' : TelemetryUtilities.HashAllPaths(this.error.message),
+            StackTrace: telemetry ? 'redacted' : (this.error.stack ? TelemetryUtilities.HashAllPaths(this.error.stack) : '')
+        };
     }
 }
 
-export class DotnetInstallScriptAcquisitionError extends DotnetAcquisitionError {
+export class DotnetInstallScriptAcquisitionError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetInstallScriptAcquisitionError';
 }
 
-export class UserManualInstallFailure extends SuppressedAcquisitionError {
+export class UserManualInstallFailure extends SuppressedAcquisitionError
+{
     eventName = 'UserManualInstallFailure';
 }
 
-export class OfflineDetectionLogicTriggered extends SuppressedAcquisitionError {
+export class OfflineDetectionLogicTriggered extends SuppressedAcquisitionError
+{
     eventName = 'OfflineDetectionLogicTriggered';
 }
 
-export class DotnetInstallationValidationMissed extends SuppressedAcquisitionError {
+export class DotnetInstallationValidationMissed extends SuppressedAcquisitionError
+{
     eventName = 'DotnetInstallationValidationMissed';
 }
 
-export class OSXOpenNotAvailableError extends DotnetAcquisitionError {
+export class OSXOpenNotAvailableError extends DotnetAcquisitionError
+{
     public readonly eventName = 'OSXOpenNotAvailableError';
 }
 
-export class WebRequestError extends DotnetAcquisitionError {
+export class WebRequestError extends DotnetAcquisitionError
+{
     public readonly eventName = 'WebRequestError';
 }
 
-export class DiskIsFullError extends DotnetAcquisitionError {
+export class DiskIsFullError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DiskIsFullError';
 }
 
-export class DotnetDownloadFailure extends DotnetAcquisitionError {
+export class DotnetDownloadFailure extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetDownloadFailure';
 }
 
-export class DotnetPreinstallDetectionError extends DotnetAcquisitionError {
+export class DotnetPreinstallDetectionError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetPreinstallDetectionError';
 }
 
-export class TimeoutSudoProcessSpawnerError extends DotnetAcquisitionError {
+export class TimeoutSudoProcessSpawnerError extends DotnetAcquisitionError
+{
     public readonly eventName = 'TimeoutSudoProcessSpawnerError';
 }
 
-export class TimeoutSudoCommandExecutionError extends DotnetAcquisitionError {
+export class TimeoutSudoCommandExecutionError extends DotnetAcquisitionError
+{
     public readonly eventName = 'TimeoutSudoCommandExecutionError';
 }
 
-export class CommandExecutionNonZeroExitFailure extends DotnetAcquisitionError {
+export class CommandExecutionNonZeroExitFailure extends DotnetAcquisitionError
+{
     public readonly eventName = 'CommandExecutionNonZeroExitFailure';
 }
 
-export class DotnetNotInstallRelatedCommandFailed extends DotnetNonAcquisitionError {
+export class DotnetNotInstallRelatedCommandFailed extends DotnetNonAcquisitionError
+{
     public readonly eventName = 'DotnetNotInstallRelatedCommandFailed';
 
-    constructor(error: Error, public readonly command: string) {
+    constructor(error: Error, public readonly command: string)
+    {
         super(error);
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
-            ErrorMessage : this.error.message,
-            CommandName : this.command,
-            ErrorName : this.error.name,
-            StackTrace : this.error.stack ? this.error.stack : ''};
-        }
+            ErrorMessage: this.error.message,
+            CommandName: this.command,
+            ErrorName: this.error.name,
+            StackTrace: this.error.stack ? this.error.stack : ''
+        };
+    }
 }
 
-export class InvalidUninstallRequest extends DotnetNonAcquisitionError {
+export class InvalidUninstallRequest extends DotnetNonAcquisitionError
+{
     public readonly eventName = 'InvalidUninstallRequest';
 }
 
-export class DotnetCommandFailed extends DotnetAcquisitionError {
+export class DotnetCommandFailed extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetCommandFailed';
 
-    constructor(error: Error, public readonly command: string, install : DotnetInstall | null) {
+    constructor(error: Error, public readonly command: string, install: DotnetInstall | null)
+    {
         super(error, install);
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        return {ErrorMessage : this.error.message,
-            CommandName : this.command,
-            ErrorName : this.error.name,
-            StackTrace : this.error.stack ? this.error.stack : '',
-            InstallId : this.install?.installId ?? 'null',
-            ...InstallToStrings(this.install!)};
-        }
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
+        return {
+            ErrorMessage: this.error.message,
+            CommandName: this.command,
+            ErrorName: this.error.name,
+            StackTrace: this.error.stack ? this.error.stack : '',
+            InstallId: this.install?.installId ?? 'null',
+            ...InstallToStrings(this.install!)
+        };
+    }
 }
 
-export class DotnetInvalidReleasesJSONError extends DotnetAcquisitionError {
-        public readonly eventName = 'DotnetInvalidReleasesJSONError';
+export class DotnetInvalidReleasesJSONError extends DotnetAcquisitionError
+{
+    public readonly eventName = 'DotnetInvalidReleasesJSONError';
 }
 
-export class DotnetNoInstallerFileExistsError extends DotnetAcquisitionError {
+export class DotnetNoInstallerFileExistsError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetNoInstallerFileExistsError';
 }
 
-export class DotnetNoInstallerResponseError extends DotnetInstallExpectedAbort {
+export class DotnetNoInstallerResponseError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetNoInstallerResponseError';
 }
 
-export class DotnetUnexpectedInstallerOSError extends DotnetAcquisitionError {
+export class DotnetUnexpectedInstallerOSError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetUnexpectedInstallerOSError';
 }
 
-export class DotnetUnexpectedInstallerArchitectureError extends DotnetAcquisitionError {
+export class DotnetUnexpectedInstallerArchitectureError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetUnexpectedInstallerArchitectureError';
 }
 
-export class DotnetFeatureBandDoesNotExistError extends DotnetAcquisitionError {
+export class DotnetFeatureBandDoesNotExistError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetFeatureBandDoesNotExistError';
 }
 
-export class DotnetInvalidRuntimePatchVersion extends DotnetAcquisitionError {
+export class DotnetInvalidRuntimePatchVersion extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetInvalidRuntimePatchVersion';
 }
 
-export class DotnetWSLSecurityError extends DotnetInstallExpectedAbort {
+export class DotnetWSLSecurityError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetWSLSecurityError';
 }
 
 
-export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionError {
-    constructor(error: Error, public readonly install: DotnetInstall | null) {
+export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionError
+{
+    constructor(error: Error, public readonly install: DotnetInstall | null)
+    {
         super(error, install);
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        return this.install ? {ErrorMessage : this.error.message,
-            AcquisitionErrorInstallId : this.install.installId ?? 'null',
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
+        return this.install ? {
+            ErrorMessage: this.error.message,
+            AcquisitionErrorInstallId: this.install.installId ?? 'null',
             ...InstallToStrings(this.install),
-            ErrorName : this.error.name,
-            StackTrace : this.error.stack ?? ''}
-            :
-            {ErrorMessage : this.error.message,
-                AcquisitionErrorInstallId : 'null',
-                ErrorName : this.error.name,
-                StackTrace : this.error.stack ?? ''};
+            ErrorName: this.error.name,
+            StackTrace: this.error.stack ?? ''
         }
+            :
+            {
+                ErrorMessage: this.error.message,
+                AcquisitionErrorInstallId: 'null',
+                ErrorName: this.error.name,
+                StackTrace: this.error.stack ?? ''
+            };
     }
+}
 
-export class DotnetAcquisitionUnexpectedError extends DotnetAcquisitionVersionError {
+export class DotnetAcquisitionUnexpectedError extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'DotnetAcquisitionUnexpectedError';
 }
 
-export class DotnetAcquisitionInstallError extends DotnetAcquisitionVersionError {
+export class DotnetAcquisitionInstallError extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'DotnetAcquisitionInstallError';
 }
 
-export class DotnetAcquisitionScriptError extends DotnetAcquisitionVersionError {
+export class DotnetAcquisitionScriptError extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'DotnetAcquisitionScriptError';
 }
 
-export class DotnetConflictingGlobalWindowsInstallError extends DotnetInstallExpectedAbort {
+export class DotnetConflictingGlobalWindowsInstallError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetConflictingGlobalWindowsInstallError';
 }
 
-export class DotnetInstallCancelledByUserError extends DotnetInstallExpectedAbort {
+export class DotnetInstallCancelledByUserError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetInstallCancelledByUserError';
 }
 
-export class DotnetDebuggingMessage extends IEvent {
+export class DotnetDebuggingMessage extends IEvent
+{
     public readonly eventName = 'DotnetDebuggingMessage';
     public readonly type = EventType.DotnetDebuggingMessage;
 
-    constructor(public readonly message: string) {
+    constructor(public readonly message: string)
+    {
         super();
         this.message = message;
     }
 
-    public getProperties() {
-        return { message : this.message };
+    public getProperties()
+    {
+        return { message: this.message };
     }
 }
 
-export class DotnetNonZeroInstallerExitCodeError extends DotnetAcquisitionError {
+export class DotnetNonZeroInstallerExitCodeError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetNonZeroInstallerExitCodeError';
 }
 
-export class DotnetOfflineFailure extends DotnetAcquisitionVersionError {
+export class DotnetOfflineFailure extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'DotnetOfflineFailure';
 }
 
-export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError {
+export class PowershellBadExecutionPolicy extends DotnetAcquisitionVersionError
+{
+    public readonly eventName = 'PowershellBadExecutionPolicy';
+}
+
+export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'DotnetAcquisitionTimeoutError';
 
-    constructor(error: Error, installId: DotnetInstall | null, public readonly timeoutValue: number) {
+    constructor(error: Error, installId: DotnetInstall | null, public readonly timeoutValue: number)
+    {
         super(error, installId);
     }
 
     public getProperties(telemetry = false): { [id: string]: string } | undefined
     {
-        if(this.install)
+        if (this.install)
         {
-            return {ErrorMessage : this.error.message,
-                TimeoutValue : this.timeoutValue.toString(),
+            return {
+                ErrorMessage: this.error.message,
+                TimeoutValue: this.timeoutValue.toString(),
                 ...InstallToStrings(this.install),
-                ErrorName : this.error.name,
-                StackTrace : this.error.stack ? this.error.stack : ''};
+                ErrorName: this.error.name,
+                StackTrace: this.error.stack ? this.error.stack : ''
+            };
         }
         else
         {
-            return {ErrorMessage : this.error.message,
-                TimeoutValue : this.timeoutValue.toString(),
-                ErrorName : this.error.name,
-                StackTrace : this.error.stack ? this.error.stack : ''};
+            return {
+                ErrorMessage: this.error.message,
+                TimeoutValue: this.timeoutValue.toString(),
+                ErrorName: this.error.name,
+                StackTrace: this.error.stack ? this.error.stack : ''
+            };
         }
     }
 
 }
 
-export class DotnetVersionResolutionError extends DotnetInstallExpectedAbort {
+export class DotnetVersionResolutionError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetVersionResolutionError';
 }
 
-export class DotnetConflictingLinuxInstallTypesError extends DotnetInstallExpectedAbort {
+export class DotnetConflictingLinuxInstallTypesError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetConflictingLinuxInstallTypesError';
 }
 
-export class DotnetCustomLinuxInstallExistsError extends DotnetInstallExpectedAbort {
+export class DotnetCustomLinuxInstallExistsError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetCustomLinuxInstallExistsError';
 }
 
-export class DotnetInstallationValidationError extends DotnetAcquisitionVersionError {
+export class DotnetInstallationValidationError extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'DotnetInstallationValidationError';
     public readonly fileStructure: string;
-    constructor(error: Error, install: DotnetInstall, public readonly dotnetPath: string) {
+    constructor(error: Error, install: DotnetInstall, public readonly dotnetPath: string)
+    {
         super(error, install);
         this.fileStructure = this.getFileStructure();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        if(this.install)
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
+        if (this.install)
         {
-            return {ErrorMessage : this.error.message,
-                AcquisitionErrorInstallId : this.install?.installId ?? 'null',
-                InstallId : this.install?.installId ?? 'null',
+            return {
+                ErrorMessage: this.error.message,
+                AcquisitionErrorInstallId: this.install?.installId ?? 'null',
+                InstallId: this.install?.installId ?? 'null',
                 ...InstallToStrings(this.install),
-                ErrorName : this.error.name,
-                StackTrace : this.error.stack ? this.error.stack : '',
-                FileStructure : this.fileStructure};
+                ErrorName: this.error.name,
+                StackTrace: this.error.stack ? this.error.stack : '',
+                FileStructure: this.fileStructure
+            };
         }
         else
         {
-            return {ErrorMessage : this.error.message,
-                AcquisitionErrorInstallId : 'null',
-                InstallId : 'null',
-                ErrorName : this.error.name,
-                StackTrace : this.error.stack ? this.error.stack : '',
-                FileStructure : this.fileStructure};
+            return {
+                ErrorMessage: this.error.message,
+                AcquisitionErrorInstallId: 'null',
+                InstallId: 'null',
+                ErrorName: this.error.name,
+                StackTrace: this.error.stack ? this.error.stack : '',
+                FileStructure: this.fileStructure
+            };
         }
     }
 
-    private getFileStructure(): string {
+    private getFileStructure(): string
+    {
         const folderPath = path.dirname(this.dotnetPath);
-        if (!fs.existsSync(folderPath)) {
-            return `Dotnet Path (${ path.basename(folderPath) }) does not exist`;
+        if (!fs.existsSync(folderPath))
+        {
+            return `Dotnet Path (${path.basename(folderPath)}) does not exist`;
         }
         // Get 2 levels worth of content of the folder
         let files = fs.readdirSync(folderPath).map(file => path.join(folderPath, file));
-        for (const file of files) {
-            if (fs.statSync(file).isDirectory()) {
+        for (const file of files)
+        {
+            if (fs.statSync(file).isDirectory())
+            {
                 files = files.concat(fs.readdirSync(file).map(fileName => path.join(file, fileName)));
             }
         }
         const relativeFiles: string[] = [];
-        for (const file of files) {
+        for (const file of files)
+        {
             relativeFiles.push(path.relative(path.dirname(folderPath), file));
         }
 
@@ -648,139 +767,169 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
     }
 }
 
-export class DotnetAcquisitionDistroUnknownError extends DotnetInstallExpectedAbort {
+export class DotnetAcquisitionDistroUnknownError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetAcquisitionDistroUnknownError';
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        return {ErrorMessage : this.error.message,
-            ErrorName : this.error.name,
-            StackTrace : this.error.stack ? this.error.stack : '',
-            InstallId : this.install?.installId ?? 'null',
-            ...InstallToStrings(this.install!)};
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
+        return {
+            ErrorMessage: this.error.message,
+            ErrorName: this.error.name,
+            StackTrace: this.error.stack ? this.error.stack : '',
+            InstallId: this.install?.installId ?? 'null',
+            ...InstallToStrings(this.install!)
+        };
     }
 }
 
 
-export abstract class DotnetAcquisitionSuccessEvent extends IEvent {
+export abstract class DotnetAcquisitionSuccessEvent extends IEvent
+{
     public readonly type = EventType.DotnetAcquisitionSuccessEvent;
 
-    public getProperties(): { [id: string]: string } | undefined {
+    public getProperties(): { [id: string]: string } | undefined
+    {
         return undefined;
     }
 }
 
-export class DotnetCommandSucceeded extends DotnetAcquisitionSuccessEvent {
+export class DotnetCommandSucceeded extends DotnetAcquisitionSuccessEvent
+{
     public readonly eventName = 'DotnetCommandSucceeded';
 
     constructor(public readonly commandName: string) { super(); }
 
-    public getProperties() {
-        return {CommandName : this.commandName};
+    public getProperties()
+    {
+        return { CommandName: this.commandName };
     }
 }
 
-export class DotnetUninstallAllStarted extends DotnetAcquisitionSuccessEvent {
+export class DotnetUninstallAllStarted extends DotnetAcquisitionSuccessEvent
+{
     public readonly eventName = 'DotnetUninstallAllStarted';
 }
 
-export class DotnetUninstallAllCompleted extends DotnetAcquisitionSuccessEvent {
+export class DotnetUninstallAllCompleted extends DotnetAcquisitionSuccessEvent
+{
     public readonly eventName = 'DotnetUninstallAllCompleted';
 }
 
-export class DotnetVersionResolutionCompleted extends DotnetAcquisitionSuccessEvent {
+export class DotnetVersionResolutionCompleted extends DotnetAcquisitionSuccessEvent
+{
     public readonly eventName = 'DotnetVersionResolutionCompleted';
 
     constructor(public readonly requestedVersion: string, public readonly resolvedVersion: string) { super(); }
 
-    public getProperties() {
-        return {RequestedVersion : this.requestedVersion,
-                ResolvedVersion : this.resolvedVersion};
+    public getProperties()
+    {
+        return {
+            RequestedVersion: this.requestedVersion,
+            ResolvedVersion: this.resolvedVersion
+        };
     }
 }
 
-export class DotnetInstallScriptAcquisitionCompleted extends DotnetAcquisitionSuccessEvent {
+export class DotnetInstallScriptAcquisitionCompleted extends DotnetAcquisitionSuccessEvent
+{
     public readonly eventName = 'DotnetInstallScriptAcquisitionCompleted';
 }
 
-export class DotnetExistingPathResolutionCompleted extends DotnetAcquisitionSuccessEvent {
+export class DotnetExistingPathResolutionCompleted extends DotnetAcquisitionSuccessEvent
+{
     public readonly eventName = 'DotnetExistingPathResolutionCompleted';
 
     constructor(public readonly resolvedPath: string) { super(); }
 
-    public getProperties(telemetry = false) {
-        return telemetry ? undefined : { ConfiguredPath : this.resolvedPath};
+    public getProperties(telemetry = false)
+    {
+        return telemetry ? undefined : { ConfiguredPath: this.resolvedPath };
     }
 }
 
-export abstract class DotnetAcquisitionMessage extends IEvent {
+export abstract class DotnetAcquisitionMessage extends IEvent
+{
     public type = EventType.DotnetAcquisitionMessage;
 
-    public getProperties(): { [id: string]: string } | undefined {
+    public getProperties(): { [id: string]: string } | undefined
+    {
         return {};
     }
 }
 
-export class DotnetAcquisitionDeletion extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionDeletion extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionDeletion';
     constructor(public readonly folderPath: string) { super(); }
 
     public getProperties(telemetry = false)
     {
-        return telemetry ? undefined : {DeletedFolderPath : this.folderPath};
+        return telemetry ? undefined : { DeletedFolderPath: this.folderPath };
     }
 }
 
-export class DotnetFallbackInstallScriptUsed extends DotnetAcquisitionMessage {
+export class DotnetFallbackInstallScriptUsed extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetFallbackInstallScriptUsed';
 }
 
-export abstract class DotnetCustomMessageEvent extends DotnetAcquisitionMessage {
+export abstract class DotnetCustomMessageEvent extends DotnetAcquisitionMessage
+{
     constructor(public readonly eventMessage: string) { super(); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return { Message: this.eventMessage };
     }
 }
 
-export abstract class DotnetVisibleWarningEvent extends DotnetCustomMessageEvent {
+export abstract class DotnetVisibleWarningEvent extends DotnetCustomMessageEvent
+{
     public readonly type = EventType.DotnetVisibleWarning;
 }
 
-export class DotnetFileIntegrityFailureEvent extends DotnetVisibleWarningEvent {
+export class DotnetFileIntegrityFailureEvent extends DotnetVisibleWarningEvent
+{
     public readonly eventName = 'DotnetFileIntegrityFailureEvent';
 }
 
-export class DotnetUnableToCheckPATHArchitecture extends DotnetVisibleWarningEvent {
+export class DotnetUnableToCheckPATHArchitecture extends DotnetVisibleWarningEvent
+{
     public readonly eventName = 'DotnetUnableToCheckPATHArchitecture';
 }
 
-export class DotnetVersionCategorizedEvent extends DotnetCustomMessageEvent {
+export class DotnetVersionCategorizedEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetVersionCategorizedEvent';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DuplicateInstallDetected extends DotnetCustomMessageEvent {
+export class DuplicateInstallDetected extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DuplicateInstallDetected';
 }
 
-export abstract class WebRequestTimer extends DotnetCustomMessageEvent {
+export abstract class WebRequestTimer extends DotnetCustomMessageEvent
+{
 
     constructor(public readonly eventMessage: string, public readonly durationMs: string,
-        public readonly finished: string, public readonly url: string, public readonly status : string
+        public readonly finished: string, public readonly url: string, public readonly status: string
     ) { super(eventMessage); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             Message: this.eventMessage,
-            DurationMs : this.durationMs,
-            Finished : this.finished,
-            Url : this.url.replace(/\//g, '.'), // urls get redacted as paths, they are not PII able since they are shared common urls. replaceAll may not exist with certain compilers, use regex
+            DurationMs: this.durationMs,
+            Finished: this.finished,
+            Url: this.url.replace(/\//g, '.'), // urls get redacted as paths, they are not PII able since they are shared common urls. replaceAll may not exist with certain compilers, use regex
             // see: https://github.com/microsoft/vscode/blob/a26fe3e4666aae75fdbfaacf7be153a07bdd12e8/src/vs/platform/telemetry/common/telemetryUtils.ts#L295C20-L295C105
-            Status : this.status
+            Status: this.status
         };
     }
 }
@@ -800,430 +949,520 @@ export class WebRequestTimeUnknown extends WebRequestTimer
     public readonly eventName = 'WebRequestTimeUnknown';
 }
 
-export class EmptyDirectoryToWipe extends DotnetCustomMessageEvent {
+export class EmptyDirectoryToWipe extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'EmptyDirectoryToWipe';
 }
 
-export class FileToWipe extends DotnetCustomMessageEvent {
+export class FileToWipe extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FileToWipe';
 }
 
-export class TriedToExitMasterSudoProcess extends DotnetCustomMessageEvent {
+export class TriedToExitMasterSudoProcess extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'TriedToExitMasterSudoProcess';
 }
 
-export class FeatureBandDoesNotExist extends DotnetCustomMessageEvent {
+export class FeatureBandDoesNotExist extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FeatureBandDoesNotExist';
 }
 
-export class FileDoesNotExist extends DotnetCustomMessageEvent {
+export class FileDoesNotExist extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FileDoesNotExist';
 }
 
-export class DotnetUninstallStarted extends DotnetCustomMessageEvent {
+export class DotnetUninstallStarted extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetUninstallStarted';
     public type = EventType.DotnetUninstallMessage;
 }
 
-export class DotnetUninstallCompleted extends DotnetCustomMessageEvent {
+export class DotnetUninstallCompleted extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetUninstallStarted';
     public type = EventType.DotnetUninstallMessage;
 }
 
-export class DotnetUninstallFailed extends DotnetCustomMessageEvent {
+export class DotnetUninstallFailed extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetUninstallStarted';
     public type = EventType.DotnetUninstallMessage;
 }
 
-export class NoExtensionIdProvided extends DotnetCustomMessageEvent {
+export class NoExtensionIdProvided extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'NoExtensionIdProvided';
 }
 
-export class ConvertingLegacyInstallRecord extends DotnetCustomMessageEvent {
+export class ConvertingLegacyInstallRecord extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'ConvertingLegacyInstallRecord';
 }
-export class FoundTrackingVersions extends DotnetCustomMessageEvent {
+export class FoundTrackingVersions extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FoundTrackingVersions';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
-export class RemovingVersionFromExtensionState extends DotnetCustomMessageEvent {
+export class RemovingVersionFromExtensionState extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'RemovingVersionFromExtensionState';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class RemovingExtensionFromList extends DotnetCustomMessageEvent {
+export class RemovingExtensionFromList extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'RemovingExtensionFromList';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class RemovingOwnerFromList extends DotnetCustomMessageEvent {
+export class RemovingOwnerFromList extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'RemovingOwnerFromList';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class SkipAddingInstallEvent extends DotnetCustomMessageEvent {
+export class SkipAddingInstallEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SkipAddingInstallEvent';
 }
 
-export class AddTrackingVersions extends DotnetCustomMessageEvent {
+export class AddTrackingVersions extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'AddTrackingVersions';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetWSLCheckEvent extends DotnetCustomMessageEvent {
+export class DotnetWSLCheckEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetWSLCheckEvent';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetWSLOperationOutputEvent extends DotnetCustomMessageEvent {
+export class DotnetWSLOperationOutputEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetWSLOperationOutputEvent';
 }
 
-export class DotnetFindPathCommandInvoked extends DotnetCustomMessageEvent {
+export class DotnetFindPathCommandInvoked extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathCommandInvoked';
-    constructor(public readonly eventMessage: string, public readonly request : IDotnetFindPathContext) { super(eventMessage); }
+    constructor(public readonly eventMessage: string, public readonly request: IDotnetFindPathContext) { super(eventMessage); }
 
-    public getProperties() {
-        return { Message: this.eventMessage, Context : JSON.stringify(this.request)};
+    public getProperties()
+    {
+        return { Message: this.eventMessage, Context: JSON.stringify(this.request) };
     };
 }
 
-export class DotnetFindPathLookupSetting extends DotnetCustomMessageEvent {
+export class DotnetFindPathLookupSetting extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathLookupSetting';
 }
 
-export class DotnetFindPathSettingFound extends DotnetCustomMessageEvent {
+export class DotnetFindPathSettingFound extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathSettingFound';
 }
 
-export class DotnetFindPathLookupPATH extends DotnetCustomMessageEvent {
+export class DotnetFindPathLookupPATH extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathLookupPATH';
 }
 
-export class DotnetFindPathPATHFound extends DotnetCustomMessageEvent {
+export class DotnetFindPathPATHFound extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathPATHFound';
 }
 
-export class DotnetFindPathLookupRealPATH extends DotnetCustomMessageEvent {
+export class DotnetFindPathLookupRealPATH extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathLookupRealPATH';
 }
 
-export class DotnetFindPathRealPATHFound extends DotnetCustomMessageEvent {
+export class DotnetFindPathRealPATHFound extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
-export class DotnetFindPathHostFxrResolutionLookup extends DotnetCustomMessageEvent {
+export class DotnetFindPathHostFxrResolutionLookup extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathHostFxrResolutionLookup';
 }
 
-export class DotnetFindPathOnRegistry extends DotnetCustomMessageEvent {
+export class DotnetFindPathOnRegistry extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathOnRegistry';
 }
 
-export class DotnetFindPathNoHostOnRegistry extends DotnetCustomMessageEvent {
+export class DotnetFindPathNoHostOnRegistry extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathNoHostOnRegistry';
 }
 
-export class DotnetFindPathOnFileSystem extends DotnetCustomMessageEvent {
+export class DotnetFindPathOnFileSystem extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathOnFileSystem';
 }
 
-export class DotnetFindPathNoHostOnFileSystem extends DotnetCustomMessageEvent {
+export class DotnetFindPathNoHostOnFileSystem extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathNoHostOnFileSystem';
 }
 
-export class DotnetFindPathNoRuntimesOnHost extends DotnetCustomMessageEvent {
+export class DotnetFindPathNoRuntimesOnHost extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathNoRuntimesOnHost';
 }
 
-export class DotnetFindPathLookupRootPATH extends DotnetCustomMessageEvent {
+export class DotnetFindPathLookupRootPATH extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathLookupRealPATH';
 }
 
-export class DotnetFindPathRootEmulationPATHFound extends DotnetCustomMessageEvent {
+export class DotnetFindPathRootEmulationPATHFound extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
-export class DotnetFindPathRootUnderEmulationButNoneSet extends DotnetCustomMessageEvent {
+export class DotnetFindPathRootUnderEmulationButNoneSet extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
-export class DotnetFindPathRootPATHFound extends DotnetCustomMessageEvent {
+export class DotnetFindPathRootPATHFound extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
-export class DotnetFindPathMetCondition extends DotnetCustomMessageEvent {
+export class DotnetFindPathMetCondition extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathMetCondition';
 }
 
-export class DotnetFindPathNoPathMetCondition extends DotnetCustomMessageEvent {
+export class DotnetFindPathNoPathMetCondition extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathNoPathMetCondition';
 }
 
-export class DotnetFindPathDidNotMeetCondition extends DotnetCustomMessageEvent {
+export class DotnetFindPathDidNotMeetCondition extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathDidNotMeetCondition';
 }
 
-export class DotnetTelemetrySettingEvent extends DotnetCustomMessageEvent {
+export class DotnetTelemetrySettingEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetTelemetrySettingEvent';
 }
 
-export class DotnetVSCodeExtensionFound extends DotnetCustomMessageEvent {
+export class DotnetVSCodeExtensionFound extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetVSCodeExtensionFound';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetVSCodeExtensionHasInstallRequest extends DotnetCustomMessageEvent {
+export class DotnetVSCodeExtensionHasInstallRequest extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetVSCodeExtensionHasInstallRequest';
 }
 
-export class DotnetVSCodeExtensionChange extends DotnetCustomMessageEvent {
+export class DotnetVSCodeExtensionChange extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetVSCodeExtensionChange';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetCommandNotFoundEvent extends DotnetCustomMessageEvent {
+export class DotnetCommandNotFoundEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetCommandNotFoundEvent';
 }
 
-export class DotnetFileIntegrityCheckEvent extends DotnetCustomMessageEvent {
+export class DotnetFileIntegrityCheckEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFileIntegrityCheckEvent';
 }
 
-export class GlobalAcquisitionContextMenuOpened extends DotnetCustomMessageEvent {
+export class GlobalAcquisitionContextMenuOpened extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'GlobalAcquisitionContextMenuOpened';
 }
 
-export class UserManualInstallVersionChosen extends DotnetCustomMessageEvent {
+export class UserManualInstallVersionChosen extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'UserManualInstallVersionChosen';
 }
 
-export class UserManualInstallRequested extends DotnetCustomMessageEvent {
+export class UserManualInstallRequested extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'UserManualInstallRequested';
 }
 
-export class UserManualInstallSuccess extends DotnetCustomMessageEvent {
+export class UserManualInstallSuccess extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'UserManualInstallSuccess';
 }
 
-export class CommandExecutionStdOut extends DotnetCustomMessageEvent {
+export class CommandExecutionStdOut extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionStdOut';
 }
 
-export class NoMatchingInstallToStopTracking extends DotnetCustomMessageEvent {
+export class NoMatchingInstallToStopTracking extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'NoMatchingInstallToStopTracking';
 }
 
-export class CommandExecutionStdError extends DotnetCustomMessageEvent {
+export class CommandExecutionStdError extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionStdError';
 }
 
-export class DotnetGlobalAcquisitionBeginEvent extends DotnetCustomMessageEvent {
+export class DotnetGlobalAcquisitionBeginEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetGlobalAcquisitionBeginEvent';
 }
 
-export class DotnetGlobalVersionResolutionCompletionEvent extends DotnetCustomMessageEvent {
+export class DotnetGlobalVersionResolutionCompletionEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetGlobalVersionResolutionCompletionEvent';
 }
 
-export class CommandProcessesExecutionFailureNonTerminal extends DotnetCustomMessageEvent {
+export class CommandProcessesExecutionFailureNonTerminal extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandProcessesExecutionFailureNonTerminal';
 }
 
-export class CommandProcessorExecutionBegin extends DotnetCustomMessageEvent {
+export class CommandProcessorExecutionBegin extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandProcessorExecutionBegin';
 }
 
-export class CommandProcessorExecutionEnd extends DotnetCustomMessageEvent {
+export class CommandProcessorExecutionEnd extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandProcessorExecutionEnd';
 }
 
-export class DotnetBeginGlobalInstallerExecution extends DotnetCustomMessageEvent {
+export class DotnetBeginGlobalInstallerExecution extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetBeginGlobalInstallerExecution';
 }
 
-export class DotnetCompletedGlobalInstallerExecution extends DotnetCustomMessageEvent {
+export class DotnetCompletedGlobalInstallerExecution extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetCompletedGlobalInstallerExecution';
 }
 
-export class DotnetGlobalAcquisitionCompletionEvent extends DotnetCustomMessageEvent {
+export class DotnetGlobalAcquisitionCompletionEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetGlobalAcquisitionCompletionEvent';
 }
-export class DotnetInstallGraveyardEvent extends DotnetCustomMessageEvent {
+export class DotnetInstallGraveyardEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetInstallGraveyardEvent';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetAlternativeCommandFoundEvent extends DotnetCustomMessageEvent {
+export class DotnetAlternativeCommandFoundEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetAlternativeCommandFoundEvent';
 }
 
-export class DotnetCommandFallbackArchitectureEvent extends DotnetCustomMessageEvent {
+export class DotnetCommandFallbackArchitectureEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetCommandFallbackArchitectureEvent';
 }
 
-export class DotnetCommandFallbackOSEvent extends DotnetCustomMessageEvent {
+export class DotnetCommandFallbackOSEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetCommandFallbackOSEvent';
 }
 
-export class DotnetInstallIdCreatedEvent extends DotnetCustomMessageEvent {
+export class DotnetInstallIdCreatedEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetInstallIdCreatedEvent';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetLegacyInstallDetectedEvent extends DotnetCustomMessageEvent {
+export class DotnetLegacyInstallDetectedEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetLegacyInstallDetectedEvent';
 }
 
-export class DotnetLegacyInstallRemovalRequestEvent extends DotnetCustomMessageEvent {
+export class DotnetLegacyInstallRemovalRequestEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetLegacyInstallRemovalRequestEvent';
 }
 
-export class DotnetFakeSDKEnvironmentVariableTriggered extends DotnetCustomMessageEvent {
+export class DotnetFakeSDKEnvironmentVariableTriggered extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFakeSDKEnvironmentVariableTriggered';
 }
 
-export class CommandExecutionNoStatusCodeWarning extends DotnetCustomMessageEvent {
+export class CommandExecutionNoStatusCodeWarning extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionNoStatusCodeWarning';
 }
 
-export class CommandExecutionSignalSentEvent extends DotnetCustomMessageEvent {
+export class CommandExecutionSignalSentEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionSignalSentEvent';
 }
 
-export class CommandExecutionStatusEvent extends DotnetCustomMessageEvent {
+export class CommandExecutionStatusEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionStatusEvent';
 }
 
-export class CommandExecutionEvent extends DotnetCustomMessageEvent {
+export class CommandExecutionEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionEvent';
 }
 
-export class SudoProcAliveCheckBegin extends DotnetCustomMessageEvent {
+export class SudoProcAliveCheckBegin extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SudoProcAliveCheckBegin';
 }
 
-export class SudoProcAliveCheckEnd extends DotnetCustomMessageEvent {
+export class SudoProcAliveCheckEnd extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SudoProcAliveCheckEnd';
 }
 
-export class SudoProcCommandExchangeBegin extends DotnetCustomMessageEvent {
+export class SudoProcCommandExchangeBegin extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SudoProcCommandExchangeBegin';
 }
 
-export class SudoProcCommandExchangePing extends DotnetCustomMessageEvent {
+export class SudoProcCommandExchangePing extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SudoProcCommandExchangePing';
 }
 
-export class WaitingForDotnetInstallerResponse extends DotnetCustomMessageEvent {
+export class WaitingForDotnetInstallerResponse extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'WaitingForDotnetInstallerResponse';
 }
 
-export class SudoProcCommandExchangeEnd extends DotnetCustomMessageEvent {
+export class SudoProcCommandExchangeEnd extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SudoProcCommandExchangeEnd';
 }
 
-export class CommandExecutionUserAskDialogueEvent extends DotnetCustomMessageEvent {
+export class CommandExecutionUserAskDialogueEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionUserAskDialogueEvent';
 }
 
-export class CommandExecutionUserCompletedDialogueEvent extends DotnetCustomMessageEvent {
+export class CommandExecutionUserCompletedDialogueEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionUserCompletedDialogueEvent';
 }
 
-export class CommandExecutionUnderSudoEvent extends DotnetCustomMessageEvent {
+export class CommandExecutionUnderSudoEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionUnderSudoEvent';
 }
 
-export class CommandExecutionUserRejectedPasswordRequest extends DotnetInstallExpectedAbort {
+export class CommandExecutionUserRejectedPasswordRequest extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'CommandExecutionUserRejectedPasswordRequest';
 }
 
-export class CommandExecutionUnknownCommandExecutionAttempt extends DotnetInstallExpectedAbort {
+export class CommandExecutionUnknownCommandExecutionAttempt extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'CommandExecutionUnknownCommandExecutionAttempt';
 }
 
-export class DotnetVersionParseEvent extends DotnetCustomMessageEvent {
+export class DotnetVersionParseEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetVersionParseEvent';
 }
 
-export class DotnetUpgradedEvent extends DotnetCustomMessageEvent {
+export class DotnetUpgradedEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetUpgradedEvent';
-    constructor(eventMsg : string)
+    constructor(eventMsg: string)
     {
         super(eventMsg);
         this.type = EventType.DotnetUpgradedEvent;
     }
 }
 
-export class DotnetOfflineInstallUsed extends DotnetCustomMessageEvent {
+export class DotnetOfflineInstallUsed extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetOfflineInstallUsed';
-    constructor(eventMsg : string)
+    constructor(eventMsg: string)
     {
         super(eventMsg);
         this.type = EventType.OfflineInstallUsed;
     }
 }
 
-export class DotnetOfflineWarning extends DotnetCustomMessageEvent {
+export class DotnetOfflineWarning extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetOfflineWarning';
-    constructor(eventMsg : string)
+    constructor(eventMsg: string)
     {
         super(eventMsg);
         this.type = EventType.OfflineWarning;
     }
 }
 
-export class NetInstallerBeginExecutionEvent extends DotnetCustomMessageEvent {
+export class NetInstallerBeginExecutionEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'NetInstallerBeginExecutionEvent';
 }
 
-export class NetInstallerEndExecutionEvent extends DotnetCustomMessageEvent {
+export class NetInstallerEndExecutionEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'NetInstallerEndExecutionEvent';
 }
 
 
-export class DotnetInstallLinuxChecks extends DotnetCustomMessageEvent {
+export class DotnetInstallLinuxChecks extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetInstallLinuxChecks';
 }
 
@@ -1231,8 +1470,9 @@ export abstract class DotnetFileEvent extends DotnetAcquisitionMessage
 {
     constructor(public readonly eventMessage: string, public readonly time: string, public readonly file: string) { super(); }
 
-    public getProperties() {
-        return {Message: this.eventMessage, Time: this.time, File: TelemetryUtilities.HashData(this.file)};
+    public getProperties()
+    {
+        return { Message: this.eventMessage, Time: this.time, File: TelemetryUtilities.HashData(this.file) };
     }
 }
 
@@ -1240,63 +1480,72 @@ export abstract class DotnetLockEvent extends DotnetFileEvent
 {
     constructor(public readonly eventMessage: string, public readonly time: string, public readonly lock: string, public readonly file: string) { super(eventMessage, time, file); }
 
-    public getProperties() {
-        return {Message: this.eventMessage, Time: this.time, Lock: this.lock, File: this.file};
+    public getProperties()
+    {
+        return { Message: this.eventMessage, Time: this.time, Lock: this.lock, File: this.file };
     }
 }
 
-export class DotnetLockAcquiredEvent extends DotnetLockEvent {
+export class DotnetLockAcquiredEvent extends DotnetLockEvent
+{
     public readonly eventName = 'DotnetLockAcquiredEvent';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetLockReleasedEvent extends DotnetLockEvent {
+export class DotnetLockReleasedEvent extends DotnetLockEvent
+{
     public readonly eventName = 'DotnetLockReleasedEvent';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetLockErrorEvent extends DotnetLockEvent {
+export class DotnetLockErrorEvent extends DotnetLockEvent
+{
     public readonly eventName = 'DotnetLockErrorEvent';
-    constructor(public readonly error : Error,
+    constructor(public readonly error: Error,
         public readonly eventMessage: string, public readonly time: string, public readonly lock: string, public readonly file: string) { super(eventMessage, time, lock, file); }
 
-    public getProperties() {
-        return {Error: this.error.toString(), Message: this.eventMessage, Time: this.time, Lock: this.lock, File: this.file};
+    public getProperties()
+    {
+        return { Error: this.error.toString(), Message: this.eventMessage, Time: this.time, Lock: this.lock, File: this.file };
     }
 
 }
 
-export class DotnetLockAttemptingAcquireEvent extends DotnetLockEvent {
+export class DotnetLockAttemptingAcquireEvent extends DotnetLockEvent
+{
     public readonly eventName = 'DotnetLockAttemptingAcquireEvent';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetFileWriteRequestEvent extends DotnetFileEvent {
+export class DotnetFileWriteRequestEvent extends DotnetFileEvent
+{
     public readonly eventName = 'DotnetFileWriteRequestEvent';
 
     public getProperties()
     {
-        return {suppressTelemetry : 'true', ...super.getProperties()};
+        return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetAcquisitionPartialInstallation extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionPartialInstallation extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionPartialInstallation';
     constructor(public readonly install: DotnetInstall) { super(); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             ...InstallToStrings(this.install!),
             PartialInstallationInstallId: this.install.installId
@@ -1304,141 +1553,172 @@ export class DotnetAcquisitionPartialInstallation extends DotnetAcquisitionMessa
     }
 }
 
-export class DotnetAcquisitionInProgress extends IEvent {
+export class DotnetAcquisitionInProgress extends IEvent
+{
     public readonly type = EventType.DotnetAcquisitionInProgress;
 
     public readonly eventName = 'DotnetAcquisitionInProgress';
     constructor(public readonly install: DotnetInstall, public readonly requestingExtensionId: string | null) { super(); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
-            InProgressInstallationInstallId : this.install.installId,
+            InProgressInstallationInstallId: this.install.installId,
             ...InstallToStrings(this.install!),
-            extensionId : TelemetryUtilities.HashData(this.requestingExtensionId)};
+            extensionId: TelemetryUtilities.HashData(this.requestingExtensionId)
+        };
     }
 }
 
-export class DotnetAcquisitionAlreadyInstalled extends IEvent {
+export class DotnetAcquisitionAlreadyInstalled extends IEvent
+{
     public readonly eventName = 'DotnetAcquisitionAlreadyInstalled';
     public readonly type = EventType.DotnetAcquisitionAlreadyInstalled;
 
     constructor(public readonly install: DotnetInstall, public readonly requestingExtensionId: string | null) { super(); }
 
-    public getProperties() {
-        return {...InstallToStrings(this.install),
-            extensionId : TelemetryUtilities.HashData(this.requestingExtensionId)};
+    public getProperties()
+    {
+        return {
+            ...InstallToStrings(this.install),
+            extensionId: TelemetryUtilities.HashData(this.requestingExtensionId)
+        };
     }
 }
 
-export class DotnetAcquisitionMissingLinuxDependencies extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionMissingLinuxDependencies extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionMissingLinuxDependencies';
 }
 
 
-export class DotnetAcquisitionScriptOutput extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionScriptOutput extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionScriptOutput';
     public isError = true;
     constructor(public readonly install: DotnetInstall, public readonly output: string) { super(); }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
-            AcquisitionInstallId : this.install.installId,
+            AcquisitionInstallId: this.install.installId,
             ...InstallToStrings(this.install!),
-                ScriptOutput: this.output
-            };
+            ScriptOutput: this.output
+        };
     }
 }
 
-export class DotnetInstallationValidated extends DotnetAcquisitionMessage {
+export class DotnetInstallationValidated extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetInstallationValidated';
     constructor(public readonly install: DotnetInstall) { super(); }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
-            ValidatedInstallId : this.install.installId,
+            ValidatedInstallId: this.install.installId,
             ...InstallToStrings(this.install!)
         };
     }
 }
 
-export class DotnetAcquisitionStatusRequested extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionStatusRequested extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionStatusRequested';
 
     constructor(public readonly version: string,
-                public readonly requestingId = '') {
+        public readonly requestingId = '')
+    {
         super();
     }
 
-    public getProperties() {
-        return {AcquisitionStartVersion : this.version,
-                RequestingExtensionId: TelemetryUtilities.HashData(this.requestingId)};
+    public getProperties()
+    {
+        return {
+            AcquisitionStartVersion: this.version,
+            RequestingExtensionId: TelemetryUtilities.HashData(this.requestingId)
+        };
     }
 }
 
-export class DotnetAcquisitionStatusUndefined extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionStatusUndefined extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionStatusUndefined';
 
-    constructor(public readonly installId: DotnetInstall) {
+    constructor(public readonly installId: DotnetInstall)
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
-            AcquisitionStatusInstallId : this.installId.installId,
+            AcquisitionStatusInstallId: this.installId.installId,
             ...InstallToStrings(this.installId!)
         };
     }
 }
 
-export class DotnetAcquisitionStatusResolved extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionStatusResolved extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionStatusResolved';
 
-    constructor(public readonly installId: DotnetInstall, public readonly version: string) {
+    constructor(public readonly installId: DotnetInstall, public readonly version: string)
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
-            AcquisitionStatusInstallId : this.installId.installId,
+            AcquisitionStatusInstallId: this.installId.installId,
             ...InstallToStrings(this.installId!),
-            AcquisitionStatusVersion : this.version
-            };
+            AcquisitionStatusVersion: this.version
+        };
     }
 }
 
-export class WebRequestSent extends DotnetAcquisitionMessage {
+export class WebRequestSent extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'WebRequestSent';
 
-    constructor(public readonly url: string) {
+    constructor(public readonly url: string)
+    {
         super();
     }
 
-    public getProperties() {
-        return {WebRequestUri : this.url};
+    public getProperties()
+    {
+        return { WebRequestUri: this.url };
     }
 }
 
-export class DotnetPreinstallDetected extends DotnetAcquisitionMessage {
+export class DotnetPreinstallDetected extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetPreinstallDetected';
     constructor(public readonly installId: DotnetInstall) { super(); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             ...InstallToStrings(this.installId!),
-            PreinstalledInstallId : this.installId.installId
-            };
+            PreinstalledInstallId: this.installId.installId
+        };
     }
 }
 
-export class TestAcquireCalled extends IEvent {
+export class TestAcquireCalled extends IEvent
+{
     public readonly eventName = 'TestAcquireCalled';
     public readonly type = EventType.DotnetAcquisitionTest;
 
-    constructor(public readonly context: IDotnetInstallationContext) {
+    constructor(public readonly context: IDotnetInstallationContext)
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return undefined;
     }
 }

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -41,7 +41,15 @@ suite('Linux Distro Logic Unit Tests', () =>
                 'apt-cache -o DPkg::Lock::Timeout=180 search --names-only ^dotnet-sdk-9.0$', 'Searched for the newest package last with regex'); // this may fail if test not exec'd first
             // the data is cached so --version may not be executed.
             const distroVersion = await new LinuxVersionResolver(acquisitionContext, getMockUtilityContext()).getRunningDistro();
-            assert.equal(recVersion, Number(distroVersion) >= 22.04 ? '9.0.1xx' : '8.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
+            if (Number(distroVersion) === 22.04)
+            {
+                // certain versions have 9 support but others do not
+                assert.include(['9.0.1xx', '8.0.1xx'], recVersion, `${recVersion} is 9 or 8 : special check for ubuntu 22.04`);
+            }
+            else
+            {
+                assert.equal(recVersion, Number(distroVersion) >= 22.04 ? '9.0.1xx' : '8.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
+            }
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -16,10 +16,10 @@ const standardTimeoutTime = 100000;
 const mockVersion = '7.0.103';
 const acquisitionContext = getMockAcquisitionContext('sdk', mockVersion);
 const mockExecutor = new MockCommandExecutor(acquisitionContext, getMockUtilityContext());
-const pair : DistroVersionPair = { distro : 'Ubuntu', version : '22.04' };
-const provider : GenericDistroSDKProvider = new GenericDistroSDKProvider(pair, acquisitionContext, getMockUtilityContext(), mockExecutor);
+const pair: DistroVersionPair = { distro: 'Ubuntu', version: '22.04' };
+const provider: GenericDistroSDKProvider = new GenericDistroSDKProvider(pair, acquisitionContext, getMockUtilityContext(), mockExecutor);
 const shouldRun = os.platform() === 'linux';
-const installType : DotnetInstallMode = 'sdk';
+const installType: DotnetInstallMode = 'sdk';
 const noDotnetString = `
 Command 'dotnet' not found, but can be installed with:
 
@@ -32,20 +32,22 @@ Command 'dotnet' not found, but can be installed with:
 
 suite('Linux Distro Logic Unit Tests', () =>
 {
-    test('Recommends Correct Version', async () => {
-        if(shouldRun)
+    test('Recommends Correct Version', async () =>
+    {
+        if (shouldRun)
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
             assert.equal(mockExecutor.attemptedCommand,
-'apt-cache -o DPkg::Lock::Timeout=180 search --names-only ^dotnet-sdk-9.0$', 'Searched for the newest package last with regex'); // this may fail if test not exec'd first
+                'apt-cache -o DPkg::Lock::Timeout=180 search --names-only ^dotnet-sdk-9.0$', 'Searched for the newest package last with regex'); // this may fail if test not exec'd first
             // the data is cached so --version may not be executed.
             const distroVersion = await new LinuxVersionResolver(acquisitionContext, getMockUtilityContext()).getRunningDistro();
-            assert.equal(recVersion, Number(distroVersion) > 22.04 ? '9.0.1xx' : '8.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
+            assert.equal(recVersion, Number(distroVersion) >= 22.04 ? '9.0.1xx' : '8.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
         }
     }).timeout(standardTimeoutTime);
 
-    test('Package Check Succeeds', async () => {
-        if(shouldRun)
+    test('Package Check Succeeds', async () =>
+    {
+        if (shouldRun)
         {
             // assert this passes : we don't want the test to be reliant on machine state for whether the package exists or not, so don't check output
             await provider.dotnetPackageExistsOnSystem(mockVersion, installType);
@@ -53,24 +55,27 @@ suite('Linux Distro Logic Unit Tests', () =>
         }
     }).timeout(standardTimeoutTime);
 
-    test('Support Status Check', async () => {
-        if(shouldRun)
+    test('Support Status Check', async () =>
+    {
+        if (shouldRun)
         {
             const status = await provider.getDotnetVersionSupportStatus(mockVersion, installType);
             assert.equal(status, DotnetDistroSupportStatus.Distro);
         }
     }).timeout(standardTimeoutTime);
 
-    test('Gets Distro Feed Install Dir', async () => {
-        if(shouldRun)
+    test('Gets Distro Feed Install Dir', async () =>
+    {
+        if (shouldRun)
         {
             const distroFeedDir = await provider.getExpectedDotnetDistroFeedInstallationDirectory();
             assert.equal(distroFeedDir, '/usr/lib/dotnet');
         }
     }).timeout(standardTimeoutTime);
 
-    test('Gets Microsoft Feed Install Dir', async () => {
-        if(shouldRun)
+    test('Gets Microsoft Feed Install Dir', async () =>
+    {
+        if (shouldRun)
         {
             const microsoftFeedDir = await provider.getExpectedDotnetMicrosoftFeedInstallationDirectory();
             assert.equal(microsoftFeedDir, '/usr/share/dotnet');
@@ -79,64 +84,72 @@ suite('Linux Distro Logic Unit Tests', () =>
 
     test('Gets Installed SDKs', async () =>
     {
-        if(shouldRun)
+        if (shouldRun)
         {
-            mockExecutor.fakeReturnValue = { stdout: `
+            mockExecutor.fakeReturnValue = {
+                stdout: `
 7.0.105 [/usr/lib/dotnet/sdk]
-7.0.104 [/usr/custom/dotnet/sdk]`, stderr: '', status: '0'};
+7.0.104 [/usr/custom/dotnet/sdk]`, stderr: '', status: '0'
+            };
             let versions = await provider.getInstalledDotnetSDKVersions();
             mockExecutor.resetReturnValues();
             assert.deepStrictEqual(versions, ['7.0.105', '7.0.104']);
 
-            mockExecutor.fakeReturnValue = {stdout: noDotnetString, stderr: '', status: '0'};
+            mockExecutor.fakeReturnValue = { stdout: noDotnetString, stderr: '', status: '0' };
             versions = await provider.getInstalledDotnetSDKVersions();
             mockExecutor.resetReturnValues();
             assert.deepStrictEqual(versions, []);
         }
     }).timeout(standardTimeoutTime);
 
-    test('Gets Installed Runtimes', async () => {
-        if(shouldRun)
+    test('Gets Installed Runtimes', async () =>
+    {
+        if (shouldRun)
         {
-            mockExecutor.fakeReturnValue = {stdout: `
+            mockExecutor.fakeReturnValue = {
+                stdout: `
 Microsoft.NETCore.App 6.0.16 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]
-Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, stderr: '', status: '0'};
+Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, stderr: '', status: '0'
+            };
             let versions = await provider.getInstalledDotnetRuntimeVersions();
             mockExecutor.resetReturnValues();
             assert.deepStrictEqual(versions, ['6.0.16', '7.0.5']);
 
-            mockExecutor.fakeReturnValue = {stdout: noDotnetString, stderr: '', status: '0'};
+            mockExecutor.fakeReturnValue = { stdout: noDotnetString, stderr: '', status: '0' };
             versions = await provider.getInstalledDotnetRuntimeVersions();
             mockExecutor.resetReturnValues();
             assert.deepStrictEqual(versions, []);
         }
     }).timeout(standardTimeoutTime);
 
-    test('Looks for Global Dotnet Path Correctly', async () => {
-        if(shouldRun)
+    test('Looks for Global Dotnet Path Correctly', async () =>
+    {
+        if (shouldRun)
         {
             await provider.getInstalledGlobalDotnetPathIfExists(installType);
             assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/bin/dotnet');
         }
     }).timeout(standardTimeoutTime);
 
-    test('Finds Existing Global Dotnet Version', async () => {
-        if(shouldRun)
+    test('Finds Existing Global Dotnet Version', async () =>
+    {
+        if (shouldRun)
         {
-            mockExecutor.fakeReturnValue = {stdout: `7.0.105`, stderr: '', status: '0'};
+            mockExecutor.fakeReturnValue = { stdout: `7.0.105`, stderr: '', status: '0' };
             let currentInfo = await provider.getInstalledGlobalDotnetVersionIfExists();
             mockExecutor.resetReturnValues();
             assert.equal(currentInfo, '7.0.105');
 
-            mockExecutor.fakeReturnValue = {stdout: noDotnetString, stderr: noDotnetString, status: '0'};
+            mockExecutor.fakeReturnValue = { stdout: noDotnetString, stderr: noDotnetString, status: '0' };
             currentInfo = await provider.getInstalledGlobalDotnetVersionIfExists();
             mockExecutor.resetReturnValues();
             assert.equal(currentInfo, null);
         }
     }).timeout(standardTimeoutTime);
 
-    test('Gives Correct Version Support Info', async () => {
-        if(shouldRun)
+    test('Gives Correct Version Support Info', async () =>
+    {
+        if (shouldRun)
         {
             let supported = await provider.isDotnetVersionSupported('11.0.101', installType);
             // In the mock data, 8.0 is not supported, so it should be false.
@@ -149,27 +162,30 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
         }
     }).timeout(standardTimeoutTime);
 
-    test('Runs Correct Install Command', async () => {
-        if(shouldRun)
+    test('Runs Correct Install Command', async () =>
+    {
+        if (shouldRun)
         {
             await provider.installDotnet(mockVersion, installType);
             assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get -o DPkg::Lock::Timeout=180 install -y dotnet-sdk-7.0');
         }
     }).timeout(standardTimeoutTime);
 
-    test('Runs Correct Uninstall Command', async () => {
-        if(shouldRun)
+    test('Runs Correct Uninstall Command', async () =>
+    {
+        if (shouldRun)
         {
             await provider.uninstallDotnet(mockVersion, installType);
             assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get -o DPkg::Lock::Timeout=180 remove -y dotnet-sdk-7.0');
         }
     }).timeout(standardTimeoutTime);
 
-    test('Runs Correct Update Command', async () => {
-        if(shouldRun)
+    test('Runs Correct Update Command', async () =>
+    {
+        if (shouldRun)
         {
             await provider.upgradeDotnet(mockVersion, installType);
             assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get -o DPkg::Lock::Timeout=180 upgrade -y dotnet-sdk-7.0');
         }
-    }).timeout(standardTimeoutTime*1000);
+    }).timeout(standardTimeoutTime * 1000);
 });

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -41,15 +41,7 @@ suite('Linux Distro Logic Unit Tests', () =>
                 'apt-cache -o DPkg::Lock::Timeout=180 search --names-only ^dotnet-sdk-9.0$', 'Searched for the newest package last with regex'); // this may fail if test not exec'd first
             // the data is cached so --version may not be executed.
             const distroVersion = await new LinuxVersionResolver(acquisitionContext, getMockUtilityContext()).getRunningDistro();
-            if (Number(distroVersion) === 22.04)
-            {
-                // certain versions have 9 support but others do not
-                assert.include(['9.0.1xx', '8.0.1xx'], recVersion, `${recVersion} is 9 or 8 : special check for ubuntu 22.04`);
-            }
-            else
-            {
-                assert.equal(recVersion, Number(distroVersion) >= 22.04 ? '9.0.1xx' : '8.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
-            }
+            assert.equal(recVersion, Number(distroVersion.version) >= 22.04 ? '9.0.1xx' : '8.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
         }
     }).timeout(standardTimeoutTime);
 


### PR DESCRIPTION
# Info

For https://github.com/dotnet/vscode-dotnet-runtime/issues/2095 

See my comment at the end for context on what this all about.

* Fixes the error which said to change your execution policy, when it was actually about language mode. See below.
* Adds bypass mode when calling the install script instead of restricted. This helps with a limited number of scenarios when default execution policy restrictions are applied by SysAdmins to the User Scope, but not when restrictions are applied MachineWide via group policy as Disabled Execution in the UI, which shows up as restricted.
* Separates the error into two -- so that a clear message is given when the execution policy is set and causing a failure, vs when the language mode is set to cause failure.
* Helps us understand the 'Validation failed' error because we learned from this the directory is missing and the install result can return 0 even if the execution policy restricts the installation and it did not install correctly. This error is actually about execution policy.
* Please see below for a more thorough investigation and testing results.

# Claim: Machine Policy is defaulted to not allow script execution. 
I check this by running on a new Windows VM (not sandbox since that has its own caveats.)
`Get-ExecutionPolicy -List`

VM:
![image](https://github.com/user-attachments/assets/2c6d4ee6-ff52-4b95-84aa-5497bb1af29a)

That didn't seem to be the case. This is azure VM. When I used 'Default' as the value it was indeed 'Restricted.'

# Claim: You can run unrestricted but even on a signed file if its downloaded from the web like the install script, it would timeout asking for a prompt for the user to continue without bypass:


I made sure the policy was set again machine wide:
- Edit Group Policy MachineWide to Disable
![image](https://github.com/user-attachments/assets/16213015-9373-42ac-8174-13cd06bd8f7b)

`Set-ExecutionPolicy -ExecutionPolicy Default -Scope LocalMachine`
![image](https://github.com/user-attachments/assets/eba673a0-e091-49c3-bfde-ab87a665b3ce)

I made sure to run this on a non elevated vscode. I started VS Code after the policy.

VM:
![image](https://github.com/user-attachments/assets/9468ac22-a7b8-494a-b64b-530ce4b7ac36)

It actually failed with folder DNE. 
no timeout.
# Claim: If you set it to bypass, it will work correctly.

- VM: 
- Failed with 
```

Error : (DotnetCommandFailed)
Failed to download .NET 8.0.12~x64:
.NET Acquisition Failed: Validation of .dotnet installation for version {"installId":"8.0.12~x64","version":"8.0.12","architecture":"x64","isGlobal":false,"installMode":"runtime"} failed: Expected installation folder c:\Users\noahgilson004\AppData\Roaming\Code\User\globalStorage\ms-dotnettools.vscode-dotnet-runtime\.dotnet\8.0.12~x64 does not exist., Error: Validation of .dotnet installation for version {"installId":"8.0.12~x64","version":"8.0.12","architecture":"x64","isGlobal":false,"installMode":"runtime"} failed: Expected installation folder c:\Users\noahgilson004\AppData\Roaming\Code\User\globalStorage\ms-dotnettools.vscode-dotnet-runtime\.dotnet\8.0.12~x64 does not exist.
	at c.assertOrThrowError (c:\Users\noahgilson004\.vscode\extensions\ms-dotnettools.vscode-dotnet-runtime-2.2.6\dist\extension.js:2:80422)
	at c.validateDotnetInstall (c:\Users\noahgilson004\.vscode\extensions\ms-dotnettools.vscode-dotnet-runtime-2.2.6\dist\extension.js:2:79912)
	at y.<anonymous> (c:\Users\noahgilson004\.vscode\extensions\ms-dotnettools.vscode-dotnet-runtime-2.2.6\dist\extension.js:2:18291)
	at Generator.next (<anonymous>)
	at s (c:\Users\noahgilson004\.vscode\extensions\ms-dotnettools.vscode-dotnet-runtime-2.2.6\dist\extension.js:2:11504)
	at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

```

The same is true if system is default.
Inspection of the log shows that trying to run the script fails.

```
STDERR:  & : File C:\Users\noahgilson004\.vscode\extensions\ms-dotnettools.vscode-dotnet-runtime-2.2.6\dist\install 
scripts\dotnet-install.ps1 cannot be loaded because running scripts is disabled on this system. For more information, 
see about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170.
At line:1 char:137
+ ... ]::Tls12; & 'c:\Users\noahgilson004\.vscode\extensions\ms-dotnettools ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : SecurityError: (:) [], PSSecurityException
    + FullyQualifiedErrorId : UnauthorizedAccess

```

However, if the group policy is not set and it is not applied machine wide, then bypass actually makes it work, when it used to fail.

![image](https://github.com/user-attachments/assets/53cbc62e-5e54-4f9e-b1cd-54db5ebfe9b1)

![image](https://github.com/user-attachments/assets/ab143573-8233-4157-8494-585d729576b5)


I will also run this through various vendor testing scenarios to confirm.

# Context

There are language modes, which constrain powershell language features, and then execution policies, which constrain running scripts in general. I have had to set flags to enable running scripts by default from a powershell terminal, but there is no documentation indicating anything but that the language mode default is full language, or unrestricted. I also tried a sandbox and it was Full by default. 

'FullLanguage is the default language mode for default sessions on all versions of Windows.'
 https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7.4&viewFallbackFrom=powershell-7.3#:~:text=The%20FullLanguage%20mode%20permits%20all%20language%20elements%20in%20the%20session.%20FullLanguage%20is%20the%20default%20language%20mode%20for%20default%20sessions%20on%20all%20versions%20of%20Windows.

What causes our error to trigger is not `Get-ExecutionPolicy` but `ExecutionContext.SessionState.LanguageMode`.

We should try to set the execution policy to `bypass` instead of `restricted` in our code as it prompts a dialogue for permission by default on unrestricted which could be the cause of unknown failures/timeouts, which is an awesome insight from @jacdavis. Even if the script is signed. 
Sadly this option does not seem to exist to bypass language mode like how you can for 1 script via execution policy.

The error that spawned this issue triggers by checking the language mode:
```
Your machine policy ConstrainedLanguage disables PowerShell language features that may be needed to install .NET. Read more at: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7.3. If you cannot safely and confidently change the execution policy, try setting a custom existingDotnetPath following our instructions here: https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md.
```
There is code I wrote that just fails it if ExecutionContext.SessionState.LanguageMode is set to ConstrainedLanguage or NoLanguage.
https://github.com/dotnet/vscode-dotnet-runtime/blob/ef5299b38ed9f5e18bfd56d8f54d0b28961630fd/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts#L195

I dont think those 2 to 4 daily people you see with that error are going to go away. The code is failing on them because it sees their language mode is restricted which is not by default and is set by a SysAdmin. If the install script team knows if we can run the script in a way with a constrained language mode, then we could do that, but that sounds impossible.
