### PR TITLE
Use a random distribution for cache reporting

### DIFF
--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -1098,7 +1098,7 @@ export class CachePutEvent extends DotnetCustomMessageEvent
 
     public getProperties()
     {
-        return { Message: this.eventMessage, indexStr: this.indexStr, value: this.value, ttl: this.ttl };
+        return { Message: this.eventMessage, indexStr: this.indexStr, value: this.value, ttl: this.ttl, ...getDisabledTelemetryOnChance(1) };
     };
 }
 
@@ -1109,7 +1109,7 @@ export class CacheGetEvent extends DotnetCustomMessageEvent
 
     public getProperties()
     {
-        return { Message: this.eventMessage, indexStr: this.indexStr, value: this.value };
+        return { Message: this.eventMessage, indexStr: this.indexStr, value: this.value, ...getDisabledTelemetryOnChance(1) };
     };
 }
 
@@ -1753,4 +1753,9 @@ export class TestAcquireCalled extends IEvent
     {
         return undefined;
     }
+}
+
+function getDisabledTelemetryOnChance(percentIntToSend: number): { [disableTelemetryId: string]: boolean }
+{
+    return { suppressTelemetry: Math.random() * 100 < percentIntToSend ? true : false };
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -1757,5 +1757,5 @@ export class TestAcquireCalled extends IEvent
 
 function getDisabledTelemetryOnChance(percentIntToSend: number): { [disableTelemetryId: string]: boolean }
 {
-    return { suppressTelemetry: Math.random() * 100 < percentIntToSend ? true : false };
+    return { suppressTelemetry: Math.random() * 100 < percentIntToSend };
 }


### PR DESCRIPTION
So, the information we have about caching is useful to see if it's helpful or not and giving a perf boost/causing issues. But also, we are sending like 500k of them per hour and the data team is not very enthused about this. We only need a small random sample to get what we need so this is a better use of $

suppressTelemetry is checked in the TelemetryObserver to not send it.