### PR TITLE
Permit Invalid Symlink Folders to Work as Custom Path Setting

### DIFF
--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -8,7 +8,8 @@ import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
 import * as vscode from 'vscode';
-import {
+import
+{
   FileUtilities,
   IDotnetAcquireContext,
   IDotnetAcquireResult,
@@ -34,16 +35,18 @@ import {
   getPathSeparator,
   LinuxVersionResolver,
   getMockUtilityContext,
+  DotnetPathFinder,
+  DotnetConditionValidator,
 } from 'vscode-dotnet-runtime-library';
 import * as extension from '../../extension';
 import { warn } from 'console';
 import { InstallTrackerSingleton } from 'vscode-dotnet-runtime-library/dist/Acquisition/InstallTrackerSingleton';
 
-const assert : any = chai.assert;
+const assert: any = chai.assert;
 const standardTimeoutTime = 40000;
 const originalPATH = process.env.PATH;
 
-suite('DotnetCoreAcquisitionExtension End to End', function()
+suite('DotnetCoreAcquisitionExtension End to End', function ()
 {
   this.retries(1);
   const storagePath = path.join(__dirname, 'tmp');
@@ -56,10 +59,10 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
   const environmentVariableCollection = new MockEnvironmentVariableCollection();
 
   const existingPathVersionToFake = '5.0.2~x64'
-  const pathWithIncorrectVersionForTest = path.join(__dirname, `/.dotnet/${existingPathVersionToFake}/dotnet`);
+  const pathWithIncorrectVersionForTest = path.join(__dirname, `/.dotnet/${existingPathVersionToFake}/${getDotnetExecutable()}`);
 
   const mockExistingPathsWithGlobalConfig: IExistingPaths = {
-    individualizedExtensionPaths: [{extensionId: 'alternative.extension', path: pathWithIncorrectVersionForTest}],
+    individualizedExtensionPaths: [{ extensionId: 'alternative.extension', path: pathWithIncorrectVersionForTest }],
     sharedExistingPath: undefined
   }
 
@@ -85,7 +88,8 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
       ]
   }`;
 
-  this.beforeAll(async () => {
+  this.beforeAll(async () =>
+  {
     extensionContext = {
       subscriptions: [],
       globalStoragePath: storagePath,
@@ -104,7 +108,8 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     });
   });
 
-  this.afterEach(async () => {
+  this.afterEach(async () =>
+  {
     // Tear down tmp storage for fresh run
     process.env.PATH = originalPATH;
 
@@ -115,18 +120,19 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     InstallTrackerSingleton.getInstance(new MockEventStream(), new MockExtensionContext()).clearPromises();
   }).timeout(standardTimeoutTime);
 
-  test('Activate', async () => {
+  test('Activate', async () =>
+  {
     // Commands should now be registered
     assert.exists(extensionContext);
     assert.isAbove(extensionContext.subscriptions.length, 0);
   }).timeout(standardTimeoutTime);
 
-  async function installRuntime(dotnetVersion : string, installMode : DotnetInstallMode, arch? : string)
+  async function installRuntime(dotnetVersion: string, installMode: DotnetInstallMode, arch?: string)
   {
     let context: IDotnetAcquireContext = { version: dotnetVersion, requestingExtensionId, mode: installMode };
-    if(arch)
+    if (arch)
     {
-        context.architecture = arch;
+      context.architecture = arch;
     }
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
     assert.exists(result, 'Command results a result');
@@ -138,25 +144,28 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
   }
 
 
-  async function installMultipleVersions(versions : string[], installMode : DotnetInstallMode)
+  async function installMultipleVersions(versions: string[], installMode: DotnetInstallMode)
   {
     let dotnetPaths: string[] = [];
-    for (const version of versions) {
+    for (const version of versions)
+    {
       const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', { version, requestingExtensionId, mode: installMode });
       assert.exists(result, 'acquire command returned a result/success');
       assert.exists(result!.dotnetPath, 'the result has a path');
       assert.include(result!.dotnetPath, version, 'the path includes the version');
-      if (result!.dotnetPath) {
+      if (result!.dotnetPath)
+      {
         dotnetPaths = dotnetPaths.concat(result!.dotnetPath);
       }
     }
     // All versions are still there after all installs are completed
-    for (const dotnetPath of dotnetPaths) {
+    for (const dotnetPath of dotnetPaths)
+    {
       assert.isTrue(fs.existsSync(dotnetPath));
     }
   }
 
-  async function installUninstallOne(dotnetVersion : string, versionToKeep : string, installMode : DotnetInstallMode, type : DotnetInstallType)
+  async function installUninstallOne(dotnetVersion: string, versionToKeep: string, installMode: DotnetInstallMode, type: DotnetInstallType)
   {
     const context: IDotnetAcquireContext = { version: dotnetVersion, requestingExtensionId, mode: installMode, installType: type };
     const contextToKeep: IDotnetAcquireContext = { version: versionToKeep, requestingExtensionId, mode: installMode, installType: type };
@@ -172,7 +181,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.isTrue(fs.existsSync(resultToKeep!.dotnetPath), 'Only one thing is uninstalled.');
   }
 
-  async function installUninstallAll(dotnetVersion : string, installMode : DotnetInstallMode)
+  async function installUninstallAll(dotnetVersion: string, installMode: DotnetInstallMode)
   {
     const context: IDotnetAcquireContext = { version: dotnetVersion, requestingExtensionId, mode: installMode };
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
@@ -184,7 +193,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.isFalse(fs.existsSync(result!.dotnetPath), 'the dotnet path result does not exist after uninstall');
   }
 
-  async function uninstallWithMultipleOwners(dotnetVersion : string, installMode : DotnetInstallMode, type : DotnetInstallType)
+  async function uninstallWithMultipleOwners(dotnetVersion: string, installMode: DotnetInstallMode, type: DotnetInstallType)
   {
     const context: IDotnetAcquireContext = { version: dotnetVersion, requestingExtensionId, mode: installMode, installType: type };
     const contextFromOtherId: IDotnetAcquireContext = { version: dotnetVersion, requestingExtensionId: 'fake.extension.two', mode: installMode, installType: type };
@@ -203,59 +212,61 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.isFalse(fs.existsSync(result!.dotnetPath), 'the dotnet path result does not exist after uninstalling from all owners');
   }
 
-  function includesPathWithLikelyDotnet(pathToCheck : string) : boolean
+  function includesPathWithLikelyDotnet(pathToCheck: string): boolean
   {
     const lowerPath = pathToCheck.toLowerCase();
     return lowerPath.includes('dotnet') || lowerPath.includes('program') || lowerPath.includes('share') || lowerPath.includes('bin') || lowerPath.includes('snap') || lowerPath.includes('homebrew');
   }
 
-  async function findPathWithRequirementAndInstall(version : string, iMode : DotnetInstallMode, arch : string, condition : DotnetVersionSpecRequirement, shouldFind : boolean, contextToLookFor? : IDotnetAcquireContext, setPath = true,
+  async function findPathWithRequirementAndInstall(version: string, iMode: DotnetInstallMode, arch: string, condition: DotnetVersionSpecRequirement, shouldFind: boolean, contextToLookFor?: IDotnetAcquireContext, setPath = true,
     blockNoArch = false, dontCheckNonPaths = true)
   {
     const installPath = await installRuntime(version, iMode, arch);
 
     // use path.dirname : the dotnet.exe cant be on the PATH
-    if(setPath)
+    if (setPath)
     {
-        process.env.PATH = `${path.dirname(installPath)}${getPathSeparator()}${process.env.PATH?.split(getPathSeparator()).filter((x : string) => !(includesPathWithLikelyDotnet(x))).join(getPathSeparator())}`;
+      process.env.PATH = `${path.dirname(installPath)}${getPathSeparator()}${process.env.PATH?.split(getPathSeparator()).filter((x: string) => !(includesPathWithLikelyDotnet(x))).join(getPathSeparator())}`;
     }
     else
     {
-        // remove dotnet so the test will work on machines with dotnet installed
-        process.env.PATH = `${process.env.PATH?.split(getPathSeparator()).filter((x : string) => !(includesPathWithLikelyDotnet(x))).join(getPathSeparator())}`;
-        process.env.DOTNET_ROOT = path.dirname(installPath);
+      // remove dotnet so the test will work on machines with dotnet installed
+      process.env.PATH = `${process.env.PATH?.split(getPathSeparator()).filter((x: string) => !(includesPathWithLikelyDotnet(x))).join(getPathSeparator())}`;
+      process.env.DOTNET_ROOT = path.dirname(installPath);
     }
 
     extensionContext.environmentVariableCollection.replace('PATH', process.env.PATH ?? '');
 
-    if(blockNoArch)
+    if (blockNoArch)
     {
-        extensionContext.environmentVariableCollection.replace('DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH', '1');
-        process.env.DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH = '1';
+      extensionContext.environmentVariableCollection.replace('DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH', '1');
+      process.env.DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH = '1';
     }
 
-    if(dontCheckNonPaths)
+    if (dontCheckNonPaths)
     {
-        process.env.DOTNET_INSTALL_TOOL_SKIP_HOSTFXR = 'true';
+      process.env.DOTNET_INSTALL_TOOL_SKIP_HOSTFXR = 'true';
     }
 
-    const result : IDotnetAcquireResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath',
-        { acquireContext : contextToLookFor ?? { version, requestingExtensionId : requestingExtensionId, mode: iMode, architecture : arch } as IDotnetAcquireContext,
-        versionSpecRequirement : condition} as IDotnetFindPathContext
+    const result: IDotnetAcquireResult = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath',
+      {
+        acquireContext: contextToLookFor ?? { version, requestingExtensionId: requestingExtensionId, mode: iMode, architecture: arch } as IDotnetAcquireContext,
+        versionSpecRequirement: condition
+      } as IDotnetFindPathContext
     );
 
     extensionContext.environmentVariableCollection.replace('DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH', '0');
     process.env.DOTNET_INSTALL_TOOL_DONT_ACCEPT_UNKNOWN_ARCH = '0';
     process.env.DOTNET_INSTALL_TOOL_SKIP_HOSTFXR = '0';
 
-    if(shouldFind)
+    if (shouldFind)
     {
-        assert.exists(result.dotnetPath, 'find path command returned a result');
-        assert.equal(result.dotnetPath.toLowerCase(), installPath.toLowerCase(), 'The path returned by findPath is correct');
+      assert.exists(result.dotnetPath, 'find path command returned a result');
+      assert.equal(result.dotnetPath.toLowerCase(), installPath.toLowerCase(), 'The path returned by findPath is correct');
     }
     else
     {
-        assert.equal(result?.dotnetPath, undefined, 'find path command returned no undefined if no path matches condition');
+      assert.equal(result?.dotnetPath, undefined, 'find path command returned no undefined if no path matches condition');
     }
   }
 
@@ -269,147 +280,166 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     await installRuntime('7.0', 'aspnetcore');
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall One Local Runtime Command', async () => {
+  test('Uninstall One Local Runtime Command', async () =>
+  {
     await installUninstallOne('2.2', '7.0', 'runtime', 'local');
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall One Local ASP.NET Runtime Command', async () => {
+  test('Uninstall One Local ASP.NET Runtime Command', async () =>
+  {
     await installUninstallOne('2.2', '6.0', 'aspnetcore', 'local');
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall All Local Runtime Command', async () => {
+  test('Uninstall All Local Runtime Command', async () =>
+  {
     await installUninstallAll('2.2', 'runtime')
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall All Local ASP.NET Runtime Command', async () => {
+  test('Uninstall All Local ASP.NET Runtime Command', async () =>
+  {
     await installUninstallAll('2.2', 'aspnetcore')
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall Runtime Only Once No Owners Exist', async () => {
+  test('Uninstall Runtime Only Once No Owners Exist', async () =>
+  {
     await uninstallWithMultipleOwners('8.0', 'runtime', 'local');
   }).timeout(standardTimeoutTime);
 
-  test('Uninstall ASP.NET Runtime Only Once No Owners Exist', async () => {
+  test('Uninstall ASP.NET Runtime Only Once No Owners Exist', async () =>
+  {
     await uninstallWithMultipleOwners('8.0', 'aspnetcore', 'local');
   }).timeout(standardTimeoutTime);
 
-  test('Install and Uninstall Multiple Local Runtime Versions', async () => {
+  test('Install and Uninstall Multiple Local Runtime Versions', async () =>
+  {
     await installMultipleVersions(['2.2', '3.0', '3.1'], 'runtime');
   }).timeout(standardTimeoutTime * 2);
 
-  test('Install and Uninstall Multiple Local ASP.NET Runtime Versions', async () => {
+  test('Install and Uninstall Multiple Local ASP.NET Runtime Versions', async () =>
+  {
     await installMultipleVersions(['2.2', '3.0', '3.1'], 'aspnetcore');
   }).timeout(standardTimeoutTime * 2);
 
-  test('Find dotnet PATH Command Met Condition', async () => {
+  test('Find dotnet PATH Command Met Condition', async () =>
+  {
     // install 5.0 then look for 5.0 path
     await findPathWithRequirementAndInstall('5.0', 'runtime', os.arch(), 'greater_than_or_equal', true);
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Met ROOT Condition', async () => {
+  test('Find dotnet PATH Command Met ROOT Condition', async () =>
+  {
     // install 7.0, set dotnet_root and not path, then look for root
     const oldROOT = process.env.DOTNET_ROOT;
 
     await findPathWithRequirementAndInstall('7.0', 'runtime', os.arch(), 'equal', true,
-        {version : '7.0', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}, false
+      { version: '7.0', mode: 'runtime', architecture: os.arch(), requestingExtensionId: requestingExtensionId }, false
     );
 
-    if(EnvironmentVariableIsDefined(oldROOT))
+    if (EnvironmentVariableIsDefined(oldROOT))
     {
-        process.env.DOTNET_ROOT = oldROOT;
+      process.env.DOTNET_ROOT = oldROOT;
     }
     else
     {
-        delete process.env.DOTNET_ROOT;
+      delete process.env.DOTNET_ROOT;
     }
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Met Version Condition', async () => {
+  test('Find dotnet PATH Command Met Version Condition', async () =>
+  {
     // Install 8.0, look for 3.1 with accepting dotnet gr than or eq to 3.1
 
     await findPathWithRequirementAndInstall('8.0', 'runtime', os.arch(), 'greater_than_or_equal', true,
-        {version : '3.1', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
+      { version: '3.1', mode: 'runtime', architecture: os.arch(), requestingExtensionId: requestingExtensionId }
     );
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Met Version Condition with Double Digit Major', async () => {
+  test('Find dotnet PATH Command Met Version Condition with Double Digit Major', async () =>
+  {
     await findPathWithRequirementAndInstall('9.0', 'runtime', os.arch(), 'less_than_or_equal', true,
-        {version : '11.0', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
+      { version: '11.0', mode: 'runtime', architecture: os.arch(), requestingExtensionId: requestingExtensionId }
     );
   }).timeout(standardTimeoutTime);
 
 
-  test('Find dotnet PATH Command Unmet Version Condition', async () => {
+  test('Find dotnet PATH Command Unmet Version Condition', async () =>
+  {
     // Install 9.0, look for 90.0 which is not equal to 9.0
     await findPathWithRequirementAndInstall('9.0', 'runtime', os.arch(), 'equal', false,
-        {version : '90.0', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
+      { version: '90.0', mode: 'runtime', architecture: os.arch(), requestingExtensionId: requestingExtensionId }
     );
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Unmet Mode Condition', async () => {
+  test('Find dotnet PATH Command Unmet Mode Condition', async () =>
+  {
     // look for 3.1 runtime but install 3.1 aspnetcore
     await findPathWithRequirementAndInstall('3.1', 'runtime', os.arch(), 'equal', false,
-        {version : '3.1', mode : 'aspnetcore', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
+      { version: '3.1', mode: 'aspnetcore', architecture: os.arch(), requestingExtensionId: requestingExtensionId }
     );
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Unmet Arch Condition', async () => {
+  test('Find dotnet PATH Command Unmet Arch Condition', async () =>
+  {
     // look for a different architecture of 3.1
-    if(os.platform() !== 'darwin')
+    if (os.platform() !== 'darwin')
     {
-        // The CI Machines are running on ARM64 for OS X.
-        // They also have an x64 HOST. We can't set DOTNET_MULTILEVEL_LOOKUP to 0 because it will break the ability to find the host on --info
-        // As a 3.1 runtime host does not provide the architecture, but we try to use 3.1 because CI machines won't have it.
-        //
-        await findPathWithRequirementAndInstall('3.1', 'runtime', os.arch() == 'arm64' ? 'x64' : os.arch(), 'greater_than_or_equal', false,
-            {version : '3.1', mode : 'runtime', architecture : 'arm64', requestingExtensionId : requestingExtensionId}, true, true
-        );
+      // The CI Machines are running on ARM64 for OS X.
+      // They also have an x64 HOST. We can't set DOTNET_MULTILEVEL_LOOKUP to 0 because it will break the ability to find the host on --info
+      // As a 3.1 runtime host does not provide the architecture, but we try to use 3.1 because CI machines won't have it.
+      //
+      await findPathWithRequirementAndInstall('3.1', 'runtime', os.arch() == 'arm64' ? 'x64' : os.arch(), 'greater_than_or_equal', false,
+        { version: '3.1', mode: 'runtime', architecture: 'arm64', requestingExtensionId: requestingExtensionId }, true, true
+      );
     }
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Unmet Arch Condition With Host that prints Arch', async () => {
-    if(os.platform() !== 'darwin')
+  test('Find dotnet PATH Command Unmet Arch Condition With Host that prints Arch', async () =>
+  {
+    if (os.platform() !== 'darwin')
     {
-        await findPathWithRequirementAndInstall('9.0', 'runtime', os.arch() == 'arm64' ? 'x64' : os.arch(), 'greater_than_or_equal', false,
-            {version : '9.0', mode : 'runtime', architecture : 'arm64', requestingExtensionId : requestingExtensionId}
-        );
+      await findPathWithRequirementAndInstall('9.0', 'runtime', os.arch() == 'arm64' ? 'x64' : os.arch(), 'greater_than_or_equal', false,
+        { version: '9.0', mode: 'runtime', architecture: 'arm64', requestingExtensionId: requestingExtensionId }
+      );
     }
   }).timeout(standardTimeoutTime);
 
 
-  test('Find dotnet PATH Command No Arch Available But Accept By Default', async () => {
+  test('Find dotnet PATH Command No Arch Available But Accept By Default', async () =>
+  {
     // look for a different architecture of 3.1
-    if(os.platform() !== 'darwin')
+    if (os.platform() !== 'darwin')
     {
-        await findPathWithRequirementAndInstall('3.1', 'runtime', os.arch() == 'arm64' ? 'x64' : os.arch(), 'greater_than_or_equal', true,
-            {version : '3.1', mode : 'runtime', architecture : 'arm64', requestingExtensionId : requestingExtensionId}
-        );
+      await findPathWithRequirementAndInstall('3.1', 'runtime', os.arch() == 'arm64' ? 'x64' : os.arch(), 'greater_than_or_equal', true,
+        { version: '3.1', mode: 'runtime', architecture: 'arm64', requestingExtensionId: requestingExtensionId }
+      );
     }
   }).timeout(standardTimeoutTime);
 
-  test('Find dotnet PATH Command Unmet Runtime Patch Condition', async () => {
+  test('Find dotnet PATH Command Unmet Runtime Patch Condition', async () =>
+  {
     // Install 8.0.{LATEST, which will be < 99}, look for 8.0.99 with accepting dotnet gr than or eq to 8.0.99
     // No tests for SDK since that's harder to replicate with a global install and different machine states
-    if(os.platform() !== 'darwin')
+    if (os.platform() !== 'darwin')
     {
-        await findPathWithRequirementAndInstall('8.0', 'runtime', os.arch(), 'greater_than_or_equal', false,
-            {version : '8.0.99', mode : 'runtime', architecture : os.arch(), requestingExtensionId : requestingExtensionId}
-        );
+      await findPathWithRequirementAndInstall('8.0', 'runtime', os.arch(), 'greater_than_or_equal', false,
+        { version: '8.0.99', mode: 'runtime', architecture: os.arch(), requestingExtensionId: requestingExtensionId }
+      );
     }
   }).timeout(standardTimeoutTime);
 
-  test('Install SDK Globally E2E (Requires Admin)', async () => {
+  test('Install SDK Globally E2E (Requires Admin)', async () =>
+  {
     // We only test if the process is running under ADMIN because non-admin requires user-intervention.
-    if(new FileUtilities().isElevated())
+    if (new FileUtilities().isElevated())
     {
       const originalPath = process.env.PATH;
       const sdkVersion = '7.0.103';
-      const context : IDotnetAcquireContext = { version: sdkVersion, requestingExtensionId: 'sample-extension', installType: 'global' };
+      const context: IDotnetAcquireContext = { version: sdkVersion, requestingExtensionId: 'sample-extension', installType: 'global' };
 
       // We cannot use the describe pattern to restore the environment variables using vscode's extension testing infrastructure.
       // So we must set and unset it ourselves, which isn't ideal as this variable could remain.
-      let result : IDotnetAcquireResult;
-      let error : any;
+      let result: IDotnetAcquireResult;
+      let error: any;
       let pathAfterInstall;
 
       // We cannot test much as we don't want to leave global installs on dev boxes. But we do want to make sure the e-2-e goes through the right path. Vendors can test the rest.
@@ -419,7 +449,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
       {
         result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquireGlobalSDK', context);
       }
-      catch(err)
+      catch (err)
       {
         error = err;
       }
@@ -429,9 +459,9 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
         process.env.VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH = undefined;
         process.env.PATH = originalPath;
 
-        if(error)
+        if (error)
         {
-          throw(new Error(`The test failed to run the acquire command successfully. Error: ${error}`));
+          throw (new Error(`The test failed to run the acquire command successfully. Error: ${error}`));
         }
       }
 
@@ -447,10 +477,11 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
       // And we wouldn't be able to kill the process so the test would leave a lot of hanging processes on the machine
       warn('The Global SDK E2E Install test cannot run as the machine is unprivileged.');
     }
-  }).timeout(standardTimeoutTime*1000);
+  }).timeout(standardTimeoutTime * 1000);
 
-  test('Telemetry Sent During Install and Uninstall', async () => {
-    if(!vscode.env.isTelemetryEnabled)
+  test('Telemetry Sent During Install and Uninstall', async () =>
+  {
+    if (!vscode.env.isTelemetryEnabled)
     {
       console.warn('The telemetry test cannot run as VS Code Telemetry is disabled in user settings.');
       return;
@@ -493,24 +524,28 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.isEmpty(errors, `No error events were reported in telemetry reporting. ${JSON.stringify(errors)}`);
   }).timeout(standardTimeoutTime);
 
-  test('Telemetry Sent on Error', async () => {
-    if(!vscode.env.isTelemetryEnabled)
+  test('Telemetry Sent on Error', async () =>
+  {
+    if (!vscode.env.isTelemetryEnabled)
     {
       console.warn('The telemetry test cannot run as VS Code Telemetry is disabled in user settings.');
       return;
     }
 
     const context: IDotnetAcquireContext = { version: 'foo', requestingExtensionId };
-    try {
+    try
+    {
       await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
       assert.isTrue(false); // An error should have been thrown
-    } catch (error) {
+    } catch (error)
+    {
       const versionError = MockTelemetryReporter.telemetryEvents.find((event: ITelemetryEvent) => event.eventName === '[ERROR]:DotnetVersionResolutionError');
       assert.exists(versionError, 'The version resolution error appears in telemetry');
     }
-  }).timeout(standardTimeoutTime/2);
+  }).timeout(standardTimeoutTime / 2);
 
-  test('Install Local Runtime Command Passes With Warning With No RequestingExtensionId', async () => {
+  test('Install Local Runtime Command Passes With Warning With No RequestingExtensionId', async () =>
+  {
     const context: IDotnetAcquireContext = { version: '3.1' };
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
     assert.exists(result, 'A result from the API exists');
@@ -519,7 +554,8 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.include(mockDisplayWorker.warningMessage, 'Ignoring existing .NET paths');
   }).timeout(standardTimeoutTime);
 
-  test('Install Local Runtime Command With Path Setting', async () => {
+  test('Install Local Runtime Command With Path Setting', async () =>
+  {
     const context: IDotnetAcquireContext = { version: '5.0', requestingExtensionId: 'alternative.extension', architecture: os.platform() };
     const resultForAcquiringPathSettingRuntime = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
     assert.exists(resultForAcquiringPathSettingRuntime!.dotnetPath, 'Basic acquire works');
@@ -528,11 +564,12 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     // so that we can tell the setting was used. We cant tell it to install an older  besides latest,
     // but we can rename the folder then re-acquire for latest and see that it uses the existing 'older' runtime path
     assert.notEqual(path.dirname(resultForAcquiringPathSettingRuntime.dotnetPath), path.dirname(pathWithIncorrectVersionForTest), 'Test setup: path setting is different from the real path');
-    fs.cpSync(path.dirname(resultForAcquiringPathSettingRuntime.dotnetPath), path.dirname(pathWithIncorrectVersionForTest), {recursive: true});
+    fs.cpSync(path.dirname(resultForAcquiringPathSettingRuntime.dotnetPath), path.dirname(pathWithIncorrectVersionForTest), { recursive: true });
     assert.isTrue(fs.existsSync(path.dirname(pathWithIncorrectVersionForTest)), 'The copy of the real dotnet to the new wrong-versioned path succeeded');
 
     fs.rmSync(resultForAcquiringPathSettingRuntime.dotnetPath);
     assert.isTrue(!fs.existsSync(resultForAcquiringPathSettingRuntime.dotnetPath), 'The deletion of the real path succeeded');
+    assert.isTrue(fs.existsSync(path.dirname(pathWithIncorrectVersionForTest)), 'The copy of the real dotnet to the new wrong-versioned path was not deleted');
 
     const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquire', context);
 
@@ -540,14 +577,15 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     assert.exists(result!.dotnetPath, 'path setting has a path');
     assert.equal(result!.dotnetPath, pathWithIncorrectVersionForTest, 'path setting is used'); // this is set for the alternative.extension in the settings
 
-    const findPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, {mode: 'runtime'}), versionSpecRequirement: 'equal' });
+    const findPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, { mode: 'runtime' }), versionSpecRequirement: 'equal' });
     assert.equal(findPath!.dotnetPath, pathWithIncorrectVersionForTest, 'findPath uses vscode setting for runtime'); // this is set for the alternative.extension in the settings
 
-    const findSDKPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, {mode: 'sdk'}), versionSpecRequirement: 'equal' });
+    const findSDKPath = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', { acquireContext: Object.assign({}, context, { mode: 'sdk' }), versionSpecRequirement: 'equal' });
     assert.equal(findSDKPath?.dotnetPath ?? undefined, undefined, 'findPath does not find path setting for the SDK');
   }).timeout(standardTimeoutTime);
 
-  test('List Sdks & Runtimes', async () => {
+  test('List Sdks & Runtimes', async () =>
+  {
     const mockAcquisitionContext = getMockAcquisitionContext('sdk', '');
     const webWorker = new MockWebRequestWorker(mockAcquisitionContext, '');
     webWorker.response = JSON.parse(mockReleasesData);
@@ -557,26 +595,27 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     const result = await vscode.commands.executeCommand<IDotnetListVersionsResult>('dotnet.listVersions', apiContext, webWorker);
     assert.exists(result);
     assert.equal(result?.length, 2, `It can find both versions of the SDKs. Found: ${result}`);
-    assert.equal(result?.filter((sdk : any) => sdk.version === '7.0.202').length, 1, 'The mock SDK with the expected version {7.0.200} was not found by the API parsing service.');
-    assert.equal(result?.filter((sdk : any) => sdk.channelVersion === '7.0').length, 1, 'The mock SDK with the expected channel version {7.0} was not found by the API parsing service.');
-    assert.equal(result?.filter((sdk : any) => sdk.supportPhase === 'active').length, 1, 'The mock SDK with the expected support phase of {active} was not found by the API parsing service.');
+    assert.equal(result?.filter((sdk: any) => sdk.version === '7.0.202').length, 1, 'The mock SDK with the expected version {7.0.200} was not found by the API parsing service.');
+    assert.equal(result?.filter((sdk: any) => sdk.channelVersion === '7.0').length, 1, 'The mock SDK with the expected channel version {7.0} was not found by the API parsing service.');
+    assert.equal(result?.filter((sdk: any) => sdk.supportPhase === 'active').length, 1, 'The mock SDK with the expected support phase of {active} was not found by the API parsing service.');
 
     // The API can find the available runtimes and their versions.
     apiContext.listRuntimes = true;
     const runtimeResult = await vscode.commands.executeCommand<IDotnetListVersionsResult>('dotnet.listVersions', apiContext, webWorker);
     assert.exists(runtimeResult);
-    assert.equal(runtimeResult?.length, 2,  `It can find both versions of the runtime. Found: ${result}`);
-    assert.equal(runtimeResult?.filter((runtime : any) => runtime.version === '7.0.4').length, 1, 'The mock Runtime with the expected version was not found by the API parsing service.');
+    assert.equal(runtimeResult?.length, 2, `It can find both versions of the runtime. Found: ${result}`);
+    assert.equal(runtimeResult?.filter((runtime: any) => runtime.version === '7.0.4').length, 1, 'The mock Runtime with the expected version was not found by the API parsing service.');
   }).timeout(standardTimeoutTime);
 
-  test('Get Recommended SDK Version', async () => {
+  test('Get Recommended SDK Version', async () =>
+  {
     const mockAcquisitionContext = getMockAcquisitionContext('sdk', '');
     const webWorker = new MockWebRequestWorker(mockAcquisitionContext, '');
     webWorker.response = JSON.parse(mockReleasesData);
 
     const result = await vscode.commands.executeCommand<IDotnetListVersionsResult>('dotnet.recommendedVersion', null, webWorker);
     assert.exists(result);
-    if(os.platform() !== 'linux')
+    if (os.platform() !== 'linux')
     {
       assert.equal(result[0].version, '7.0.202', 'The SDK did not recommend the version it was supposed to, which should be {7.0.200} from the mock data.');
     }
@@ -587,7 +626,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
     }
   }).timeout(standardTimeoutTime);
 
-  async function testAcquire(installMode : DotnetInstallMode)
+  async function testAcquire(installMode: DotnetInstallMode)
   {
     // Runtime is not yet installed
     const context: IDotnetAcquireContext = { version: '3.1', requestingExtensionId, mode: installMode };
@@ -620,8 +659,8 @@ suite('DotnetCoreAcquisitionExtension End to End', function()
 
   test('acquireStatus does respect Mode', async () =>
   {
-    const runtimeContext : IDotnetAcquireContext = { version: '5.0', requestingExtensionId, mode: 'runtime' };
-    const aspNetContext : IDotnetAcquireContext =  { version: '5.0', requestingExtensionId, mode: 'aspnetcore' };
+    const runtimeContext: IDotnetAcquireContext = { version: '5.0', requestingExtensionId, mode: 'runtime' };
+    const aspNetContext: IDotnetAcquireContext = { version: '5.0', requestingExtensionId, mode: 'aspnetcore' };
 
     let result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.acquireStatus', runtimeContext);
     assert.notExists(result);

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -16,23 +16,23 @@ import { realpathSync, existsSync, readFileSync } from 'fs';
 import { EnvironmentVariableIsDefined, getDotnetExecutable, getOSArch, getPathSeparator } from '../Utils/TypescriptUtilities';
 import { DotnetConditionValidator } from './DotnetConditionValidator';
 import
-    {
-        DotnetFindPathHostFxrResolutionLookup,
-        DotnetFindPathLookupPATH,
-        DotnetFindPathLookupRealPATH,
-        DotnetFindPathLookupRootPATH,
-        DotnetFindPathNoHostOnFileSystem,
-        DotnetFindPathNoHostOnRegistry,
-        DotnetFindPathNoRuntimesOnHost,
-        DotnetFindPathOnFileSystem,
-        DotnetFindPathOnRegistry,
-        DotnetFindPathPATHFound,
-        DotnetFindPathRealPATHFound,
-        DotnetFindPathRootEmulationPATHFound,
-        DotnetFindPathRootPATHFound,
-        DotnetFindPathRootUnderEmulationButNoneSet,
-        FileDoesNotExist
-    } from '../EventStream/EventStreamEvents';
+{
+    DotnetFindPathHostFxrResolutionLookup,
+    DotnetFindPathLookupPATH,
+    DotnetFindPathLookupRealPATH,
+    DotnetFindPathLookupRootPATH,
+    DotnetFindPathNoHostOnFileSystem,
+    DotnetFindPathNoHostOnRegistry,
+    DotnetFindPathNoRuntimesOnHost,
+    DotnetFindPathOnFileSystem,
+    DotnetFindPathOnRegistry,
+    DotnetFindPathPATHFound,
+    DotnetFindPathRealPATHFound,
+    DotnetFindPathRootEmulationPATHFound,
+    DotnetFindPathRootPATHFound,
+    DotnetFindPathRootUnderEmulationButNoneSet,
+    FileDoesNotExist
+} from '../EventStream/EventStreamEvents';
 import { RegistryReader } from './RegistryReader';
 import { FileUtilities } from '../Utils/FileUtilities';
 import { IFileUtilities } from '../Utils/IFileUtilities';
@@ -295,6 +295,7 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
 
         for (const tentativePath of tentativePaths)
         {
+            // This will even work if only the sdk is installed, list-runtimes on an sdk installed host would work
             const runtimeInfo = await new DotnetConditionValidator(this.workerContext, this.utilityContext, this.executor).getRuntimes(tentativePath);
             if (runtimeInfo.length > 0)
             {

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -15,23 +15,24 @@ import * as lodash from 'lodash';
 import { realpathSync, existsSync, readFileSync } from 'fs';
 import { EnvironmentVariableIsDefined, getDotnetExecutable, getOSArch, getPathSeparator } from '../Utils/TypescriptUtilities';
 import { DotnetConditionValidator } from './DotnetConditionValidator';
-import {
-    DotnetFindPathHostFxrResolutionLookup,
-    DotnetFindPathLookupPATH,
-    DotnetFindPathLookupRealPATH,
-    DotnetFindPathLookupRootPATH,
-    DotnetFindPathNoHostOnFileSystem,
-    DotnetFindPathNoHostOnRegistry,
-    DotnetFindPathNoRuntimesOnHost,
-    DotnetFindPathOnFileSystem,
-    DotnetFindPathOnRegistry,
-    DotnetFindPathPATHFound,
-    DotnetFindPathRealPATHFound,
-    DotnetFindPathRootEmulationPATHFound,
-    DotnetFindPathRootPATHFound,
-    DotnetFindPathRootUnderEmulationButNoneSet,
-    FileDoesNotExist
-} from '../EventStream/EventStreamEvents';
+import
+    {
+        DotnetFindPathHostFxrResolutionLookup,
+        DotnetFindPathLookupPATH,
+        DotnetFindPathLookupRealPATH,
+        DotnetFindPathLookupRootPATH,
+        DotnetFindPathNoHostOnFileSystem,
+        DotnetFindPathNoHostOnRegistry,
+        DotnetFindPathNoRuntimesOnHost,
+        DotnetFindPathOnFileSystem,
+        DotnetFindPathOnRegistry,
+        DotnetFindPathPATHFound,
+        DotnetFindPathRealPATHFound,
+        DotnetFindPathRootEmulationPATHFound,
+        DotnetFindPathRootPATHFound,
+        DotnetFindPathRootUnderEmulationButNoneSet,
+        FileDoesNotExist
+    } from '../EventStream/EventStreamEvents';
 import { RegistryReader } from './RegistryReader';
 import { FileUtilities } from '../Utils/FileUtilities';
 import { IFileUtilities } from '../Utils/IFileUtilities';
@@ -39,7 +40,7 @@ import { IFileUtilities } from '../Utils/IFileUtilities';
 export class DotnetPathFinder implements IDotnetPathFinder
 {
 
-    public constructor(private readonly workerContext : IAcquisitionWorkerContext, private readonly utilityContext : IUtilityContext, private executor? : ICommandExecutor, private file? : IFileUtilities)
+    public constructor(private readonly workerContext: IAcquisitionWorkerContext, private readonly utilityContext: IUtilityContext, private executor?: ICommandExecutor, private file?: IFileUtilities)
     {
         this.executor ??= new CommandExecutor(this.workerContext, this.utilityContext);
         this.file ??= new FileUtilities();
@@ -59,14 +60,14 @@ export class DotnetPathFinder implements IDotnetPathFinder
      *
      * The VS Code Workspace environment may also be different from the System environment.
      */
-    public async findDotnetRootPath(requestedArchitecture : string) : Promise<string | undefined>
+    public async findDotnetRootPath(requestedArchitecture: string): Promise<string | undefined>
     {
         this.workerContext.eventStream.post(new DotnetFindPathLookupRootPATH(`Looking up .NET on the root.`));
 
-        if(requestedArchitecture === 'x64' && (this.executor !== undefined ? (await getOSArch(this.executor)).includes('arm') : false))
+        if (requestedArchitecture === 'x64' && (this.executor !== undefined ? (await getOSArch(this.executor)).includes('arm') : false))
         {
             let dotnetOnRootEmulationPath = process.env.DOTNET_ROOT_X64;
-            if(EnvironmentVariableIsDefined(dotnetOnRootEmulationPath))
+            if (EnvironmentVariableIsDefined(dotnetOnRootEmulationPath))
             {
                 // DOTNET_ROOT should be set to the directory containing the dotnet executable, not the executable itself.
                 // https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables
@@ -81,7 +82,7 @@ export class DotnetPathFinder implements IDotnetPathFinder
         }
 
         let dotnetOnRootPath = process.env.DOTNET_ROOT;
-        if(EnvironmentVariableIsDefined(dotnetOnRootPath))
+        if (EnvironmentVariableIsDefined(dotnetOnRootPath))
         {
             // DOTNET_ROOT should be set to the directory containing the dotnet executable, not the executable itself.
             dotnetOnRootPath = path.join(dotnetOnRootPath!, getDotnetExecutable());
@@ -101,26 +102,26 @@ export class DotnetPathFinder implements IDotnetPathFinder
      * In an install such as homebrew, the PATH is not indicative of all of the PATHs. So dotnet may be missing in the PATH even though it is found in an alternative shell.
      * The PATH can be discovered using path_helper on mac.
      */
-    public async findRawPathEnvironmentSetting(tryUseTrueShell = true) : Promise<string[] | undefined>
+    public async findRawPathEnvironmentSetting(tryUseTrueShell = true): Promise<string[] | undefined>
     {
         const oldLookup = process.env.DOTNET_MULTILEVEL_LOOKUP;
         process.env.DOTNET_MULTILEVEL_LOOKUP = '0'; // make it so --list-runtimes only finds the runtimes on that path: https://learn.microsoft.com/en-us/dotnet/core/compatibility/deployment/7.0/multilevel-lookup#reason-for-change
 
         const searchEnvironment = process.env; // this is the default, but sometimes it does not get picked up
-        const options = tryUseTrueShell && os.platform() !== 'win32' ? { env : searchEnvironment, shell: process.env.SHELL === '/bin/bash' ? '/bin/bash' : '/bin/sh'} : {env : searchEnvironment};
+        const options = tryUseTrueShell && os.platform() !== 'win32' ? { env: searchEnvironment, shell: process.env.SHELL === '/bin/bash' ? '/bin/bash' : '/bin/sh' } : { env: searchEnvironment };
 
         this.workerContext.eventStream.post(new DotnetFindPathLookupPATH(`Looking up .NET on the path. Process.env.path: ${process.env.PATH}.
 Executor Path: ${(await this.executor?.execute(
-    os.platform() === 'win32' ? CommandExecutor.makeCommand('echo', ['%PATH%']) : CommandExecutor.makeCommand('env', []),
-    undefined,
-    false))?.stdout}
+            os.platform() === 'win32' ? CommandExecutor.makeCommand('echo', ['%PATH%']) : CommandExecutor.makeCommand('env', []),
+            undefined,
+            false))?.stdout}
 
-Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(CommandExecutor.makeCommand('env', ['bash']), {shell : '/bin/bash'}, false))?.stdout : 'N/A'}
+Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(CommandExecutor.makeCommand('env', ['bash']), { shell: '/bin/bash' }, false))?.stdout : 'N/A'}
 `
         ));
 
         let pathLocatorCommand = '';
-        if(os.platform() === 'win32')
+        if (os.platform() === 'win32')
         {
             pathLocatorCommand = (await this.executor?.tryFindWorkingCommand([
                 // We have to give the command an argument to return status 0, and the only thing its guaranteed to find is itself :)
@@ -140,7 +141,7 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
 
         const findCommand = CommandExecutor.makeCommand(pathLocatorCommand, ['dotnet']);
         const dotnetsOnPATH = (await this.executor?.execute(findCommand, options))?.stdout.split('\n').map(x => x.trim()).filter(x => x !== '');
-        if(dotnetsOnPATH && dotnetsOnPATH.length > 0)
+        if (dotnetsOnPATH && dotnetsOnPATH.length > 0)
         {
             this.workerContext.eventStream.post(new DotnetFindPathPATHFound(`Found .NET on the path: ${JSON.stringify(dotnetsOnPATH)}`));
             return this.returnWithRestoringEnvironment(await this.getTruePath(dotnetsOnPATH), 'DOTNET_MULTILEVEL_LOOKUP', oldLookup);
@@ -164,7 +165,7 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
                 }
             }
 
-            if(validPathsOnPATH.length > 0)
+            if (validPathsOnPATH.length > 0)
             {
                 return this.returnWithRestoringEnvironment(validPathsOnPATH, 'DOTNET_MULTILEVEL_LOOKUP', oldLookup);
             }
@@ -174,9 +175,9 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
-    private async returnWithRestoringEnvironment(returnValue : string[] | undefined, envVarToRestore : string, envResToRestore : string | undefined) : Promise<string[] | undefined>
+    private async returnWithRestoringEnvironment(returnValue: string[] | undefined, envVarToRestore: string, envResToRestore: string | undefined): Promise<string[] | undefined>
     {
-        if(EnvironmentVariableIsDefined(envVarToRestore))
+        if (EnvironmentVariableIsDefined(envVarToRestore))
         {
             process.env[envVarToRestore] = envResToRestore;
         }
@@ -194,11 +195,11 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
      *
      * We can't use realpath on all paths, because some paths are polymorphic executables and the realpath is invalid.
      */
-    public async findRealPathEnvironmentSetting(tryUseTrueShell = true) : Promise<string[] | undefined>
+    public async findRealPathEnvironmentSetting(tryUseTrueShell = true): Promise<string[] | undefined>
     {
         this.workerContext.eventStream.post(new DotnetFindPathLookupRealPATH(`Looking up .NET on the real path.`));
         const dotnetsOnPATH = await this.findRawPathEnvironmentSetting(tryUseTrueShell);
-        if(dotnetsOnPATH && dotnetsOnPATH.length > 0)
+        if (dotnetsOnPATH && dotnetsOnPATH.length > 0)
         {
             const realPaths = dotnetsOnPATH.map(x => realpathSync(x));
             this.workerContext.eventStream.post(new DotnetFindPathRealPATHFound(`Found .NET on the path: ${JSON.stringify(dotnetsOnPATH)}, realpath: ${realPaths}`));
@@ -207,19 +208,19 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
         return undefined;
     }
 
-    public async findHostInstallPaths(requestedArchitecture : string) : Promise<string[] | undefined>
+    public async findHostInstallPaths(requestedArchitecture: string): Promise<string[] | undefined>
     {
         this.workerContext.eventStream.post(new DotnetFindPathHostFxrResolutionLookup(`Looking up .NET without checking the PATH.`));
 
         const oldLookup = process.env.DOTNET_MULTILEVEL_LOOKUP;
         process.env.DOTNET_MULTILEVEL_LOOKUP = '0';
 
-        if(os.platform() === 'win32')
+        if (os.platform() === 'win32')
         {
             const registryReader = new RegistryReader(this.workerContext, this.utilityContext, this.executor);
             const hostPathWin = await registryReader.getHostLocation(requestedArchitecture);
             const paths = hostPathWin ? [path.join(hostPathWin, getDotnetExecutable()), path.join(realpathSync(hostPathWin), getDotnetExecutable())] : [];
-            if(paths.length > 0)
+            if (paths.length > 0)
             {
                 this.workerContext.eventStream.post(new DotnetFindPathOnRegistry(`The host could be found in the registry. ${JSON.stringify(paths)}`));
             }
@@ -236,14 +237,14 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
 
             // https://github.com/dotnet/designs/blob/main/accepted/2021/install-location-per-architecture.md#new-format
 
-            const paths : string[] = [];
+            const paths: string[] = [];
             const netSixAndAboveHostInstallSaveLocation = `/etc/dotnet/install_location_${requestedArchitecture}`;
             const netFiveAndNetSixAboveFallBackInstallSaveLocation = `/etc/dotnet/install_location`;
 
             paths.push(...this.getPathsFromEtc(netSixAndAboveHostInstallSaveLocation));
             paths.push(...this.getPathsFromEtc(netFiveAndNetSixAboveFallBackInstallSaveLocation));
 
-            if(paths.length > 0)
+            if (paths.length > 0)
             {
                 this.workerContext.eventStream.post(new DotnetFindPathOnFileSystem(`The host could be found in the file system. ${JSON.stringify(paths)}`));
             }
@@ -256,10 +257,10 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
         }
     }
 
-    private getPathsFromEtc(etcLoc : string) : Array<string>
+    private getPathsFromEtc(etcLoc: string): Array<string>
     {
-        const paths : string[] = [];
-        if(this.file!.existsSync(etcLoc))
+        const paths: string[] = [];
+        if (this.file!.existsSync(etcLoc))
         {
             try
             {
@@ -267,7 +268,7 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
                 paths.push(path.join(installPath, getDotnetExecutable()));
                 paths.push(path.join(realpathSync(installPath), getDotnetExecutable()));
             }
-            catch(error : any) // eslint-disable-line @typescript-eslint/no-explicit-any
+            catch (error: any) // eslint-disable-line @typescript-eslint/no-explicit-any
             {
                 // readfile throws if the file gets deleted in between the existing check and now
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -288,14 +289,14 @@ Bin Bash Path: ${os.platform() !== 'win32' ? (await this.executor?.execute(Comma
      * @returns The actual physical location/path on disk where the executables lie for each of the paths.
      * Some of the symlinks etc resolve to a path which works but is still not the actual path.
      */
-    private async getTruePath(tentativePaths : string[]) : Promise<string[]>
+    public async getTruePath(tentativePaths: string[]): Promise<string[]>
     {
         const truePaths = [];
 
-        for(const tentativePath of tentativePaths)
+        for (const tentativePath of tentativePaths)
         {
             const runtimeInfo = await new DotnetConditionValidator(this.workerContext, this.utilityContext, this.executor).getRuntimes(tentativePath);
-            if(runtimeInfo.length > 0)
+            if (runtimeInfo.length > 0)
             {
                 // q.t. from @dibarbet on the C# Extension:
                 // The .NET install layout is a well known structure on all platforms.

--- a/vscode-dotnet-runtime-library/src/Acquisition/ExistingPathResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/ExistingPathResolver.ts
@@ -33,7 +33,7 @@ export class ExistingPathResolver
     {
         let existingPath = this.getExistingPath(existingPaths, extensionId, windowDisplayWorker);
         // The user path setting may be a symlink but we dont want to resolve it since a snap symlink isnt a real directory, we can find the true path better this way:
-        existingPath = (await new DotnetPathFinder(this.workerContext, this.utilityContext, this.executor).getTruePath([]))?.at(0) ?? null;
+        existingPath = (await new DotnetPathFinder(this.workerContext, this.utilityContext, this.executor).getTruePath([existingPath ?? '']))?.at(0) ?? null;
         if (existingPath && (await this.providedPathMeetsAPIRequirement(this.workerContext, existingPath, this.workerContext.acquisitionContext, requirement) || this.allowInvalidPath(this.workerContext)))
         {
             return { dotnetPath: existingPath } as IDotnetAcquireResult;

--- a/vscode-dotnet-runtime-library/src/Acquisition/ExistingPathResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/ExistingPathResolver.ts
@@ -32,8 +32,11 @@ export class ExistingPathResolver
     public async resolveExistingPath(existingPaths: IExistingPaths | undefined, extensionId: string | undefined, windowDisplayWorker: IWindowDisplayWorker, requirement?: DotnetVersionSpecRequirement): Promise<IDotnetAcquireResult | undefined>
     {
         let existingPath = this.getExistingPath(existingPaths, extensionId, windowDisplayWorker);
-        // The user path setting may be a symlink but we dont want to resolve it since a snap symlink isnt a real directory, we can find the true path better this way:
-        existingPath = (await new DotnetPathFinder(this.workerContext, this.utilityContext, this.executor).getTruePath([existingPath ?? '']))?.at(0) ?? null;
+        if (!this.allowInvalidPath(this.workerContext))
+        {
+            // The user path setting may be a symlink but we dont want to resolve it since a snap symlink isnt a real directory, we can find the true path better this way:
+            existingPath = (await new DotnetPathFinder(this.workerContext, this.utilityContext, this.executor).getTruePath([existingPath ?? '']))?.at(0) ?? null;
+        }
         if (existingPath && (await this.providedPathMeetsAPIRequirement(this.workerContext, existingPath, this.workerContext.acquisitionContext, requirement) || this.allowInvalidPath(this.workerContext)))
         {
             return { dotnetPath: existingPath } as IDotnetAcquireResult;

--- a/vscode-dotnet-runtime-library/src/Acquisition/ExistingPathResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/ExistingPathResolver.ts
@@ -23,6 +23,7 @@ If you would like to continue to use the setting anyways, set dotnetAcquisitionE
 
 export class ExistingPathResolver
 {
+    private lastSeenNonTruePathValue: string | null = null;
 
     public constructor(private readonly workerContext: IAcquisitionWorkerContext, private readonly utilityContext: IUtilityContext, private executor?: ICommandExecutor)
     {
@@ -32,6 +33,7 @@ export class ExistingPathResolver
     public async resolveExistingPath(existingPaths: IExistingPaths | undefined, extensionId: string | undefined, windowDisplayWorker: IWindowDisplayWorker, requirement?: DotnetVersionSpecRequirement): Promise<IDotnetAcquireResult | undefined>
     {
         let existingPath = this.getExistingPath(existingPaths, extensionId, windowDisplayWorker);
+        this.lastSeenNonTruePathValue = existingPath;
         if (!this.allowInvalidPath(this.workerContext))
         {
             // The user path setting may be a symlink but we dont want to resolve it since a snap symlink isnt a real directory, we can find the true path better this way:
@@ -43,6 +45,15 @@ export class ExistingPathResolver
         }
 
         return undefined;
+    }
+
+    /**
+     * @remarks Returns the last path this class processed before getting the true path.
+     * This is a bit of a hack to allow tests to evaluate the class more thoroughly.
+     */
+    public getlastSeenNonTruePathValue(): string | null
+    {
+        return this.lastSeenNonTruePathValue;
     }
 
     private getExistingPath(existingPaths: IExistingPaths | undefined, extensionId: string | undefined, windowDisplayWorker: IWindowDisplayWorker): string | null

--- a/vscode-dotnet-runtime-library/src/Acquisition/ExistingPathResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/ExistingPathResolver.ts
@@ -14,6 +14,7 @@ import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { DotnetConditionValidator } from './DotnetConditionValidator';
 import { IDotnetFindPathContext } from '../IDotnetFindPathContext';
 import { DotnetVersionSpecRequirement } from '../DotnetVersionSpecRequirement';
+import { DotnetPathFinder } from './DotnetPathFinder';
 
 const badExistingPathWarningMessage = `The 'existingDotnetPath' setting was set, but it did not meet the requirements for this extension to run properly.
 This setting has been ignored.
@@ -23,14 +24,16 @@ If you would like to continue to use the setting anyways, set dotnetAcquisitionE
 export class ExistingPathResolver
 {
 
-    public constructor(private readonly workerContext : IAcquisitionWorkerContext, private readonly utilityContext : IUtilityContext, private executor? : ICommandExecutor)
+    public constructor(private readonly workerContext: IAcquisitionWorkerContext, private readonly utilityContext: IUtilityContext, private executor?: ICommandExecutor)
     {
         this.executor ??= new CommandExecutor(this.workerContext, this.utilityContext);
     }
 
-    public async resolveExistingPath(existingPaths: IExistingPaths | undefined, extensionId: string | undefined, windowDisplayWorker: IWindowDisplayWorker, requirement? : DotnetVersionSpecRequirement): Promise<IDotnetAcquireResult | undefined>
+    public async resolveExistingPath(existingPaths: IExistingPaths | undefined, extensionId: string | undefined, windowDisplayWorker: IWindowDisplayWorker, requirement?: DotnetVersionSpecRequirement): Promise<IDotnetAcquireResult | undefined>
     {
-        const existingPath = this.getExistingPath(existingPaths, extensionId, windowDisplayWorker);
+        let existingPath = this.getExistingPath(existingPaths, extensionId, windowDisplayWorker);
+        // The user path setting may be a symlink but we dont want to resolve it since a snap symlink isnt a real directory, we can find the true path better this way:
+        existingPath = (await new DotnetPathFinder(this.workerContext, this.utilityContext, this.executor).getTruePath([]))?.at(0) ?? null;
         if (existingPath && (await this.providedPathMeetsAPIRequirement(this.workerContext, existingPath, this.workerContext.acquisitionContext, requirement) || this.allowInvalidPath(this.workerContext)))
         {
             return { dotnetPath: existingPath } as IDotnetAcquireResult;
@@ -39,7 +42,7 @@ export class ExistingPathResolver
         return undefined;
     }
 
-    private getExistingPath(existingPaths: IExistingPaths | undefined, extensionId: string | undefined, windowDisplayWorker: IWindowDisplayWorker) : string | null
+    private getExistingPath(existingPaths: IExistingPaths | undefined, extensionId: string | undefined, windowDisplayWorker: IWindowDisplayWorker): string | null
     {
         if (existingPaths && ((existingPaths?.individualizedExtensionPaths?.length ?? 0) > 0 || existingPaths?.sharedExistingPath))
         {
@@ -62,10 +65,11 @@ export class ExistingPathResolver
             else
             {
                 const matchingExtensions = existingPaths.individualizedExtensionPaths?.filter((pair) => pair.extensionId === extensionId);
-                if(matchingExtensions && matchingExtensions.length > 0)
+                if (matchingExtensions && matchingExtensions.length > 0)
                 {
                     const existingLocalPath = existingPaths.individualizedExtensionPaths?.filter((pair) => pair.extensionId === extensionId);
-                    if (existingLocalPath && existingLocalPath.length > 0) {
+                    if (existingLocalPath && existingLocalPath.length > 0)
+                    {
                         return existingLocalPath![0].path;
                     }
                 }
@@ -87,19 +91,19 @@ export class ExistingPathResolver
         return null;
     }
 
-    private allowInvalidPath(workerContext : IAcquisitionWorkerContext) : boolean
+    private allowInvalidPath(workerContext: IAcquisitionWorkerContext): boolean
     {
         return workerContext.allowInvalidPathSetting ?? false;
     }
 
-    private async providedPathMeetsAPIRequirement(workerContext : IAcquisitionWorkerContext, existingPath : string, apiRequest : IDotnetAcquireContext, requirement? : DotnetVersionSpecRequirement) : Promise<boolean>
+    private async providedPathMeetsAPIRequirement(workerContext: IAcquisitionWorkerContext, existingPath: string, apiRequest: IDotnetAcquireContext, requirement?: DotnetVersionSpecRequirement): Promise<boolean>
     {
         const validator = new DotnetConditionValidator(this.workerContext, this.utilityContext, this.executor);
-        const validated = await validator.dotnetMeetsRequirement(existingPath, {acquireContext : apiRequest, versionSpecRequirement : requirement ?? 'equal'} as IDotnetFindPathContext);
+        const validated = await validator.dotnetMeetsRequirement(existingPath, { acquireContext: apiRequest, versionSpecRequirement: requirement ?? 'equal' } as IDotnetFindPathContext);
 
-        if(!validated && !this.allowInvalidPath(workerContext))
+        if (!validated && !this.allowInvalidPath(workerContext))
         {
-            this.utilityContext.ui.showWarningMessage(`${badExistingPathWarningMessage}\nExtension: ${workerContext.acquisitionContext.requestingExtensionId ?? 'Unspecified'}`, () => {/* No Callback */}, );
+            this.utilityContext.ui.showWarningMessage(`${badExistingPathWarningMessage}\nExtension: ${workerContext.acquisitionContext.requestingExtensionId ?? 'Unspecified'}`, () => {/* No Callback */ },);
         }
 
         return validated;

--- a/vscode-dotnet-runtime-library/src/test/unit/ExistingPathResolver.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/ExistingPathResolver.test.ts
@@ -19,8 +19,8 @@ const individualPath = 'foo';
 const sharedPath = 'bar';
 
 const mockPaths: IExistingPaths = {
-    individualizedExtensionPaths: [{extensionId: 'alternative.extension', path: individualPath}],
-    sharedExistingPath: sharedPath
+  individualizedExtensionPaths: [{ extensionId: 'alternative.extension', path: individualPath }],
+  sharedExistingPath: sharedPath
 }
 
 const extensionConfiguration = new MockExtensionConfiguration(mockPaths.individualizedExtensionPaths!, true, mockPaths.sharedExistingPath!);
@@ -32,57 +32,58 @@ const listRuntimesResultWithEightOnly = `
 Microsoft.NETCore.App 8.0.7 [C:\\Program Files\\dotnet\\shared\\Microsoft.AspNetCore.App]
 
 `;
-const executionResultWithEightOnly = { status : '', stdout: listRuntimesResultWithEightOnly, stderr: '' };
+const executionResultWithEightOnly = { status: '', stdout: listRuntimesResultWithEightOnly, stderr: '' };
 
 const listRuntimesResultWithEightASPOnly = `
 Microsoft.AspNetCore.App 8.0.7 [C:\\Program Files\\dotnet\\shared\\Microsoft.AspNetCore.App]
 
 `;
-const executionResultWithEightAspOnly = { status : '', stdout: listRuntimesResultWithEightASPOnly, stderr: '' };
+const executionResultWithEightAspOnly = { status: '', stdout: listRuntimesResultWithEightASPOnly, stderr: '' };
 
 const listSDKsResultWithEightOnly = `
 8.0.101 [C:\\Program Files\\dotnet\\sdk]
-`;
-const executionResultWithListSDKsResultWithEightOnly = { status : '', stdout: listSDKsResultWithEightOnly, stderr: '' };
+`
+const executionResultWithListSDKsResultWithEightOnly = { status: '', stdout: listSDKsResultWithEightOnly, stderr: '' };
 
-function getExistingPathResolverWithVersionAndCommandResult(version: string, requestingExtensionId : string | undefined, commandResult: CommandExecutorResult, allowInvalidPaths = false, mode : DotnetInstallMode | undefined = undefined) : ExistingPathResolver
+function getExistingPathResolverWithVersionAndCommandResult(version: string, requestingExtensionId: string | undefined, commandResult: CommandExecutorResult, allowInvalidPaths = false, mode: DotnetInstallMode | undefined = undefined): ExistingPathResolver
 {
-    const context: IDotnetAcquireContext = { version: version, requestingExtensionId: requestingExtensionId, mode: mode ?? 'runtime'};
-    const newConfig = new MockExtensionContext();
-    if(allowInvalidPaths)
-    {
-        newConfig.update('dotnetAcquisitionExtension.allowInvalidPaths', true);
-    }
-    const mockWorkerContext = getMockAcquisitionContext(mode ?? 'runtime', version, undefined, undefined, newConfig);
-    mockWorkerContext.acquisitionContext = context;
+  const context: IDotnetAcquireContext = { version: version, requestingExtensionId: requestingExtensionId, mode: mode ?? 'runtime' };
+  const newConfig = new MockExtensionContext();
+  if (allowInvalidPaths)
+  {
+    newConfig.update('dotnetAcquisitionExtension.allowInvalidPaths', true);
+  }
+  const mockWorkerContext = getMockAcquisitionContext(mode ?? 'runtime', version, undefined, undefined, newConfig);
+  mockWorkerContext.acquisitionContext = context;
 
-    const mockExecutor = new MockCommandExecutor(mockWorkerContext, mockUtility);
-    mockExecutor.fakeReturnValue = commandResult;
-    const existingPathResolver = new ExistingPathResolver(mockWorkerContext, mockUtility, mockExecutor);
-    return existingPathResolver;
+  const mockExecutor = new MockCommandExecutor(mockWorkerContext, mockUtility);
+  mockExecutor.fakeReturnValue = commandResult;
+  const existingPathResolver = new ExistingPathResolver(mockWorkerContext, mockUtility, mockExecutor);
+  return existingPathResolver;
 }
 
-suite('ExistingPathResolver Unit Tests', () => {
+suite('ExistingPathResolver Unit Tests', () =>
+{
 
-    test('Use Shared Existing Path Setting over Individual Setting when no Extension Id is Provided', async () =>
-    {
-      const existingPathResolver = getExistingPathResolverWithVersionAndCommandResult('8.0', undefined, executionResultWithEightOnly);
+  test('Use Shared Existing Path Setting over Individual Setting when no Extension Id is Provided', async () =>
+  {
+    const existingPathResolver = getExistingPathResolverWithVersionAndCommandResult('8.0', undefined, executionResultWithEightOnly);
 
-      const existingPath = await existingPathResolver.resolveExistingPath(extensionConfigWorker.getAllPathConfigurationValues(), undefined, new MockWindowDisplayWorker());
-      assert(existingPath, 'The existing path is returned');
-      assert(existingPath?.dotnetPath, 'The existing path is using a dotnet path object');
-      assert.equal(existingPath?.dotnetPath, sharedPath);
+    const existingPath = await existingPathResolver.resolveExistingPath(extensionConfigWorker.getAllPathConfigurationValues(), undefined, new MockWindowDisplayWorker());
+    assert(existingPath, 'The existing path is returned');
+    assert(existingPath?.dotnetPath, 'The existing path is using a dotnet path object');
+    assert.equal(existingPath?.dotnetPath, sharedPath);
   }).timeout(standardTimeoutTime);
 
   test('Prefer Individual Existing Path Setting over Shared Setting', async () =>
   {
-      const extensionIdAlt = 'alternative.extension';
-      const existingPathResolver = getExistingPathResolverWithVersionAndCommandResult('8.0', extensionIdAlt, executionResultWithEightOnly);
+    const extensionIdAlt = 'alternative.extension';
+    const existingPathResolver = getExistingPathResolverWithVersionAndCommandResult('8.0', extensionIdAlt, executionResultWithEightOnly);
 
-      const existingPath = await existingPathResolver.resolveExistingPath(extensionConfigWorker.getAllPathConfigurationValues(), extensionIdAlt, new MockWindowDisplayWorker());
-      assert(existingPath, 'The existing path is returned');
-      assert(existingPath?.dotnetPath, 'The existing path is using a dotnet path object');
-      assert.equal(existingPath?.dotnetPath, individualPath);
+    const existingPath = await existingPathResolver.resolveExistingPath(extensionConfigWorker.getAllPathConfigurationValues(), extensionIdAlt, new MockWindowDisplayWorker());
+    assert(existingPath, 'The existing path is returned');
+    assert(existingPath?.dotnetPath, 'The existing path is using a dotnet path object');
+    assert.equal(existingPath?.dotnetPath, individualPath);
   }).timeout(standardTimeoutTime);
 
   test('It will use the legacy mode and return the path even if it does not meet an api request if allowInvalidPaths is set', async () =>
@@ -100,15 +101,15 @@ suite('ExistingPathResolver Unit Tests', () => {
   }).timeout(standardTimeoutTime);
 
   test('It will not return the path setting if the path does includes a runtime that matches the api request but not an aspnet runtime', async () =>
-    {
-      const existingPathResolver = getExistingPathResolverWithVersionAndCommandResult('8.0', undefined, executionResultWithEightOnly, false, 'aspnetcore');
-      const existingPath = await existingPathResolver.resolveExistingPath(extensionConfigWorker.getAllPathConfigurationValues(), undefined, new MockWindowDisplayWorker());
-      assert.equal(existingPath, undefined, 'It returns undefined when the setting does not match the API request');
-    }).timeout(standardTimeoutTime);
+  {
+    const existingPathResolver = getExistingPathResolverWithVersionAndCommandResult('8.0', undefined, executionResultWithEightOnly, false, 'aspnetcore');
+    const existingPath = await existingPathResolver.resolveExistingPath(extensionConfigWorker.getAllPathConfigurationValues(), undefined, new MockWindowDisplayWorker());
+    assert.equal(existingPath, undefined, 'It returns undefined when the setting does not match the API request');
+  }).timeout(standardTimeoutTime);
 
   test('It will still use the PATH if it has an SDK which satisfies the condition even if there is no runtime that does', async () =>
   {
-    const context: IDotnetAcquireContext = { version: '8.0', mode : 'runtime' };
+    const context: IDotnetAcquireContext = { version: '8.0', mode: 'runtime' };
     const mockWorkerContext = getMockAcquisitionWorkerContext(context);
     const mockExecutor = new MockCommandExecutor(mockWorkerContext, mockUtility);
     mockExecutor.fakeReturnValue = executionResultWithEightAspOnly;


### PR DESCRIPTION
For https://github.com/dotnet/vscode-csharp/issues/7925#issuecomment-2596918380

We have a custom setting and could cause C# to fail if someone sets the setting to a symlink install which doesn't actually have a folder in it, even if it has a valid executable because DOTNET_ROOT wants a folder. Read more below on how this fix works and why.

Works with snap setting set: 
![image](https://github.com/user-attachments/assets/4b90b21f-005a-414c-aa48-bfad7941a736)

Works with Feed Set to Symlink:
/usr/bin/dotnet (which is really /usr/lib/dotnet/)

![image](https://github.com/user-attachments/assets/a02da6c7-981d-4493-8436-8d4b899222af)

![image](https://github.com/user-attachments/assets/d4a75cf0-4b21-4482-b6d2-7a81715d1051)


# Snap (after installing via package manager and uninstalling, then using snap)

Interesting, the symlink which could be set as /usr/lib/dotnet in this case doesn't work as an executable with snap when we try to find the executable due to how its placed (/usr/lib/dotnet/dotnet does not exist.)

But our code uses custom snap logic to make it work in a different method.

# Package Manager
However with a package manager, /usr/lib/dotnet is the actual location and /usr/lib/dotnet/dotnet is a valid executable, so this works. /usr/bin/dotnet is also a valid executable, and that is the symlink to the lib folder, so our logic accepts it, but then it's not valid for DOTNET_ROOT. I didnt know DOTNET_ROOT required the folder, so thank you for that context @dibarbet.

Our path logic tries to not do realpath first, and this would normally have been caught so we'd give the correct path; its OK because we call --list-runtimes and go 2 directories up. But we didn't do that for the user setting path in an attempt to respect what they set.

# Solution

This should be fixed in our extension.
I dont know if I'd call it a 'bug' per se, but we can make the behavior better. They shouldnt have to know all of this nuance.

This means we could
a - call realpath on /usr/bin/dotnet (or the user setting) b - call --list-runtimes on /usr/bin/dotnet (the user setting) and go 2 directories up to find the actual path

both would cause us to return path.join(/usr/lib/dotnet, dotnet), however, realpath already returns the executable, while list--runtimes parsing would point us only to /usr/lib/dotnet/shared/blah.

a and b have similar ish performance characteristics because they both need to spawn a shell (most expensive perf), but --list-runtimes is going to be cached in the future so that theoretically means list-runtimes is faster as it wont need to spawn a shell. I guess we could cache realpath too, so performance isnt much of a concern.

b is better in my opinion, as a would actually break with a snap install. realpath of snap/bin/dotnet is /usr/bin/snap, which is not a valid executable, so it wouldn't be found. since it follows the flow of the other code in our extension to go 2 dirs up at the end of the call. Users do some (wild) stuff and if they removed realpath from their system we'd also be cooked in that situation, not that its a high priority.