### PR TITLE
Do not consider SDKs when validating the runtime requirements.

### DIFF
--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetConditionValidator.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetConditionValidator.test.ts
@@ -86,6 +86,30 @@ suite('DotnetConditionValidator Unit Tests', () =>
         assert.isTrue(meetsReq, 'It finds non preview SDK if rejectPreviews set');
     });
 
+    test('It validates runtimes separately from sdks', async () => {
+        const runtime8_0_7Requirement = {
+            acquireContext: getMockAcquisitionContext('runtime', '8.0.7').acquisitionContext,
+            versionSpecRequirement: 'greater_than_or_equal'
+        } as IDotnetFindPathContext
+
+        mockExecutor.fakeReturnValue = executionResultWithListRuntimesResultWithFullOnly;
+        mockExecutor.otherCommandPatternsToMock = ['--list-runtimes', '--list-sdks'];
+        mockExecutor.otherCommandsReturnValues = [executionResultWithListRuntimesResultWithFullOnly, executionResultWithListSDKsResultWithPreviewOnly];
+
+        const conditionValidator = new DotnetConditionValidator(acquisitionContext, utilityContext, mockExecutor);
+
+        let meetsReq = await conditionValidator.dotnetMeetsRequirement('dotnet', runtime8_0_7Requirement);
+        assert.isTrue(meetsReq, 'It finds the 8.0.7 runtime');
+
+        const runtime8_0_8Requirement = {
+            acquireContext: getMockAcquisitionContext('runtime', '8.0.8').acquisitionContext,
+            versionSpecRequirement: 'greater_than_or_equal'
+        } as IDotnetFindPathContext
+
+        meetsReq = await conditionValidator.dotnetMeetsRequirement('dotnet', runtime8_0_8Requirement);
+        assert.isFalse(meetsReq, 'It does not find the 8.0.8 runtime or treat the 8.0.101 SDK as a runtime');
+    });
+
     test('It does not take newer major SDK if latestPatch or feature used', async () =>
     {
         const conditionValidator = new DotnetConditionValidator(acquisitionContext, utilityContext, mockExecutor);


### PR DESCRIPTION
The runtimes installed with SDKs are already includes in the runtimes list. Comparing runtime and SDK versions does not make sense.

Part of the fix for https://github.com/dotnet/vscode-csharp/issues/8034