### PR TITLE
Fix Issue when VS Code is pkilled and we hold a lock

### DIFF
--- a/vscode-dotnet-runtime-library/src/Utils/LockUsedByThisInstanceSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/LockUsedByThisInstanceSingleton.ts
@@ -30,7 +30,7 @@ export class LockUsedByThisInstanceSingleton
 
     public hasVsCodeInstanceInteractedWithLock(lockKey: string): boolean
     {
-        lockKey = path.resolve(lockKey);
+        lockKey = path.basename(lockKey).trim();
         const hasInteracted = this.lockStringAndThisVsCodeInstanceOwnsIt[lockKey] === true;
         this.lockStringAndThisVsCodeInstanceOwnsIt[lockKey] = true; // This could be a set but this is also fine
         return hasInteracted;

--- a/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
@@ -83,16 +83,9 @@ export async function executeWithLock<A extends any[], R>(eventStream: IEventStr
     {
         eventStream?.post(new DotnetLockReleasedEvent(`Lock about to be released, but we never touched it (pkilled vscode?)`, new Date().toISOString(), lockPath, lockPath));
 
-        if (lockfile.checkSync(lockPath))
-        {
-            eventStream?.post(new DotnetLockReleasedEvent(`Lock about to be released, and checkSync showed it.`, new Date().toISOString(), lockPath, lockPath));
-            lockfile.unlockSync(lockPath);
-        }
-        else
-        {
-            eventStream?.post(new DotnetLockReleasedEvent(`Lock is not owned by us, delete it`, new Date().toISOString(), lockPath, lockPath));
-            fs.rmdirSync(`${lockPath}.lock`, { recursive: true });
-        }
+        eventStream?.post(new DotnetLockReleasedEvent(`Lock is not owned by us, delete it`, new Date().toISOString(), lockPath, lockPath));
+        fs.rmdirSync(`${lockPath}.lock`, { recursive: true });
+
     }
 
     retryTimeMs = retryTimeMs > 0 ? retryTimeMs : 100;


### PR DESCRIPTION
# Context

- proper_lockfile is the approach we take to have a concept of a mutex/lock in nodejs.
- This writes a dir on disk based on another existing file on disk, so if you lock foo.txt, it creates foo.txt.lock. This represents the lock.
- If someone pkills vscode, the lock is not cleaned up. The lock library will eventually make it stale, but that means the extension will fail to acquire a dead lock for the timeout time (approx 10 minutes) so it will seem like it fails.
- We can rm -rf the lock in this case by having a singleton keep track of if this instance of vscode ever touched the lock.

# Fix

- unlockSync will fail if we don't own the lock. We don't own the lock if an old process owned it as their ownership is an in-memory local dictionary. We should always just rmDir it. This has no consequences I know of on their lib based on their code, since everything is stored in local memory, it is blown away when vscode gets pkilled. Any of our sub processes would also get blown away, except for perhaps the sudo master process, which is capable of communicating with a new vscode window; thankfully, a lock is required to talk to that process. There is a slight bug possibility, where it was told to run some command and pipes the output back out to vscode if it is quickly pkilled and relaunched, but I think this is lower priority to fix.

- This also makes it so that the lockFile key in the list of touched lock files is based on the ending file name instead of the full path, to prevent issues where the path may be abbreviated / relative.

# Importance

Required for 2.3.0 to release.
