### PR TITLE
Skip Parsing Empty Dotnet Executable

### DIFF
--- a/sample/src/extension.ts
+++ b/sample/src/extension.ts
@@ -375,7 +375,7 @@ ${JSON.stringify(result) ?? 'undefined'}`);
         try
         {
             const result: IDotnetListVersionsResult | undefined = await vscode.commands.executeCommand('dotnet.recommendedVersion', { listRuntimes: getRuntimes });
-            vscode.window.showInformationMessage(`Recommended SDK Version to Install: ${result?.at(0)?.version}`);
+            vscode.window.showInformationMessage(`Recommended SDK Version to Install: ${result?.[0]?.version}`);
         }
         catch (error)
         {

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -29,22 +29,28 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
     {
         const hostArch = await this.getHostArchitecture(dotnetExecutablePath, requirement);
 
-        if (requirement.acquireContext.mode === 'sdk') {
+        if (requirement.acquireContext.mode === 'sdk')
+        {
             const availableSDKs = await this.getSDKs(dotnetExecutablePath);
-            if (availableSDKs.some((sdk) => {
+            if (availableSDKs.some((sdk) =>
+            {
                 return this.stringArchitectureMeetsRequirement(hostArch, requirement.acquireContext.architecture) &&
                     this.stringVersionMeetsRequirement(sdk.version, requirement.acquireContext.version, requirement) && this.allowPreview(sdk.version, requirement);
-            })) {
+            }))
+            {
                 return true;
             }
         }
-        else {
+        else
+        {
             // No need to consider SDKs when looking for runtimes as all the runtimes installed with the SDKs will be included in the runtimes list.
             const availableRuntimes = await this.getRuntimes(dotnetExecutablePath);
-            if (availableRuntimes.some((runtime) => {
+            if (availableRuntimes.some((runtime) =>
+            {
                 return runtime.mode === requirement.acquireContext.mode && this.stringArchitectureMeetsRequirement(hostArch, requirement.acquireContext.architecture) &&
                     this.stringVersionMeetsRequirement(runtime.version, requirement.acquireContext.version, requirement) && this.allowPreview(runtime.version, requirement);
-            })) {
+            }))
+            {
                 return true;
             }
         }
@@ -70,6 +76,11 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
     {
         // dotnet --info is not machine-readable and subject to breaking changes. See https://github.com/dotnet/sdk/issues/33697 and https://github.com/dotnet/runtime/issues/98735/
         // Unfortunately even with a new API, that might not go in until .NET 10 and beyond, so we have to rely on dotnet --info for now.*/
+
+        if (!hostPath || hostPath === '""')
+        {
+            return '';
+        }
 
         const infoCommand = CommandExecutor.makeCommand(`"${hostPath}"`, ['--info']);
         const envWithForceEnglish = process.env;
@@ -102,6 +113,11 @@ Please set the PATH to a dotnet host that matches the architecture ${requirement
 
     public async getSDKs(existingPath: string): Promise<IDotnetListInfo[]>
     {
+        if (!existingPath || existingPath === '""')
+        {
+            return [];
+        }
+
         const findSDKsCommand = await this.setCodePage() ? CommandExecutor.makeCommand(`chcp`, [`65001`, `|`, `"${existingPath}"`, '--list-sdks']) :
             CommandExecutor.makeCommand(`"${existingPath}"`, ['--list-sdks']);
 
@@ -254,6 +270,11 @@ Please set the PATH to a dotnet host that matches the architecture ${requirement
 
     public async getRuntimes(existingPath: string): Promise<IDotnetListInfo[]>
     {
+        if (!existingPath || existingPath === '""')
+        {
+            return [];
+        }
+
         const findRuntimesCommand = await this.setCodePage() ? CommandExecutor.makeCommand(`chcp`, [`65001`, `|`, `"${existingPath}"`, '--list-runtimes']) :
             CommandExecutor.makeCommand(`"${existingPath}"`, ['--list-runtimes']);
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
@@ -74,7 +74,7 @@ export function InstallToStrings(install: DotnetInstall)
 
 export function looksLikeRuntimeVersion(version: string): boolean
 {
-    const band: string | undefined = version.split('.')?.at(2);
+    const band: string | undefined = version.split('.')?.[2];
     return (band?.length ?? 0) <= 2; // assumption : there exists no runtime version at this point over 99 sub versions
 }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RegistryReader.ts
@@ -5,13 +5,13 @@
 import * as os from 'os';
 import * as path from 'path';
 
-import { IRegistryReader } from "./IRegistryReader";
 import { CommandExecutor } from '../Utils/CommandExecutor';
+import { CommandExecutorResult } from '../Utils/CommandExecutorResult';
 import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { IUtilityContext } from '../Utils/IUtilityContext';
-import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
-import { CommandExecutorResult } from '../Utils/CommandExecutorResult';
 import { DOTNET_INFORMATION_CACHE_DURATION_MS } from './CacheTimeConstants';
+import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
+import { IRegistryReader } from "./IRegistryReader";
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
@@ -63,11 +63,11 @@ export class RegistryReader extends IRegistryReader
             // Output is of the type
             // REGISTRY_KEY
             // Key   REG_SZ    C:\path\to\dotnet
-            let keyRow = result.stdout?.trim()?.split("\n")?.at(1)?.trim(); // Get the line that contains Key REG_SZ Path
+            let keyRow = result.stdout?.trim()?.split("\n")?.[1]?.trim(); // Get the line that contains Key REG_SZ Path
             if (!keyRow)
             {
                 // If there's an extra newline in the output or reg.exe format changes, find the line which contains the key -- slower
-                keyRow = result.stdout?.trim()?.split("\n")?.filter((x) => x.toLowerCase().includes('path') || x.toLowerCase().includes('installlocation'))?.at(0)?.trim();
+                keyRow = result.stdout?.trim()?.split("\n")?.filter((x) => x.toLowerCase().includes('path') || x.toLowerCase().includes('installlocation'))?.[0]?.trim();
             }
             const finalPath = keyRow?.split(' ')?.filter((x: any) => x !== '')?.slice(2)?.join(' '); // remove N (typically 4) spaces between each output, then remove the ''s, then split by space again to remove Key and REG_SZ, and recombine any path with spaces
             return finalPath

--- a/vscode-dotnet-runtime-library/src/Acquisition/VersionUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/VersionUtilities.ts
@@ -3,9 +3,9 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
 
-import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IEventStream } from '../EventStream/EventStream';
-import {
+import
+{
     DotnetFeatureBandDoesNotExistError,
     DotnetInvalidRuntimePatchVersion,
     DotnetVersionParseEvent,
@@ -14,6 +14,7 @@ import {
     FeatureBandDoesNotExist
 } from '../EventStream/EventStreamEvents';
 import { getInstallFromContext } from '../Utils/InstallIdUtilities';
+import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 
 const invalidFeatureBandErrorString = `A feature band couldn't be determined for the requested version: `;
 
@@ -22,7 +23,7 @@ const invalidFeatureBandErrorString = `A feature band couldn't be determined for
  * @param fullySpecifiedVersion the fully specified version of the sdk, e.g. 7.0.301 to get the major from.
  * @returns the major in the form of '3', etc.
  */
-export function getMajor(fullySpecifiedVersion : string, eventStream : IEventStream, context : IAcquisitionWorkerContext) : string
+export function getMajor(fullySpecifiedVersion: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): string
 {
     // The called function will check that we can do the split, so we don't need to check again.
     return getMajorMinor(fullySpecifiedVersion, eventStream, context).split('.')[0];
@@ -33,7 +34,7 @@ export function getMajor(fullySpecifiedVersion : string, eventStream : IEventStr
  * @param fullySpecifiedVersion the fully specified version of the sdk, e.g. 7.0.301 to get the minor from.
  * @returns the major.minor in the form of '0', etc.
  */
-export function getMinor(fullySpecifiedVersion : string, eventStream : IEventStream, context : IAcquisitionWorkerContext) : string
+export function getMinor(fullySpecifiedVersion: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): string
 {
     // The called function will check that we can do the split, so we don't need to check again.
     return getMajorMinor(fullySpecifiedVersion, eventStream, context).split('.')[1];
@@ -45,9 +46,9 @@ export function getMinor(fullySpecifiedVersion : string, eventStream : IEventStr
  * @param fullySpecifiedVersion the fully specified version, e.g. 7.0.301 to get the major minor from.
  * @returns the major.minor in the form of '3.1', etc.
  */
-export function getMajorMinor(fullySpecifiedVersion : string, eventStream : IEventStream, context : IAcquisitionWorkerContext) : string
+export function getMajorMinor(fullySpecifiedVersion: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): string
 {
-    if(fullySpecifiedVersion.split('.').length < 2)
+    if (fullySpecifiedVersion.split('.').length < 2)
     {
         const event = new DotnetVersionResolutionError(new EventCancellationError('DotnetVersionResolutionError',
             `The requested version ${fullySpecifiedVersion} is invalid.`),
@@ -66,12 +67,12 @@ export function getMajorMinor(fullySpecifiedVersion : string, eventStream : IEve
  * @returns a single string representing the band number, e.g. 3 in 7.0.301.
  * @remarks can return '' if no band exists in the fully specified version, and if considerErrorIfNoBand is false.
  */
-export function getFeatureBandFromVersion(fullySpecifiedVersion : string, eventStream : IEventStream, context : IAcquisitionWorkerContext, considerErrorIfNoBand = true) : string
+export function getFeatureBandFromVersion(fullySpecifiedVersion: string, eventStream: IEventStream, context: IAcquisitionWorkerContext, considerErrorIfNoBand = true): string
 {
-    const band : string | undefined = fullySpecifiedVersion.split('.')?.at(2)?.charAt(0);
-    if(band === undefined)
+    const band: string | undefined = fullySpecifiedVersion.split('.')?.[2]?.charAt(0);
+    if (band === undefined)
     {
-        if(considerErrorIfNoBand)
+        if (considerErrorIfNoBand)
         {
             const event = new DotnetFeatureBandDoesNotExistError(new EventCancellationError('DotnetFeatureBandDoesNotExistError', `${invalidFeatureBandErrorString}${fullySpecifiedVersion}.`),
                 getInstallFromContext(context));
@@ -92,7 +93,7 @@ export function getFeatureBandFromVersion(fullySpecifiedVersion : string, eventS
  * @returns a single string representing the band patch version, e.g. 12 in 7.0.312.
  * @remarks can return '' if no band exists in the fully specified version, and if considerErrorIfNoBand is false.
  */
-export function getFeatureBandPatchVersion(fullySpecifiedVersion : string, eventStream : IEventStream, context : IAcquisitionWorkerContext, considerErrorIfNoBand = true) : string
+export function getFeatureBandPatchVersion(fullySpecifiedVersion: string, eventStream: IEventStream, context: IAcquisitionWorkerContext, considerErrorIfNoBand = true): string
 {
     return Number(getSDKPatchVersionString(fullySpecifiedVersion, eventStream, context, considerErrorIfNoBand)).toString();
 }
@@ -103,12 +104,12 @@ export function getFeatureBandPatchVersion(fullySpecifiedVersion : string, event
  * Can return '' if no band exists in the fully specified version, and if considerErrorIfNoBand is false.
  * Not meant for public use.
  */
-export function getSDKPatchVersionString(fullySpecifiedVersion : string, eventStream : IEventStream, context : IAcquisitionWorkerContext, considerErrorIfNoBand = true) : string
+export function getSDKPatchVersionString(fullySpecifiedVersion: string, eventStream: IEventStream, context: IAcquisitionWorkerContext, considerErrorIfNoBand = true): string
 {
-    const patch : string | undefined = fullySpecifiedVersion.split('.')?.at(2)?.substring(1)?.split('-')?.at(0);
-    if(patch === undefined || !isNumber(patch))
+    const patch: string | undefined = fullySpecifiedVersion.split('.')?.[2]?.substring(1)?.split('-')?.[0];
+    if (patch === undefined || !isNumber(patch))
     {
-        if(considerErrorIfNoBand)
+        if (considerErrorIfNoBand)
         {
             const event = new DotnetFeatureBandDoesNotExistError(new EventCancellationError('DotnetFeatureBandDoesNotExistError',
                 `${invalidFeatureBandErrorString}${fullySpecifiedVersion}.`),
@@ -130,7 +131,7 @@ export function getSDKPatchVersionString(fullySpecifiedVersion : string, eventSt
  * @returns a single string representing the band and patch version, e.g. 312 in 7.0.312.
  * Returns null if the string is not fully specified.
  */
-export function getSDKCompleteBandAndPatchVersionString(fullySpecifiedVersion : string, eventStream : IEventStream, context : IAcquisitionWorkerContext) : string | null
+export function getSDKCompleteBandAndPatchVersionString(fullySpecifiedVersion: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): string | null
 {
     try
     {
@@ -138,7 +139,7 @@ export function getSDKCompleteBandAndPatchVersionString(fullySpecifiedVersion : 
         const patch = getSDKPatchVersionString(fullySpecifiedVersion, eventStream, context, false);
         return `${band}${patch}`;
     }
-    catch ( error : any )
+    catch (error: any)
     {
         // Catch failure for when version does not include a band, etc
     }
@@ -151,10 +152,10 @@ export function getSDKCompleteBandAndPatchVersionString(fullySpecifiedVersion : 
  * Needs to handle 8, 8.0, etc. This is why we don't use semver. We don't error if there isn't a patch but we should if the patch is invalid.
  * Returns null if no patch is in the string (e.g. 8.0).
  */
-export function getRuntimePatchVersionString(fullySpecifiedVersion : string, eventStream : IEventStream, context : IAcquisitionWorkerContext) : string | null
+export function getRuntimePatchVersionString(fullySpecifiedVersion: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): string | null
 {
-    const patch : string | undefined = fullySpecifiedVersion.split('.')?.at(2)?.split('-')?.at(0);
-    if(patch && !isNumber(patch))
+    const patch: string | undefined = fullySpecifiedVersion.split('.')?.[2]?.split('-')?.[0];
+    if (patch && !isNumber(patch))
     {
         const event = new DotnetInvalidRuntimePatchVersion(new EventCancellationError('DotnetInvalidRuntimePatchVersion',
             `The runtime patch version ${patch} from ${fullySpecifiedVersion} is NaN.`),
@@ -170,23 +171,23 @@ export function getRuntimePatchVersionString(fullySpecifiedVersion : string, eve
  * @param fullySpecifiedVersion the requested version to analyze.
  * @returns true IFF version is of an expected length and format.
  */
-export function isValidLongFormVersionFormat(fullySpecifiedVersion : string, eventStream : IEventStream, context : IAcquisitionWorkerContext) : boolean
+export function isValidLongFormVersionFormat(fullySpecifiedVersion: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): boolean
 {
     const numberOfPeriods = fullySpecifiedVersion.split('.').length - 1;
     // 9 is used to prevent bad versions (current expectation is 7 but we want to support .net 10 etc)
-    if(numberOfPeriods === 2 && fullySpecifiedVersion.length < 11)
+    if (numberOfPeriods === 2 && fullySpecifiedVersion.length < 11)
     {
-    if(isNonSpecificFeatureBandedVersion(fullySpecifiedVersion) ||
-        (
-            getSDKPatchVersionString(fullySpecifiedVersion, eventStream, context).length <= 2 &&
-            getSDKPatchVersionString(fullySpecifiedVersion, eventStream, context).length > 1
+        if (isNonSpecificFeatureBandedVersion(fullySpecifiedVersion) ||
+            (
+                getSDKPatchVersionString(fullySpecifiedVersion, eventStream, context).length <= 2 &&
+                getSDKPatchVersionString(fullySpecifiedVersion, eventStream, context).length > 1
+            )
         )
-    )
-    {
-        return true;
-    }
+        {
+            return true;
+        }
 
-    eventStream.post(new DotnetVersionParseEvent(`The version has a bad patch number: ${fullySpecifiedVersion}`));
+        eventStream.post(new DotnetVersionParseEvent(`The version has a bad patch number: ${fullySpecifiedVersion}`));
     }
 
     eventStream.post(new DotnetVersionParseEvent(`The version has more or less than two periods, or it is too long: ${fullySpecifiedVersion}`));
@@ -198,7 +199,7 @@ export function isValidLongFormVersionFormat(fullySpecifiedVersion : string, eve
  * @param fullySpecifiedVersion the requested version to analyze.
  * @returns true IFF version is of an rc, preview, internal build, etc.
  */
-export function isPreviewVersion(fullySpecifiedVersion : string, eventStream : IEventStream, context : IAcquisitionWorkerContext) : boolean
+export function isPreviewVersion(fullySpecifiedVersion: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): boolean
 {
     return fullySpecifiedVersion.includes('-');
 }
@@ -208,7 +209,7 @@ export function isPreviewVersion(fullySpecifiedVersion : string, eventStream : I
  * @param version the requested version to analyze.
  * @returns true IFF version is a feature band with an unspecified sub-version was given e.g. 6.0.4xx or 6.0.40x
  */
-export function isNonSpecificFeatureBandedVersion(version : string) : boolean
+export function isNonSpecificFeatureBandedVersion(version: string): boolean
 {
     const numberOfPeriods = version.split('.').length - 1;
     return version.split('.').slice(0, 2).every(x => isNumber(x)) && version.endsWith('x') && numberOfPeriods === 2;
@@ -219,7 +220,7 @@ export function isNonSpecificFeatureBandedVersion(version : string) : boolean
  * @param version the requested version to analyze.
  * @returns true IFF version is a specific version e.g. 7.0.301.
  */
-export function isFullySpecifiedVersion(version : string, eventStream : IEventStream, context : IAcquisitionWorkerContext) : boolean
+export function isFullySpecifiedVersion(version: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): boolean
 {
     return version.split('.').every(x => isNumber(x)) && isValidLongFormVersionFormat(version, eventStream, context) && !isNonSpecificFeatureBandedVersion(version);
 }
@@ -229,7 +230,7 @@ export function isFullySpecifiedVersion(version : string, eventStream : IEventSt
  * @param version the requested version to analyze.
  * @returns true IFF a major release represented as an integer was given. e.g. 6, which we convert to 6.0, OR a major minor was given, e.g. 6.1.
  */
-export function isNonSpecificMajorOrMajorMinorVersion(version : string) : boolean
+export function isNonSpecificMajorOrMajorMinorVersion(version: string): boolean
 {
     const numberOfPeriods = version.split('.').length - 1;
     return isNumber(version) && numberOfPeriods >= 0 && numberOfPeriods < 2;

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -436,7 +436,7 @@ ${stderr}`));
         {
             const { env, ...optionsWithoutEnv } = options;
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            this.context?.eventStream.post(new CommandExecutionEvent(`Executing command ${fullCommandString} with options ${JSON.stringify(options.env !== null && options.env !== undefined ? { env: minimizeEnvironment(env), ...optionsWithoutEnv } : options)}.`));
+            this.context?.eventStream.post(new CommandExecutionEvent(`Executing command ${fullCommandString} with options ${JSON.stringify(options?.env !== null && options?.env !== undefined ? { env: minimizeEnvironment(env), ...optionsWithoutEnv } : options)}.`));
 
             if (command.runUnderSudo)
             {
@@ -561,7 +561,7 @@ Please report this at https://github.com/dotnet/vscode-dotnet-runtime/issues.`),
             try
             {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                const cmdFoundOutput = (await this.execute(command, options?.at(optIdx) ?? options, false)).status;
+                const cmdFoundOutput = (await this.execute(command, options?.[optIdx] ?? options, false)).status;
                 if (cmdFoundOutput === '0')
                 {
                     workingCommand = command;

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
@@ -47,7 +47,7 @@ suite('DotnetPathFinder Unit Tests', function ()
             const result = await finder.findHostInstallPaths(os.arch());
 
             assert.isTrue(result !== undefined, 'The dotnet path finder found a dotnet path');
-            assert.equal(result?.at(0), path.join(fakeDotnetPath, 'dotnet'), 'The correct path is found');
+            assert.equal(result?.[0], path.join(fakeDotnetPath, 'dotnet'), 'The correct path is found');
         } // Windows and other lookup is covered in the registryReader or the runtime extension functional test
     }).timeout(10000 * 2);
 
@@ -66,7 +66,7 @@ suite('DotnetPathFinder Unit Tests', function ()
             const result = await finder.findHostInstallPaths(os.arch());
 
             assert.isTrue(result !== undefined, 'The dotnet path finder found a dotnet path');
-            assert.equal(result?.at(0), path.join(fakeDotnetPath, 'dotnet'), 'The correct path is found');
+            assert.equal(result?.[0], path.join(fakeDotnetPath, 'dotnet'), 'The correct path is found');
         }
     });
 });


### PR DESCRIPTION
Callers may try to find --list-runtimes with an empty string, especially if the existingPath setting is empty, which can return '""' instead of ''. This is a performance improvement.

In addition, it looks like a recent change I did break some of the logic to find a working command. options?.at() is not valid when options is not provided as an array because it is  an object type. [] indexing does the same thing and is safer, as indexing on an object will just return undefined, unless it has a '0' key, but that is never expected here.