### PR TITLE
Fix bug getting the status of a command

### DIFF
--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -466,7 +466,7 @@ with options ${JSON.stringify(options)}.`));
                 rejected => // Rejected object: error type with stderr : Buffer, stdout : Buffer ... with .code (number) or .signal (string)}
                 { // see https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                    const result = { stdout: rejected?.stdout?.toString() ?? '', stderr: rejected?.stderr?.toString() ?? '', status: rejected?.error?.code?.toString() ?? rejected?.error?.signal.toString() ?? '' };
+                    const result = { stdout: rejected?.stdout?.toString() ?? '', stderr: rejected?.stderr?.toString() ?? '', status: rejected?.code?.toString() ?? rejected?.signal?.toString() ?? '' };
                     if (terminalFailure)
                     {
                         this.logCommandResult(result, fullCommandString);


### PR DESCRIPTION
# Improvements for 2.2.9 Release (Bugs found during Vendor Testing)

# Issue 1 - Getting the Status of a Command 

Fixes https://github.com/dotnet/vscode-dotnet-runtime/issues/2164

The nodejs spec for the special cased promisify version of exec mentions that it throws an object with an error, stdout and stderr. It looks like the object it throws is not an error in an object but rather an error object. So calling .error is incorrect.

This fixes the handling of cancellations.

![image](https://github.com/user-attachments/assets/f242fd2d-1bab-48ce-b806-8075ebd7033b)


# Issue 2 - Caching Web Requests