### PR TITLE
Fix Proxy Lookup

### DIFF
--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning].
 ## [2.3.1] - 2025-4-7
 
 - Update Axios-Cache-Interceptor and Axios to help avoid possibly Invalid Url issues.
+- Fixes Proxy Lookup to prevent Invalid Url Issues.
 - Adds an alternative fetch request mechanism to rely on the native library without axios if Axios fails.
+- Performance improvements and optimizations.
+- Collects less information in the user log.
+- Fixes installation issues with Linux, especially on Ubuntu 24.04.
 
 ## [2.3.0] - 2025-3-25
 

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -958,6 +958,11 @@ export class EmptyDirectoryToWipe extends DotnetCustomMessageEvent
     public readonly eventName = 'EmptyDirectoryToWipe';
 }
 
+export class ProxyUsed extends DotnetCustomMessageEvent
+{
+    public readonly eventName = 'ProxyUsed';
+}
+
 export class FileToWipe extends DotnetCustomMessageEvent
 {
     public readonly eventName = 'FileToWipe';

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorkerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorkerSingleton.ts
@@ -335,7 +335,7 @@ export class WebRequestWorkerSingleton
 
             if (this.proxySettingConfiguredManually(ctx) || discoveredProxy)
             {
-                const finalProxy = ctx?.proxyUrl && ctx?.proxyUrl !== '""' ? ctx.proxyUrl : discoveredProxy;
+                const finalProxy = ctx?.proxyUrl && ctx?.proxyUrl !== '""' && ctx?.proxyUrl !== '' ? ctx.proxyUrl : discoveredProxy;
                 ctx.eventStream.post(new ProxyUsed(`Utilizing the Proxy : Manual ? ${ctx?.proxyUrl}, Automatic: ${discoveredProxy}, Decision : ${finalProxy}`))
                 const proxyAgent = new HttpsProxyAgent(finalProxy);
                 return proxyAgent;

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorkerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorkerSingleton.ts
@@ -37,6 +37,7 @@ import
     EventBasedError,
     EventCancellationError,
     OfflineDetectionLogicTriggered,
+    ProxyUsed,
     SuppressedAcquisitionError,
     WebRequestCachedTime,
     WebRequestError,
@@ -316,10 +317,10 @@ export class WebRequestWorkerSingleton
 
     private async GetProxyAgentIfNeeded(ctx: IAcquisitionWorkerContext): Promise<HttpsProxyAgent<string> | null>
     {
-        let discoveredProxy = '';
-        if (!this.proxySettingConfiguredManually(ctx))
+        try
         {
-            try
+            let discoveredProxy = '';
+            if (!this.proxySettingConfiguredManually(ctx))
             {
                 const autoDetectProxies = await getProxySettings();
                 if (autoDetectProxies?.https)
@@ -331,16 +332,18 @@ export class WebRequestWorkerSingleton
                     discoveredProxy = autoDetectProxies.http.toString();
                 }
             }
-            catch (error: any)
+
+            if (this.proxySettingConfiguredManually(ctx) || discoveredProxy)
             {
-                ctx.eventStream.post(new SuppressedAcquisitionError(error, `The proxy lookup failed, most likely due to limited registry access. Skipping automatic proxy lookup.`));
+                const finalProxy = ctx?.proxyUrl && ctx?.proxyUrl !== '""' ? ctx.proxyUrl : discoveredProxy;
+                ctx.eventStream.post(new ProxyUsed(`Utilizing the Proxy : Manual ? ${ctx?.proxyUrl}, Automatic: ${discoveredProxy}, Decision : ${finalProxy}`))
+                const proxyAgent = new HttpsProxyAgent(finalProxy);
+                return proxyAgent;
             }
         }
-
-        if (this.proxySettingConfiguredManually(ctx) || discoveredProxy)
+        catch (error: any)
         {
-            const proxyAgent = new HttpsProxyAgent(ctx.proxyUrl ?? discoveredProxy);
-            return proxyAgent;
+            ctx.eventStream.post(new SuppressedAcquisitionError(error, `The proxy lookup failed, most likely due to limited registry access. Skipping automatic proxy lookup.`));
         }
 
         return null;
@@ -479,7 +482,7 @@ If you're on a proxy and disable registry access, you must set the proxy in our 
 
     private proxySettingConfiguredManually(ctx: IAcquisitionWorkerContext): boolean
     {
-        return ctx?.proxyUrl ? true : false;
+        return ctx?.proxyUrl ? ctx?.proxyUrl !== '""' : false;
     }
 
     private timeoutMsFromCtx(ctx: IAcquisitionWorkerContext): number


### PR DESCRIPTION
The old lookup was as follows:
`ctx?.proxyUrl ?? configuredProxy`.

But `??` does not evaluate truthfulness. It evaluates nullness. '' is false but it is not null. The default empty value option for getting the string setting is '' or '""'. Setting this to the proxy agent will make it so it never finds the user setting and it will also make it fail: https://github.com/search?q=repo%3ATooTallNate%2Fproxy-agents%20invalid%20url&type=code

And it wasn't in the try block, as this is a best effort approach it should be.