### PR TITLE
Don't record all of the environment in the log

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
@@ -161,7 +161,7 @@ export class InstallTrackerSingleton
     private getLockFilePathForKey(provider: IInstallationDirectoryProvider, dataKey: string): string
     {
         const providerPath = provider.getInstallDir('foo');
-        var hasNumber = /\d/;
+        const hasNumber = /\d/;
 
         const dir = hasNumber.test(providerPath) ? path.dirname(providerPath) : providerPath; // bad codependency I dont want to untangle atm : sdk local itnstall providers dont create a separate folder, runtime ones do
         // but installing state should be at the root folder (not trustable from __dirname and can't access vscode storage folder) ... so if the folder is like 8.0 or 8.0~aspnetcore~x64 e go up to root

--- a/vscode-dotnet-runtime-library/src/LocalMemoryCacheSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/LocalMemoryCacheSingleton.ts
@@ -7,9 +7,11 @@
 import * as nodeCache from 'node-cache';
 import { IAcquisitionWorkerContext } from "./Acquisition/IAcquisitionWorkerContext";
 import { CacheClearEvent, CacheGetEvent, CachePutEvent } from "./EventStream/EventStreamEvents";
+import { TelemetryUtilities } from './EventStream/TelemetryUtilities';
 import { CommandExecutor } from "./Utils/CommandExecutor";
 import { CommandExecutorCommand } from "./Utils/CommandExecutorCommand";
 import { CommandExecutorResult } from "./Utils/CommandExecutorResult";
+import { minimizeEnvironment } from './Utils/TypescriptUtilities';
 
 export interface CacheableCommand
 {
@@ -109,6 +111,11 @@ export class LocalMemoryCacheSingleton
             if (k === 'dotnetInstallToolCacheTtlMs')
             {
                 return undefined;
+            }
+            else if (k === 'env')
+            {
+                return `${minimizeEnvironment(v)}-${TelemetryUtilities.HashData(JSON.stringify(v))}`; // Each command with a unique env must be cached uniquely -- it's helpful to see what the important vars are in the log.
+                // But we don't want to store the entire env/log it.
             }
             return v;
         })}`;

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -435,8 +435,8 @@ ${stderr}`));
         else
         {
             const { env, ...optionsWithoutEnv } = options;
-            this.context?.eventStream.post(new CommandExecutionEvent(`Executing command ${fullCommandString}
-with options ${JSON.stringify(options.env !== null && options.env !== undefined ? { env: minimizeEnvironment(env), ...optionsWithoutEnv } : options)}.`));
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            this.context?.eventStream.post(new CommandExecutionEvent(`Executing command ${fullCommandString} with options ${JSON.stringify(options.env !== null && options.env !== undefined ? { env: minimizeEnvironment(env), ...optionsWithoutEnv } : options)}.`));
 
             if (command.runUnderSudo)
             {

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -57,7 +57,7 @@ import { ICommandExecutor } from './ICommandExecutor';
 import { IFileUtilities } from './IFileUtilities';
 import { IUtilityContext } from './IUtilityContext';
 import { LockUsedByThisInstanceSingleton } from './LockUsedByThisInstanceSingleton';
-import { executeWithLock, isRunningUnderWSL, loopWithTimeoutOnCond } from './TypescriptUtilities';
+import { executeWithLock, isRunningUnderWSL, loopWithTimeoutOnCond, minimizeEnvironment } from './TypescriptUtilities';
 
 export class CommandExecutor extends ICommandExecutor
 {
@@ -434,8 +434,9 @@ ${stderr}`));
         }
         else
         {
+            const { env, ...optionsWithoutEnv } = options;
             this.context?.eventStream.post(new CommandExecutionEvent(`Executing command ${fullCommandString}
-with options ${JSON.stringify(options)}.`));
+with options ${JSON.stringify(options.env !== null && options.env !== undefined ? { env: minimizeEnvironment(env), ...optionsWithoutEnv } : options)}.`));
 
             if (command.runUnderSudo)
             {

--- a/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
@@ -157,6 +157,71 @@ export async function executeWithLock<A extends any[], R>(eventStream: IEventStr
     return returnResult;
 }
 
+const possiblyUsefulUpperCaseEnvVars = new Set<string>([ // This is a local variable instead of in the function so it doesn't get recreated every time the function is called. I looked at compiled JS and didn't see it get optimized.
+    'COMMONPROGRAMFILES',
+    'COMMONPROGRAMFILES(x86)',
+    'PATH',
+    'SYSTEMROOT',
+    'PROGRAMFILES',
+    'POWERSHELL_DISTRIBUTION_CHANNEL',
+    'PROCESSOR_IDENTIFIER',
+    'PSMODULEPATH',
+    'PROCESSOR_ARCHITECTURE',
+    'VSCODE_CLI',
+    'VSCODE_CODE_CACHE_PATH',
+    'VSCODE_HANDLES_UNCAUGHT_ERRORS',
+    'RESOLVEDLANGUAGE',
+    'VSCODE_PID',
+    'WINDIR',
+    'DIRCMD',
+    'TERM_PROGRAM_VERSION',
+    'ALLUSERSPROFILE',
+    'COMSPEC',
+    'DOTNET_MULTILEVEL_LOOKUP',
+    'ELECTRON_RUN_AS_NODE',
+    'LANG',
+    'HOME',
+    'PATHEXT',
+    'SHELL',
+    'TERM',
+    'PWD',
+    'BASHOPTS',
+    'SHELLOPTS',
+    'PS1',
+    'PS2',
+    'DOTNET_INSTALL_TOOL_UNDER_TEST',
+    'VSCODE_DOTNET_GLOBAL_INSTALL_FAKE_PATH',
+    'DOTNET_ROOT',
+    'DOTNET_ROOT_X86',
+    'DOTNET_ROOT_X64',
+    'DOTNET_ROOT(x86)',
+    'DOTNET_CLI_UI_LANGUAGE',
+    'CHCP',
+    'DOTNET_NOLOGO',
+    'DOTNET_HOST_PATH',
+    'DOTNET_ROLL_FORWARD',
+    'DOTNET_ROLL_FORWARD_TO_PRERELEASE',
+    'DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX',
+]);
+
+/*
+* @remarks Not intended for telemetry redaction -- PII must be handled correctly elsewhere by a telemetry system.
+* This is intended for logging to the console or a log file where we don't want to write out sensitive information, but we do want information that is useful for debugging weird user situations.
+*/
+export function minimizeEnvironment(pathEnv: NodeJS.ProcessEnv): string
+{
+    let pathEnvString = ``;
+
+    for (const key in pathEnv)
+    {
+        if (possiblyUsefulUpperCaseEnvVars.has(key.toUpperCase()))
+        {
+            pathEnvString += `${key}: ${pathEnv[key]}\n}`;
+        }
+    }
+    return pathEnvString;
+}
+
 export async function getOSArch(executor: ICommandExecutor): Promise<string>
 {
     if (os.platform() === 'darwin')

--- a/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
@@ -216,7 +216,7 @@ export function minimizeEnvironment(pathEnv: NodeJS.ProcessEnv): string
     {
         if (possiblyUsefulUpperCaseEnvVars.has(key.toUpperCase()))
         {
-            pathEnvString += `${key}: ${pathEnv[key]}\n}`;
+            pathEnvString += `${key}: ${pathEnv[key]}\n`;
         }
     }
     return pathEnvString;


### PR DESCRIPTION
We only need certain information to help debug logs, and when customers submit them to us, they are less likely to redact everything. It's been helpful having this information for debugging and this will make it harder to debug in case there are variables that I didn't think of, that a user might set that'd cause a bug, but for the sake of collecting less information on the log file we should do this.

This also hashes the string of the env used as the key to cache commands, since each command environment may result in different results, we want to still have a 'unique' enough ID for it without storing this data in our cache.