### PR TITLE
Do not consider SDKs when validating the runtime requirements. 

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -32,7 +32,6 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
         if (requirement.acquireContext.mode === 'sdk') {
             const availableSDKs = await this.getSDKs(dotnetExecutablePath);
             if (availableSDKs.some((sdk) => {
-                // The SDK includes the Runtime, ASP.NET Core Runtime, and Windows Desktop Runtime. So, we don't need to check the mode.
                 return this.stringArchitectureMeetsRequirement(hostArch, requirement.acquireContext.architecture) &&
                     this.stringVersionMeetsRequirement(sdk.version, requirement.acquireContext.version, requirement) && this.allowPreview(sdk.version, requirement);
             })) {

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetConditionValidator.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetConditionValidator.test.ts
@@ -86,6 +86,30 @@ suite('DotnetConditionValidator Unit Tests', () =>
         assert.isTrue(meetsReq, 'It finds non preview SDK if rejectPreviews set');
     });
 
+    test('It validates runtimes separately from sdks', async () => {
+        const runtime8_0_7Requirement = {
+            acquireContext: getMockAcquisitionContext('runtime', '8.0.7').acquisitionContext,
+            versionSpecRequirement: 'greater_than_or_equal'
+        } as IDotnetFindPathContext
+
+        mockExecutor.fakeReturnValue = executionResultWithListRuntimesResultWithFullOnly;
+        mockExecutor.otherCommandPatternsToMock = ['--list-runtimes', '--list-sdks'];
+        mockExecutor.otherCommandsReturnValues = [executionResultWithListRuntimesResultWithFullOnly, executionResultWithListSDKsResultWithPreviewOnly];
+
+        const conditionValidator = new DotnetConditionValidator(acquisitionContext, utilityContext, mockExecutor);
+
+        let meetsReq = await conditionValidator.dotnetMeetsRequirement('dotnet', runtime8_0_7Requirement);
+        assert.isTrue(meetsReq, 'It finds the 8.0.7 runtime');
+
+        const runtime8_0_8Requirement = {
+            acquireContext: getMockAcquisitionContext('runtime', '8.0.8').acquisitionContext,
+            versionSpecRequirement: 'greater_than_or_equal'
+        } as IDotnetFindPathContext
+
+        meetsReq = await conditionValidator.dotnetMeetsRequirement('dotnet', runtime8_0_8Requirement);
+        assert.isFalse(meetsReq, 'It does not find the 8.0.8 runtime or treat the 8.0.101 SDK as a runtime');
+    });
+
     test('It does not take newer major SDK if latestPatch or feature used', async () =>
     {
         const conditionValidator = new DotnetConditionValidator(acquisitionContext, utilityContext, mockExecutor);

--- a/vscode-dotnet-runtime-library/src/test/unit/ExistingPathResolver.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/ExistingPathResolver.test.ts
@@ -113,7 +113,7 @@ suite('ExistingPathResolver Unit Tests', () =>
     assert.equal(existingPath, undefined, 'It returns undefined when the setting does not match the API request');
   }).timeout(standardTimeoutTime);
 
-  test('It will still use the PATH if it has an SDK which satisfies the condition even if there is no runtime that does', async () =>
+  test('It will not use the PATH if it does not have a runtime which satisfies the condition even if there is an SDK that does', async () =>
   {
     const context: IDotnetAcquireContext = { version: '8.0', mode: 'runtime' };
     const mockWorkerContext = getMockAcquisitionWorkerContext(context);
@@ -125,11 +125,7 @@ suite('ExistingPathResolver Unit Tests', () =>
     const existingPathResolver = new ExistingPathResolver(mockWorkerContext, mockUtility, mockExecutor);
 
     const existingPath = await existingPathResolver.resolveExistingPath(extensionConfigWorker.getAllPathConfigurationValues(), undefined, new MockWindowDisplayWorker());
-    const nonTrueExistingPath = existingPathResolver.getlastSeenNonTruePathValue();
 
-    assert(existingPath, 'The existing path is returned when an SDK matches the path but no runtime is installed');
-    assert(nonTrueExistingPath, 'The existing path is using a dotnet path object');
-    assert.equal(nonTrueExistingPath, sharedPath);
-    assert.equal(existingPath?.dotnetPath, os.platform() === 'win32' ? 'C:\\Program Files\\dotnet\\dotnet.exe' : 'dotnet', 'The true path is called on the fake path to get dotnet executable');
+    assert.notExists(existingPath, 'The existing path is not returned when an SDK matches the path but no runtime is installed');
   }).timeout(standardTimeoutTime);
 });


### PR DESCRIPTION
The runtimes installed with SDKs are already includes in the runtimes list. Comparing runtime and SDK versions does not make sense.

Part of the fix for https://github.com/dotnet/vscode-csharp/issues/8034