### PR TITLE
Implement Node Mutex

### DIFF
--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "sample-extension",
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "sample-extension",
-			"version": "2.3.1",
+			"version": "2.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"@vscode/vsce": "^2.19.0",
@@ -32,7 +32,8 @@
 			}
 		},
 		"../vscode-dotnet-runtime-extension": {
-			"version": "2.3.1",
+			"name": "vscode-dotnet-runtime",
+			"version": "2.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/chai-as-promised": "^7.1.8",
@@ -93,7 +94,6 @@
 				"mocha": "^9.1.3",
 				"node-cache": "^5.1.2",
 				"open": "^8.4.0",
-				"proper-lockfile": "^4.1.2",
 				"rimraf": "3.0.2",
 				"run-script-os": "^1.1.6",
 				"semver": "^7.6.2",
@@ -114,6 +114,7 @@
 			}
 		},
 		"../vscode-dotnet-sdk-extension": {
+			"name": "vscode-dotnet-sdk",
 			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -2304,7 +2304,6 @@
     "mocha" "^9.1.3"
     "node-cache" "^5.1.2"
     "open" "^8.4.0"
-    "proper-lockfile" "^4.1.2"
     "rimraf" "3.0.2"
     "run-script-os" "^1.1.6"
     "semver" "^7.6.2"

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -67,7 +67,6 @@
                 "mocha": "^9.1.3",
                 "node-cache": "^5.1.2",
                 "open": "^8.4.0",
-                "proper-lockfile": "^4.1.2",
                 "rimraf": "3.0.2",
                 "run-script-os": "^1.1.6",
                 "semver": "^7.6.2",

--- a/vscode-dotnet-runtime-extension/yarn.lock
+++ b/vscode-dotnet-runtime-extension/yarn.lock
@@ -2089,7 +2089,6 @@
     "mocha" "^9.1.3"
     "node-cache" "^5.1.2"
     "open" "^8.4.0"
-    "proper-lockfile" "^4.1.2"
     "rimraf" "3.0.2"
     "run-script-os" "^1.1.6"
     "semver" "^7.6.2"

--- a/vscode-dotnet-runtime-library/.vscode/settings.json
+++ b/vscode-dotnet-runtime-library/.vscode/settings.json
@@ -19,7 +19,8 @@
         "pkexec",
         "REGHEXVALUE",
         "REGTYPE",
-        "setx"
+        "setx",
+        "vscd"
     ],
     // Formatting on save
     "editor.formatOnSave": true,

--- a/vscode-dotnet-runtime-library/package-lock.json
+++ b/vscode-dotnet-runtime-library/package-lock.json
@@ -31,7 +31,6 @@
 				"mocha": "^9.1.3",
 				"node-cache": "^5.1.2",
 				"open": "^8.4.0",
-				"proper-lockfile": "^4.1.2",
 				"rimraf": "3.0.2",
 				"run-script-os": "^1.1.6",
 				"semver": "^7.6.2",
@@ -1223,12 +1222,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/graceful-fs": {
-			"version": "4.2.11",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
-			"license": "ISC"
-		},
 		"node_modules/growl": {
 			"version": "1.10.5",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/growl/-/growl-1.10.5.tgz",
@@ -2017,17 +2010,6 @@
 			"integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
 			"license": "MIT"
 		},
-		"node_modules/proper-lockfile": {
-			"version": "4.1.2",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-			"integrity": "sha1-yLneKvay8WAQZ/mOAaxmuqIjFB8=",
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.4",
-				"retry": "^0.12.0",
-				"signal-exit": "^3.0.2"
-			}
-		},
 		"node_modules/proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proto-list/-/proto-list-1.2.4.tgz",
@@ -2136,15 +2118,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/retry": {
-			"version": "0.12.0",
-			"resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"node_modules/rimraf": {

--- a/vscode-dotnet-runtime-library/package.json
+++ b/vscode-dotnet-runtime-library/package.json
@@ -52,7 +52,6 @@
 		"mocha": "^9.1.3",
 		"node-cache": "^5.1.2",
 		"open": "^8.4.0",
-		"proper-lockfile": "^4.1.2",
 		"rimraf": "3.0.2",
 		"run-script-os": "^1.1.6",
 		"semver": "^7.6.2",

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -57,7 +57,7 @@ You will need to restart VS Code after these changes. If PowerShell is still not
 
     public async installDotnet(installationContext: IDotnetInstallationContext, installObj: DotnetInstall): Promise<void>
     {
-        return executeWithLock(this.eventStream, false, `${path.resolve(installationContext.installDir)}.lock`,
+        return executeWithLock(this.eventStream, false, installObj.installId,
             LOCAL_LOCK_PING_DURATION_MS, installationContext.timeoutSeconds * 1000,
             async (installContext: IDotnetInstallationContext, install: DotnetInstall) =>
             {

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
@@ -160,13 +160,7 @@ export class InstallTrackerSingleton
 
     private getLockFilePathForKey(provider: IInstallationDirectoryProvider, dataKey: string): string
     {
-        const providerPath = provider.getInstallDir('foo');
-        const hasNumber = /\d/;
-
-        const dir = hasNumber.test(providerPath) ? path.dirname(providerPath) : providerPath; // bad codependency I dont want to untangle atm : sdk local itnstall providers dont create a separate folder, runtime ones do
-        // but installing state should be at the root folder (not trustable from __dirname and can't access vscode storage folder) ... so if the folder is like 8.0 or 8.0~aspnetcore~x64 e go up to root
-
-        return path.join(dir, `${dataKey}.lock`); // install object required but we call the dir of it
+        return `${dataKey}.lock`;
     }
 
     /**

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
@@ -160,7 +160,7 @@ export class InstallTrackerSingleton
 
     private getLockFilePathForKey(provider: IInstallationDirectoryProvider, dataKey: string): string
     {
-        return `${dataKey}.lock`;
+        return `${dataKey}Lk`;
     }
 
     /**

--- a/vscode-dotnet-runtime-library/src/Acquisition/StringConstants.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/StringConstants.ts
@@ -14,12 +14,12 @@ import { IInstallationDirectoryProvider } from './IInstallationDirectoryProvider
 */
 export function GLOBAL_INSTALL_STATE_MODIFIER_LOCK(directoryProvider: IInstallationDirectoryProvider, install: DotnetInstall): string
 {
-    return 'modifyingGlobalState.lock';
+    return 'vscdGlLk';
 }
 
 export function RUN_UNDER_SUDO_LOCK(sudoDirectory: string): string
 {
-    return 'runUnderSudo.lock';
+    return 'vscdSudoLk';
 }
 
 export const UNABLE_TO_ACQUIRE_GLOBAL_LOCK_ERR = '898998';

--- a/vscode-dotnet-runtime-library/src/Acquisition/StringConstants.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/StringConstants.ts
@@ -3,7 +3,6 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import { DotnetInstall } from './DotnetInstall';
 import { IInstallationDirectoryProvider } from './IInstallationDirectoryProvider';
 
@@ -15,12 +14,12 @@ import { IInstallationDirectoryProvider } from './IInstallationDirectoryProvider
 */
 export function GLOBAL_INSTALL_STATE_MODIFIER_LOCK(directoryProvider: IInstallationDirectoryProvider, install: DotnetInstall): string
 {
-    return path.join(path.resolve(directoryProvider.getInstallDir(install.installId)), 'modifyingGlobalState.lock');
+    return 'modifyingGlobalState.lock';
 }
 
 export function RUN_UNDER_SUDO_LOCK(sudoDirectory: string): string
 {
-    return path.join(sudoDirectory, 'runUnderSudo.lock');
+    return 'runUnderSudo.lock';
 }
 
 export const UNABLE_TO_ACQUIRE_GLOBAL_LOCK_ERR = '898998';

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -1561,6 +1561,11 @@ export abstract class DotnetLockEvent extends DotnetFileEvent
     }
 }
 
+export class GenericDotnetLockEvent extends DotnetLockEvent
+{
+    public readonly eventName = 'GenericDotnetLockEvent';
+}
+
 export class DotnetLockAcquiredEvent extends DotnetLockEvent
 {
     public readonly eventName = 'DotnetLockAcquiredEvent';

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -1557,7 +1557,7 @@ export abstract class DotnetLockEvent extends DotnetFileEvent
 
     public getProperties()
     {
-        return { Message: this.eventMessage, Time: this.time, Lock: this.lock, File: this.file };
+        return { Message: this.eventMessage, Time: this.time, Lock: this.lock, File: this.file, ...getDisabledTelemetryOnChance(1) };
     }
 }
 

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -1566,49 +1566,6 @@ export class GenericDotnetLockEvent extends DotnetLockEvent
     public readonly eventName = 'GenericDotnetLockEvent';
 }
 
-export class DotnetLockAcquiredEvent extends DotnetLockEvent
-{
-    public readonly eventName = 'DotnetLockAcquiredEvent';
-
-    public getProperties()
-    {
-        return { suppressTelemetry: 'true', ...super.getProperties() };
-    }
-}
-
-export class DotnetLockReleasedEvent extends DotnetLockEvent
-{
-    public readonly eventName = 'DotnetLockReleasedEvent';
-
-    public getProperties()
-    {
-        return { suppressTelemetry: 'true', ...super.getProperties() };
-    }
-}
-
-export class DotnetLockErrorEvent extends DotnetLockEvent
-{
-    public readonly eventName = 'DotnetLockErrorEvent';
-    constructor(public readonly error: Error,
-        public readonly eventMessage: string, public readonly time: string, public readonly lock: string, public readonly file: string) { super(eventMessage, time, lock, file); }
-
-    public getProperties()
-    {
-        return { Error: this.error.toString(), Message: this.eventMessage, Time: this.time, Lock: this.lock, File: this.file };
-    }
-
-}
-
-export class DotnetLockAttemptingAcquireEvent extends DotnetLockEvent
-{
-    public readonly eventName = 'DotnetLockAttemptingAcquireEvent';
-
-    public getProperties()
-    {
-        return { suppressTelemetry: 'true', ...super.getProperties() };
-    }
-}
-
 export class DotnetFileWriteRequestEvent extends DotnetFileEvent
 {
     public readonly eventName = 'DotnetFileWriteRequestEvent';

--- a/vscode-dotnet-runtime-library/src/Utils/LockUsedByThisInstanceSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/LockUsedByThisInstanceSingleton.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as path from 'path';
-
 export class LockUsedByThisInstanceSingleton
 {
     protected static instance: LockUsedByThisInstanceSingleton;
@@ -26,14 +24,6 @@ export class LockUsedByThisInstanceSingleton
         }
 
         return LockUsedByThisInstanceSingleton.instance;
-    }
-
-    public hasVsCodeInstanceInteractedWithLock(lockKey: string): boolean
-    {
-        lockKey = path.basename(lockKey).trim();
-        const hasInteracted = this.lockStringAndThisVsCodeInstanceOwnsIt[lockKey] === true;
-        this.lockStringAndThisVsCodeInstanceOwnsIt[lockKey] = true; // This could be a set but this is also fine
-        return hasInteracted;
     }
 
     public hasSpawnedSudoSuccessfullyWithoutDeath(): boolean
@@ -72,6 +62,4 @@ export class LockUsedByThisInstanceSingleton
     {
         this.sudoError = err;
     }
-
-
 }

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -249,6 +249,7 @@ export class NodeIPCMutex
         }
         catch (error: any)
         {
+            this.logger.log(`Failed to remove stale lock: ${JSON.stringify(error ?? '')}.`);
             if (os.platform() !== 'win32')
             {
                 throw error; // We don't have permission to remove the lock, and it is owned by a dead process. We can't acquire it, so there's not much else we can do.

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -1,0 +1,249 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+import * as os from 'os';
+import * as path from 'path';
+import { createServer, createConnection, Server } from 'net';
+import { rm } from 'fs/promises';
+import * as fs from 'fs';
+
+/**
+ * A wrapper you write around your logger so that events from the mutex ownership can be logged.
+ */
+export class INodeIPCMutexLogger
+{
+    public log(message: string): void
+    {
+        console.log(message); // Replace with your own logging implementation.
+    }
+}
+
+/**
+ * NodeIPCMutex is a class that provides a mutex (mutual exclusion) lock using IPC (Inter-Process Communication) on Node.js.
+ * It will work across multiple processes and async code in the same process.
+ * It uses a named pipe on Windows and a file descriptor on Linux and OS X to create the lock.
+ *
+ * Many locking mechanisms such as lockfile and proper-lockfile run into issues when processes are killed or die unexpectedly, because they rely on the file system.
+ * windows-mutex is another library, which is a wrapper around a C mutex, however it is Windows only.
+ * async-mutex is another node.js library, but it stores a list of owners in memory, which may cause issues if multiple processes try to acquire the same lock.
+ * Named pipes on windows die when processes die. There is no equivalent check on Linux or OS X, but IPC allows us to check whether the process is still alive or not so we don't deadlock
+ *
+ * Much of this code is inspired by VSCode's IPC code, which is a well tested approach. However, their approach focuses on permitting only one main VS Code Process to run at a time.
+ * https://github.com/microsoft/vscode/blob/main/extensions/git/src/ipc/ipcServer.ts#L15
+ * https://github.com/microsoft/vscode/blob/main/src/vs/code/electron-main/main.ts#L318
+ */
+export class NodeIPCMutex
+{
+    private lockPath: string;
+    private server?: Server;
+
+    /**
+     *
+     * @param lockId - The ID of the lock. This should be a unique identifier for the lock being created.
+     * @param logger - A custom logger for your own logging events. By default, this will log to the console.
+     */
+    constructor(lockId: string, readonly logger: INodeIPCMutexLogger = new INodeIPCMutexLogger())
+    {
+        this.lockPath = this.getIPCHandlePath(lockId);
+    }
+
+    private getIPCHandlePath(id: string): string
+    {
+        // The windows file system default length may cause us to fail to create the handle if we don't truncate it.
+        if (id.length > (256 - `\\\\.\\pipe\\vscode-dotnet-install-tool-`.length))
+        {
+            id = id.substring(0, 255);
+        }
+
+        if (process.platform === 'win32')
+        {
+            // Special File System to get a Named Pipe on windows (File Descriptors won't work) : https://nodejs.org/docs/latest/api/net.html#ipc-support:~:text=On%20Windows%2C%20the,owning%20process%20exits.
+            return `\\\\.\\pipe\\vscode-dotnet-install-tool-${id}-sock`;
+        }
+
+        if (process.platform !== 'darwin' && process.env['XDG_RUNTIME_DIR'])
+        {
+            // The user or system told us to use this as our applications temporary directory, so this this instead of /temp/
+            return path.join(process.env['XDG_RUNTIME_DIR'] as string, `vscode-dotnet-install-tool-${id}.sock`);
+        }
+
+        // A file descriptor in /temp/ is a good option to hold this sock.
+        // Access to /tmp/ may be restricted, but all processes must use the same directory, we can't really condition on this.
+        return path.join(os.tmpdir(), `vscode-dotnet-install-tool-${id}.sock`);
+    }
+
+    /**
+     * @remarks This function will try to hold a lock to prevent both other processes and other async code in this processes from running simultaneously..
+     * It will retry acquiring the lock if it is already held by another process or async code in this process.
+     * It will also check if the lock is stale (i.e., if the process holding the lock has died) and clean it up if necessary.
+     * It will fail and throw if it cannot acquire the lock after the specified number of retries.
+     *
+     * @param fn - The function to run while we have the lock. This should be a promise, and will be awaited with its value returned.
+     * Use the () => {} syntax to ensure your scope is correctly bound to the function so it can access the variables you declare.
+     * @param retryDelayMs The number of milliseconds to wait before retrying to acquire the lock if it is already held by another process.
+     * @param timeoutTimeMs The total amount of time to try to acquire the lock before giving up. This is the maximum time to wait for the lock to be released.
+     * @param actionId The action ID to use for logging and debugging purposes. This should be a unique identifier for the action being performed.
+     * @returns The awaited value returned by the function passed in as fn.
+     */
+    public async acquire<T>(fn: () => Promise<T>, retryDelayMs: number = 100, timeoutTimeMs: number = 1000, actionId: string): Promise<T>
+    {
+        const maxRetries = timeoutTimeMs / retryDelayMs;
+        let retries = 0;
+
+        while (true)
+        {
+            try
+            {
+                return await this.tryAcquire(fn);
+            }
+            catch (error: any)
+            {
+                if (error?.code === 'EADDRINUSE') //  We couldn't acquire the lock, even though nobody else is using it.
+                {
+                    if (retries >= maxRetries)
+                    {
+                        throw new Error(`Failed to acquire lock after ${maxRetries} retries.`);
+                    }
+
+                    if (await this.isLockStale(actionId))
+                    {
+                        await this.cleanupStaleLock();
+                    }
+                    else
+                    {
+                        await this.delay(retryDelayMs);
+                        retries++;
+                    }
+                }
+                else // Another process is using this lock.
+                {
+                    throw error;
+                }
+            }
+        }
+    }
+
+    private async tryAcquire<T>(fn: () => Promise<T>): Promise<T>
+    {
+        return new Promise<T>((resolve, reject) =>
+        {
+            this.server = createServer();
+
+            this.server.on('error', reject);
+            this.server.listen(this.lockPath, async () =>
+            {
+                this.server!.removeListener('error', reject);
+                try
+                {
+                    // Set permissions to allow other processes to access/delete the handle
+                    // On Windows, only write permissions can be changed, but that is OK.
+                    // https://nodejs.org/api/fs.html#filehandlechmodmode:~:text=Caveats%3A%20on%20Windows%20only%20the%20write%20permission%20can%20be%20changed%2C%20and%20the%20distinction%20among%20the%20permissions%20of%20group%2C%20owner%2C%20or%20others%20is%20not%20implemented.
+                    await fs.promises.chmod(this.lockPath, 0o666); // 6 is read/write (not execute) for user, group, and others.
+                }
+                catch (err)
+                {
+                    this.logger.log(`Failed to set permissions on ${this.lockPath}: ${err}`);
+                }
+
+                try
+                {
+                    const returnResult = await fn();
+                    return resolve(returnResult); // Return out, and let the finally logic close the server before we return.
+                }
+                catch (err)
+                {
+                    reject(err);
+                }
+                finally
+                {
+                    this.release(); // Release the lock when done.
+                }
+            });
+        })
+    }
+
+    private release(): void
+    {
+        if (this.server)
+        {
+            this.server.close();
+            // .close() will delete the fd on Linux and OS X, if the process doesn't die, so we don't need to do that again.
+            this.server = undefined;
+        }
+    }
+
+    /**
+     * @remarks A stale lock is a lock that is held by a process that has died or is no longer running.
+     * This function checks if the lock is stale by trying to connect to it.
+     *
+     * @param msg - The message to log if the lock is stale.
+     * @returns True if the lock is stale, false otherwise.
+     */
+    private async isLockStale(msg: string): Promise<boolean>
+    {
+        const resolved = await new Promise<boolean>((resolve, reject) =>
+        {
+            const socket = createConnection(this.lockPath, () =>
+            {
+                socket.removeListener('error', reject); // Ignore other errors : we were able to connect, that's all that matters.
+                this.logger.log(`Connected to existing lock: ${msg}`);
+                socket.destroy();
+                return resolve(false); // Someone else (another PID or other async code in our process) holds the 'lock' or 'server' on the handle and is live. We must wait.
+            });
+
+            socket.once('error', (err) =>
+            {
+                this.logger.log(`Unable to connect to existing lock: ${JSON.stringify(err ?? '')}.`);
+                return resolve(true); // Possible error: ENOENT, if the other process finishes and 'rm's while we wait. It's ok if we consider it stale now, even if it doesnt exist.
+            });
+        })
+            .catch((error: any) => // Handle synchronous errors from the socket connection.
+            {
+                if (os.platform() === 'win32' || error?.code !== 'ECONNREFUSED')
+                {
+                    if (error?.code === 'EPERM')
+                    {
+                        // Another procecss is running as administrator which is blocking us from being able to acquire the lock.
+                        this.logger.log(`Unable to acquire lock: ${msg}. Another process is running as administrator, but we are not.`);
+                        return false; // Let's try again later.
+                    }
+
+                    this.logger.log(`Unable to acquire lock: ${JSON.stringify(error ?? '')}.`);
+                    return false;
+                }
+                if (error?.code === 'ECONNREFUSED') // The process is dead - it may have been pkilled and did not drop the file handle.
+                {
+                    this.logger.log(`Lock is stale, as ECONNREFUSED detected: ${msg}.`);
+                    return (true); // We can acquire the lock, and delete the file handle.
+                }
+
+                this.logger.log(`Unable to acquire lock: ${JSON.stringify(error ?? '')}.`);
+                return false; // We don't know what happened, but we can't acquire the lock.
+            });
+        return resolved;
+    }
+
+    private async cleanupStaleLock(): Promise<void>
+    {
+        try
+        {
+            // On Linux and OS X the pipe is left behind when a process holding a pipe dies.
+            await rm(this.lockPath, { force: true }); // Remove the lockFile
+        }
+        catch (error: any)
+        {
+            if (os.platform() !== 'win32')
+            {
+                throw error; // We don't have permission to remove the lock, and it is owned by a dead process. We can't acquire it, so there's not much else we can do.
+            }
+        }
+    }
+
+    private async delay(delayMs: number): Promise<void>
+    {
+        // Could implement exponential backoff here if we wanted to.
+        return new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+}
+

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -8,13 +8,13 @@ import * as os from 'os';
 import * as path from 'path';
 
 /**
- * A wrapper you write around your logger so that events from the mutex ownership can be logged.
+ * Customize logging events for the mutex using this interface.
  */
 export class INodeIPCMutexLogger
 {
     public log(message: string): void
     {
-        console.log(message); // Replace with your own logging implementation.
+        // no op
     }
 }
 
@@ -56,7 +56,7 @@ export class NodeIPCMutex
         const lengthLimit = os.platform() === 'win32' ? 256 : 104; // Mac 10.9 and FreeBSD have their own length limit.
 
         // On Unix, A file descriptor in /temp/ is a good option to hold this sock.
-        // In Linux, The user or system may set XDG_RUNTIME_DIR to set our applications temporary directory, so this this instead of /temp/
+        // In Linux, The user or system may set XDG_RUNTIME_DIR to set our applications temporary directory, so use this instead of /temp/
         // On Unix, Access to /tmp/ may be restricted, but all processes must use the same directory, so we can't condition to use another dir based on the permissions for it.
 
         // On Windows, '\\\\.\\pipe\\` is a Special File System to get a Named Pipe (File Descriptors won't work)

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -134,30 +134,32 @@ export class NodeIPCMutex
     {
         return new Promise<T>((resolve, reject) =>
         {
-            this.server = createServer();
-
-            this.server.on('error', reject);
-            // The listeningListener interface is designed to return void, but we need to return the result of running f while holding the handle.
-            // eslint-disable-next-line  @typescript-eslint/no-misused-promises
-            this.server.listen(this.lockPath, async () =>
+            try
             {
-                try
+                this.server = createServer();
+                this.server.on('error', reject);
+                // The listeningListener interface is designed to return void, but we need to return the result of running f while holding the handle.
+                // eslint-disable-next-line  @typescript-eslint/no-misused-promises
+                this.server.listen(this.lockPath, async () =>
                 {
-                    this.server?.removeListener('error', reject);
-                    const returnResult = await fn();
-                    return resolve(returnResult); // Return out, and let the finally logic close the server before we return.
-                }
-                catch (err: any)
-                {
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                    return reject(err?.message && err?.name ? err as Error : new Error(`Failed to acquire lock: ${JSON.stringify(err ?? '')}`));
-                }
-                finally
-                {
-                    this.release(); // Release the lock when done.
-                }
-            });
-        })
+                    try
+                    {
+                        this.server?.removeListener('error', reject);
+                        const returnResult = await fn();
+                        return resolve(returnResult); // Return out, and let the finally logic close the server before we return.
+                    }
+                    catch (err: any)
+                    {
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                        return reject(err?.message && err?.name ? err as Error : new Error(`Failed to acquire lock: ${JSON.stringify(err ?? '')}`));
+                    }
+                });
+            }
+            finally
+            {
+                this.release();
+            }
+        });
     }
 
     private release(): void

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -213,10 +213,16 @@ export class NodeIPCMutex
         {
             const socket = createConnection(this.lockPath, () =>
             {
-                socket.removeListener('error', reject); // Ignore other errors : we were able to connect, that's all that matters.
-                socket.destroy();
-                this.logger.log(`Connected to existing lock: ${msg}`);
-                return resolve(false); // Someone else (another PID or other async code in our process) holds the 'lock' or 'server' on the handle and is live. We must wait.
+                try
+                {
+                    socket.removeListener('error', reject); // Ignore other errors : we were able to connect, that's all that matters.
+                    this.logger.log(`Connected to existing lock: ${msg}`);
+                    return resolve(false); // Someone else (another PID or other async code in our process) holds the 'lock' or 'server' on the handle and is live. We must wait.
+                }
+                finally
+                {
+                    socket.destroy(); // Clean up the socket.
+                }
             });
 
             socket.once('error', (err) =>

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -113,8 +113,8 @@ export class NodeIPCMutex
                     else
                     {
                         await this.delay(retryDelayMs);
-                        retries++;
                     }
+                    ++retries;
                 }
                 else // Another process is using this lock.
                 {

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -111,6 +111,7 @@ export class NodeIPCMutex
                         await this.cleanupStaleLock();
                         if (this.hasCleanedUpBefore)
                         {
+                            this.release(); // On Mac, the server may fail earlier on and stay around? Make sure it is gone.
                             await this.delay(retryDelayMs);
                         }
                         this.hasCleanedUpBefore = true;

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -80,7 +80,7 @@ export class NodeIPCMutex
     }
 
     /**
-     * @remarks This function will try to hold a lock to prevent both other processes and other async code in this processes from running simultaneously..
+     * @remarks This function will try to hold a lock to prevent both other processes and other async code in this processes from running simultaneously.
      * It will retry acquiring the lock if it is already held by another process or async code in this process.
      * It will also check if the lock is stale (i.e., if the process holding the lock has died) and clean it up if necessary.
      * It will fail and throw if it cannot acquire the lock after the specified number of retries.

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -153,7 +153,7 @@ Report this issue to our vscode-dotnet-runtime GitHub for help.`);
             this.server = createServer();
 
             this.server.on('error', reject);
-            // The listeningListener interface is designed to return void, but we need to return the result of running f while holding the handle.
+            // The listeningListener interface is designed to return void, but we need to return the result of running fn while holding the handle.
             // eslint-disable-next-line  @typescript-eslint/no-misused-promises
             this.server.listen(this.lockPath, async () =>
             {

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -36,7 +36,7 @@ export class NodeIPCMutex
 {
     private readonly lockPath: string;
     private server?: Server;
-
+    private hasCleanedUpBefore = false;
     /**
      *
      * @param lockId - The ID of the lock. This should be a unique identifier for the lock being created.
@@ -109,11 +109,17 @@ export class NodeIPCMutex
                     if (await this.isLockStale(actionId))
                     {
                         await this.cleanupStaleLock();
+                        if (this.hasCleanedUpBefore)
+                        {
+                            await this.delay(retryDelayMs);
+                        }
+                        this.hasCleanedUpBefore = true;
                     }
                     else
                     {
                         await this.delay(retryDelayMs);
                     }
+
                     ++retries;
                 }
                 else // Another process is using this lock.

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -134,32 +134,30 @@ export class NodeIPCMutex
     {
         return new Promise<T>((resolve, reject) =>
         {
-            try
+            this.server = createServer();
+
+            this.server.on('error', reject);
+            // The listeningListener interface is designed to return void, but we need to return the result of running f while holding the handle.
+            // eslint-disable-next-line  @typescript-eslint/no-misused-promises
+            this.server.listen(this.lockPath, async () =>
             {
-                this.server = createServer();
-                this.server.on('error', reject);
-                // The listeningListener interface is designed to return void, but we need to return the result of running f while holding the handle.
-                // eslint-disable-next-line  @typescript-eslint/no-misused-promises
-                this.server.listen(this.lockPath, async () =>
+                try
                 {
-                    try
-                    {
-                        this.server?.removeListener('error', reject);
-                        const returnResult = await fn();
-                        return resolve(returnResult); // Return out, and let the finally logic close the server before we return.
-                    }
-                    catch (err: any)
-                    {
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                        return reject(err?.message && err?.name ? err as Error : new Error(`Failed to acquire lock: ${JSON.stringify(err ?? '')}`));
-                    }
-                });
-            }
-            finally
-            {
-                this.release();
-            }
-        });
+                    this.server?.removeListener('error', reject);
+                    const returnResult = await fn();
+                    return resolve(returnResult); // Return out, and let the finally logic close the server before we return.
+                }
+                catch (err: any)
+                {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                    return reject(err?.message && err?.name ? err as Error : new Error(`Failed to acquire lock: ${JSON.stringify(err ?? '')}`));
+                }
+                finally
+                {
+                    this.release(); // Release the lock when done.
+                }
+            });
+        })
     }
 
     private release(): void

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -250,10 +250,6 @@ export class NodeIPCMutex
         catch (error: any)
         {
             this.logger.log(`Failed to remove stale lock: ${JSON.stringify(error ?? '')}.`);
-            if (os.platform() !== 'win32')
-            {
-                throw error; // We don't have permission to remove the lock, and it is owned by a dead process. We can't acquire it, so there's not much else we can do.
-            }
         }
     }
 

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -110,7 +110,14 @@ export class NodeIPCMutex
                 {
                     if (retries >= maxRetryCountToEndAtRoughlyTimeoutTime)
                     {
-                        throw new Error(`Action: ${actionId} Failed to acquire lock after ${retries} retries out of ${maxRetryCountToEndAtRoughlyTimeoutTime} total available attempts.`);
+                        throw new Error(`Action: ${actionId} Failed to acquire lock after ${retries} retries out of ${maxRetryCountToEndAtRoughlyTimeoutTime} total available attempts.
+The lock: ${this.lockPath} may be held by another process or instance of vscode. Try restarting your machine, deleting the lock, and or increasing the timeout time in the extension settings.
+
+Increase your OS path length limit to at least 256 characters.
+On Linux, you can set XDG_RUNTIME_DIR to be a writeable directory by your user.
+
+If you still face issues, set VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX=true in the environment.
+Report this issue to our vscode-dotnet-runtime GitHub for help.`);
                     }
 
                     if (await this.isLockStale(actionId))
@@ -133,14 +140,6 @@ export class NodeIPCMutex
                 }
                 else // Another process is using this lock.
                 {
-                    error.message += `\nAfter ${retries} attempts, we could not acquire the lock ${this.lockPath}.
-It may be held by another process or instance of vscode. Try restarting your machine, deleting the lock, and or increasing the timeout time in the extension settings.
-
-Increase your OS path length limit to at least 256 characters.
-On Linux, you can set XDG_RUNTIME_DIR to be a writeable directory by your user.
-
-If you still face issues, set VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX=true in the environment.
-Report this issue to our vscode-dotnet-runtime GitHub for help.`;
                     throw error;
                 }
             }

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -2,7 +2,6 @@
 *  Licensed to the .NET Foundation under one or more agreements.
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
-import * as fs from 'fs';
 import { rm } from 'fs/promises';
 import { createConnection, createServer, Server } from 'net';
 import * as os from 'os';
@@ -139,17 +138,6 @@ export class NodeIPCMutex
                 try
                 {
                     this.server?.removeListener('error', reject);
-                    try
-                    {
-                        // Set permissions to allow other processes to access/delete the handle
-                        // On Windows, only write permissions can be changed, but that is OK.
-                        // https://nodejs.org/api/fs.html#filehandlechmodmode:~:text=Caveats%3A%20on%20Windows%20only%20the%20write%20permission%20can%20be%20changed%2C%20and%20the%20distinction%20among%20the%20permissions%20of%20group%2C%20owner%2C%20or%20others%20is%20not%20implemented.
-                        await fs.promises.chmod(this.lockPath, 0o666); // 6 is read/write (not execute) for user, group, and others.
-                    }
-                    catch (err: any)
-                    {
-                        this.logger.log(`Failed to set permissions on ${this.lockPath}: ${JSON.stringify(err ?? '')}`);
-                    }
                     const returnResult = await fn();
                     return resolve(returnResult); // Return out, and let the finally logic close the server before we return.
                 }

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -51,7 +51,7 @@ export class NodeIPCMutex
 
     private getIPCHandlePath(id: string): string
     {
-        const lengthLimit = os.platform() === 'win32' ? 256 : 107;
+        const lengthLimit = os.platform() === 'win32' ? 256 : 104; // Mac 10.9 and FreeBSD have their own length limit.
 
         // On Unix, A file descriptor in /temp/ is a good option to hold this sock.
         // In Linux, The user or system may set XDG_RUNTIME_DIR to set our applications temporary directory, so this this instead of /temp/

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -136,21 +136,20 @@ export class NodeIPCMutex
             // eslint-disable-next-line  @typescript-eslint/no-misused-promises
             this.server.listen(this.lockPath, async () =>
             {
-                this.server?.removeListener('error', reject);
                 try
                 {
-                    // Set permissions to allow other processes to access/delete the handle
-                    // On Windows, only write permissions can be changed, but that is OK.
-                    // https://nodejs.org/api/fs.html#filehandlechmodmode:~:text=Caveats%3A%20on%20Windows%20only%20the%20write%20permission%20can%20be%20changed%2C%20and%20the%20distinction%20among%20the%20permissions%20of%20group%2C%20owner%2C%20or%20others%20is%20not%20implemented.
-                    await fs.promises.chmod(this.lockPath, 0o666); // 6 is read/write (not execute) for user, group, and others.
-                }
-                catch (err: any)
-                {
-                    this.logger.log(`Failed to set permissions on ${this.lockPath}: ${JSON.stringify(err ?? '')}`);
-                }
-
-                try
-                {
+                    this.server?.removeListener('error', reject);
+                    try
+                    {
+                        // Set permissions to allow other processes to access/delete the handle
+                        // On Windows, only write permissions can be changed, but that is OK.
+                        // https://nodejs.org/api/fs.html#filehandlechmodmode:~:text=Caveats%3A%20on%20Windows%20only%20the%20write%20permission%20can%20be%20changed%2C%20and%20the%20distinction%20among%20the%20permissions%20of%20group%2C%20owner%2C%20or%20others%20is%20not%20implemented.
+                        await fs.promises.chmod(this.lockPath, 0o666); // 6 is read/write (not execute) for user, group, and others.
+                    }
+                    catch (err: any)
+                    {
+                        this.logger.log(`Failed to set permissions on ${this.lockPath}: ${JSON.stringify(err ?? '')}`);
+                    }
                     const returnResult = await fn();
                     return resolve(returnResult); // Return out, and let the finally logic close the server before we return.
                 }

--- a/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
@@ -3,27 +3,18 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
 import * as os from 'os';
-
-import * as fs from 'fs';
-import * as path from 'path';
-import * as lockfile from 'proper-lockfile';
 import { SYSTEM_INFORMATION_CACHE_DURATION_MS } from '../Acquisition/CacheTimeConstants';
 import { IAcquisitionWorkerContext } from '../Acquisition/IAcquisitionWorkerContext';
 import { IEventStream } from '../EventStream/EventStream';
 import
 {
-    DotnetLockAcquiredEvent,
-    DotnetLockAttemptingAcquireEvent,
-    DotnetLockErrorEvent,
-    DotnetLockEvent,
-    DotnetLockReleasedEvent, DotnetWSLCheckEvent, EventBasedError,
+    DotnetWSLCheckEvent,
     GenericDotnetLockEvent
 } from '../EventStream/EventStreamEvents';
 import { IEvent } from '../EventStream/IEvent';
 import { CommandExecutor } from './CommandExecutor';
 import { ICommandExecutor } from './ICommandExecutor';
 import { IUtilityContext } from './IUtilityContext';
-import { LockUsedByThisInstanceSingleton } from './LockUsedByThisInstanceSingleton';
 import { INodeIPCMutexLogger, NodeIPCMutex } from './NodeIPCMutex';
 
 export async function loopWithTimeoutOnCond(sampleRatePerMs: number, durationToWaitBeforeTimeoutMs: number, conditionToStop: () => boolean, doAfterStop: () => void,

--- a/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
@@ -63,7 +63,7 @@ export async function executeWithLock<A extends any[], R>(eventStream: IEventStr
 {
     // Are we in a mutex-relevant inner function call, that is called by a parent function that already holds the lock?
     // If so, we don't need to acquire the lock again and we also shouldn't release it as the parent function will do that.
-    if (alreadyHoldingLock)
+    if (alreadyHoldingLock || process.env.VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX === 'true')
     {
         // eslint-disable-next-line @typescript-eslint/await-thenable
         return f(...(args));

--- a/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
@@ -84,13 +84,13 @@ export async function executeWithLock<A extends any[], R>(eventStream: IEventStr
     {
         class NodeIPCMutexLoggerWrapper extends INodeIPCMutexLogger
         {
-            constructor(private readonly eventStream: IEventStream)
+            constructor(private readonly loggerEventStream: IEventStream)
             {
                 super();
             }
             public log(message: string)
             {
-                this.eventStream.post(new GenericDotnetLockEvent(message, new Date().toISOString(), lockPath, lockPath));
+                this.loggerEventStream.post(new GenericDotnetLockEvent(message, new Date().toISOString(), lockPath, lockPath));
             }
         }
 
@@ -99,6 +99,8 @@ export async function executeWithLock<A extends any[], R>(eventStream: IEventStr
 
         const result = await mutex.acquire(async () =>
         {
+            // await must be used to make the linter allow fn to be async, which it must be.
+            // eslint-disable-next-line no-return-await
             return await f(...(args));
         }, retryTimeMs, timeoutTimeMs, lockPath);
         return result;

--- a/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
@@ -15,13 +15,16 @@ import
     DotnetLockAcquiredEvent,
     DotnetLockAttemptingAcquireEvent,
     DotnetLockErrorEvent,
-    DotnetLockReleasedEvent, DotnetWSLCheckEvent, EventBasedError
+    DotnetLockEvent,
+    DotnetLockReleasedEvent, DotnetWSLCheckEvent, EventBasedError,
+    GenericDotnetLockEvent
 } from '../EventStream/EventStreamEvents';
 import { IEvent } from '../EventStream/IEvent';
 import { CommandExecutor } from './CommandExecutor';
 import { ICommandExecutor } from './ICommandExecutor';
 import { IUtilityContext } from './IUtilityContext';
 import { LockUsedByThisInstanceSingleton } from './LockUsedByThisInstanceSingleton';
+import { INodeIPCMutexLogger, NodeIPCMutex } from './NodeIPCMutex';
 
 export async function loopWithTimeoutOnCond(sampleRatePerMs: number, durationToWaitBeforeTimeoutMs: number, conditionToStop: () => boolean, doAfterStop: () => void,
     eventStream: IEventStream | null, waitEvent: IEvent): Promise<void>
@@ -77,83 +80,29 @@ export async function executeWithLock<A extends any[], R>(eventStream: IEventStr
         // eslint-disable-next-line @typescript-eslint/await-thenable
         return f(...(args));
     }
-
-    // Someone PKilled Vscode while we held the lock previously. Need to clean up the lock created by the lib (lib adds .lock unless you use LockFilePath option)
-    if (fs.existsSync(`${lockPath}.lock`) && !(LockUsedByThisInstanceSingleton.getInstance().hasVsCodeInstanceInteractedWithLock(lockPath)))
+    else
     {
-        eventStream?.post(new DotnetLockReleasedEvent(`Lock about to be released, but we never touched it (pkilled vscode?)`, new Date().toISOString(), lockPath, lockPath));
-
-        try
+        class NodeIPCMutexLoggerWrapper extends INodeIPCMutexLogger
         {
-            fs.rmdirSync(`${lockPath}.lock`, { recursive: true });
-            eventStream?.post(new DotnetLockReleasedEvent(`Lock is not owned by us, deleted it`, new Date().toISOString(), lockPath, lockPath));
+            constructor(private readonly eventStream: IEventStream)
+            {
+                super();
+            }
+            public log(message: string)
+            {
+                this.eventStream.post(new GenericDotnetLockEvent(message, new Date().toISOString(), lockPath, lockPath));
+            }
         }
-        catch (e)
+
+        const logger = new NodeIPCMutexLoggerWrapper(eventStream);
+        const mutex = new NodeIPCMutex(lockPath, logger);
+
+        const result = await mutex.acquire(async () =>
         {
-            eventStream?.post(new DotnetLockReleasedEvent(`Lock is not owned by us, but deletion failed: ${JSON.stringify(e)}`, new Date().toISOString(), lockPath, lockPath));
-        }
+            return await f(...(args));
+        }, retryTimeMs, timeoutTimeMs, lockPath);
+        return result;
     }
-
-    retryTimeMs = retryTimeMs > 0 ? retryTimeMs : 100;
-    const retryCountToEndRoughlyAtTimeoutMs = timeoutTimeMs / retryTimeMs;
-    let returnResult: any;
-    let codeFailureAndNotLockFailure = null;
-
-    // Make the directory and file to hold a lock over if it DNE. If it exists, thats OK (.lock is a different file than the lock file)
-    try
-    {
-        fs.mkdirSync(path.dirname(lockPath), { recursive: true });
-    }
-    catch (err)
-    {
-        // The file owning directory already exists
-    }
-
-    eventStream?.post(new DotnetLockAttemptingAcquireEvent(`Lock Acquisition request to begin.`, new Date().toISOString(), lockPath, lockPath));
-    fs.writeFileSync(lockPath, '', { encoding: 'utf-8' });
-    await lockfile.lock(lockPath, { stale: (timeoutTimeMs - (retryTimeMs * 2)) /*if a proc holding the lock has not returned in the stale time it will auto fail*/, retries: { retries: retryCountToEndRoughlyAtTimeoutMs, minTimeout: retryTimeMs, maxTimeout: retryTimeMs } })
-        .then(async (release) =>
-        {
-            eventStream?.post(new DotnetLockAcquiredEvent(`Lock Acquired.`, new Date().toISOString(), lockPath, lockPath));
-            try
-            {
-                // eslint-disable-next-line @typescript-eslint/await-thenable
-                returnResult = await f(...(args));
-            }
-            catch (errorFromF: any)
-            {
-                codeFailureAndNotLockFailure = errorFromF;
-            }
-            eventStream?.post(new DotnetLockReleasedEvent(`Lock about to be released.`, new Date().toISOString(), lockPath, lockPath));
-            return release().catch((unlockError: Error) => { if (unlockError.message.includes('already released') || unlockError.message.includes('by you')) { return; } else { throw unlockError; } }); // sometimes the lib will fail to release even if it never acquired it.
-        })
-        .catch((lockingError: Error) =>
-        {
-            // If we don't catch here, the lock will never be released.
-            try
-            {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                eventStream.post(new DotnetLockErrorEvent(lockingError, lockingError?.message ?? 'Unable to acquire lock or unlock lock. Trying to unlock.', new Date().toISOString(), lockPath, lockPath));
-                if (lockfile.checkSync(lockPath))
-                {
-                    eventStream?.post(new DotnetLockReleasedEvent(`Lock about to be released after checkSync due to lockError Event`, new Date().toISOString(), lockPath, lockPath));
-                    lockfile.unlockSync(lockPath);
-                }
-            }
-            catch (eWhenUnlocking: any)
-            {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                eventStream.post(new DotnetLockErrorEvent(eWhenUnlocking, eWhenUnlocking?.message ?? `Unable to acquire lock ${lockPath}`, new Date().toISOString(), lockPath, lockPath));
-            }
-            throw new EventBasedError('DotnetLockErrorEvent', lockingError?.message, lockingError?.stack);
-        });
-
-    if (codeFailureAndNotLockFailure)
-    {
-        throw codeFailureAndNotLockFailure;
-    }
-
-    return returnResult;
 }
 
 const possiblyUsefulUpperCaseEnvVars = new Set<string>([ // This is a local variable instead of in the function so it doesn't get recreated every time the function is called. I looked at compiled JS and didn't see it get optimized.

--- a/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
@@ -83,7 +83,14 @@ export async function executeWithLock<A extends any[], R>(eventStream: IEventStr
         }
 
         const logger = new NodeIPCMutexLoggerWrapper(eventStream);
-        const mutex = new NodeIPCMutex(lockId, logger);
+        const mutex = new NodeIPCMutex(lockId, logger, `The lock may be held by another process or instance of vscode. Try restarting your machine, deleting the lock, and or increasing the timeout time in the extension settings.
+
+Increase your OS path length limit to at least 256 characters.
+On Linux, you can set XDG_RUNTIME_DIR to be a writeable directory by your user.
+
+If you still face issues, set VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX=true in the environment.
+Report this issue to our vscode-dotnet-runtime GitHub for help.`
+        );
 
         const result = await mutex.acquire(async () =>
         {

--- a/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
@@ -87,7 +87,7 @@ export async function executeWithLock<A extends any[], R>(eventStream: IEventStr
 
         const result = await mutex.acquire(async () =>
         {
-            // await must be used to make the linter allow fn to be async, which it must be.
+            // await must be used to make the linter allow f to be async, which it must be.
             // eslint-disable-next-line no-return-await
             return await f(...(args));
         }, retryTimeMs, timeoutTimeMs, `${lockId}-${crypto.randomUUID()}`);

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockRunTask.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockRunTask.ts
@@ -3,6 +3,7 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
 
+import { exit } from 'process';
 import { INodeIPCTestLogger, printWithLock } from '../unit/TestUtility';
 
 process.on('message', async (msg: any) =>
@@ -15,7 +16,9 @@ process.on('message', async (msg: any) =>
             {
                 console.log(`Send update: ${logger.logs}`);
                 process.send?.({ status: 'update', message: logger.logs });
+                logger.logs = []; // Clear the logs to avoid sending the same message multiple times.
             }
         );
+        exit(0);
     }
 });

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockRunTask.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockRunTask.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+
+import { INodeIPCTestLogger, printWithLock } from '../unit/TestUtility';
+
+process.on('message', async (msg: any) =>
+{
+    if (msg?.run)
+    {
+        const logger = new INodeIPCTestLogger(); // The logger passed is not a class but list of events.
+        await printWithLock(process.argv[4], process.argv[2], Number(process.argv[3]), logger,
+            async () =>
+            {
+                console.log(`Send update: ${logger.logs}`);
+                process.send?.({ status: 'update', message: logger.logs });
+            }
+        );
+    }
+});

--- a/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
@@ -18,7 +18,7 @@ const testTimeoutMs = 10000 * 2; // 20 seconds
 
 suite('Log Based NodeIPCMutex Unit Tests', function ()
 {
-    this.retries(4);
+    this.retries(2);
 
     function firstComesBeforeSecond(arr: string[], first: string, second: string): boolean
     {
@@ -69,7 +69,7 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
         await wait(100);
         printWithLock(myLock, taskBText, 500, logger);
 
-        await wait(500);
+        await wait(800);
 
         assert(logger.logs.includes(`${acquiredText}${taskBText}`), `${logger.logs}
  B was able to get the lock even if it started while A was running.`);
@@ -96,7 +96,7 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
 
             printWithLock(myLock, taskBText, 4500, loggerForMultiFork);
 
-            await wait(7000);
+            await wait(8000);
 
             assert(loggerForMultiFork.logs.includes(`${acquiredText}${taskBText}`), `${loggerForMultiFork.logs}
  B was able to get the lock even if it started while A was running.`);
@@ -132,7 +132,7 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
             printWithLock(myLock, taskBText, 5500, loggerForHoldingDies);
             child.kill('SIGKILL');
 
-            await wait(7000);
+            await wait(9000);
 
             assert(firstComesBeforeSecond(loggerForHoldingDies.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForHoldingDies.logs}
  A acquired before B`);
@@ -168,7 +168,7 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
             child.kill('SIGKILL');
             printWithLock(myLock, taskBText, 5200, loggerForHoldingDiesAfter);
 
-            await wait(7000); // Wait for A to finish and release the lock.
+            await wait(9000); // Wait for A to finish and release the lock.
 
             assert(firstComesBeforeSecond(loggerForHoldingDiesAfter.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForHoldingDiesAfter.logs}
  A acquired before B`);

--- a/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
@@ -14,6 +14,7 @@ const childTaskFile = path.join(__dirname, '../mocks/MockRunTask.js');
 const loggerForMultiFork = new INodeIPCTestLogger();
 const loggerForHoldingDies = new INodeIPCTestLogger();
 const loggerForHoldingDiesAfter = new INodeIPCTestLogger();
+const testTimeoutMs = 10000 * 2; // 20 seconds
 
 suite('Log Based NodeIPCMutex Unit Tests', function ()
 {
@@ -52,7 +53,7 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
 
         assert(logger.logs.includes(`${acquiredText}${taskBText}`), `${logger.logs} B was able to get A after A finished.`);
         assert(firstComesBeforeSecond(logger.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${logger.logs} A acquired before B`);
-    }).timeout(10000 * 2);
+    }).timeout(testTimeoutMs);
 
     test('It can communicate with another task while it is active', async () =>
     {
@@ -67,7 +68,7 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
 
         assert(logger.logs.includes(`${acquiredText}${taskBText}`), `${logger.logs} B was able to get the lock even if it started while A was running.`);
         assert(firstComesBeforeSecond(logger.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${logger.logs} A acquired before B`);
-    });
+    }).timeout(testTimeoutMs);
 
     test('Multiple processes share the mutex correctly', async () =>
     {
@@ -98,7 +99,7 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
         {
             child.kill(); // Clean up the child process.
         }
-    });
+    }).timeout(testTimeoutMs);
 
     test('It can acquire if the holding process dies if it was not dead at the others first acquire attempt', async () =>
     {
@@ -130,7 +131,7 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
         {
             child.kill(); // Clean up the child process.
         }
-    }).timeout(10000 * 2);
+    }).timeout(testTimeoutMs);
 
     test('It can lock even if the holding process dies before the next process begins', async () =>
     {
@@ -162,5 +163,5 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
         {
             child.kill(); // Clean up the child process.
         }
-    }).timeout(10000 * 2);
+    }).timeout(testTimeoutMs);
 });

--- a/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
@@ -1,0 +1,166 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+import * as chai from 'chai';
+import { fork } from 'child_process';
+import * as path from 'path';
+import { acquiredText, INodeIPCTestLogger, printWithLock, releasedText, wait } from './TestUtility';
+const assert = chai.assert;
+
+const taskAText = 'Task A';
+const taskBText = 'Task B';
+const childTaskFile = path.join(__dirname, '../mocks/MockRunTask.js');
+const loggerForMultiFork = new INodeIPCTestLogger();
+const loggerForHoldingDies = new INodeIPCTestLogger();
+const loggerForHoldingDiesAfter = new INodeIPCTestLogger();
+
+suite('Log Based NodeIPCMutex Unit Tests', function ()
+{
+    this.retries(4);
+
+    function firstComesBeforeSecond(arr: string[], first: string, second: string): boolean
+    {
+        const firstIndex = arr.indexOf(first);
+        const secondIndex = arr.indexOf(second);
+        return firstIndex < secondIndex && firstIndex !== -1 && secondIndex !== -1;
+    }
+
+    test('Events queued in order and waits', async () =>
+    {
+        const logger = new INodeIPCTestLogger();
+        const myLock = `EventQueueTestMutex`;
+
+        printWithLock(myLock, taskAText, 500, logger);
+        await wait(100);
+        assert(logger.logs.includes(`${acquiredText}${taskAText}`), `${logger.logs} A acquires the lock when nobody holds it`);
+        assert(!logger.logs.includes(`${releasedText}${taskAText}`), `${logger.logs} A does not release the lock during the function execution`);
+
+        try
+        {
+            printWithLock(myLock, taskBText, 100, logger);
+        }
+        catch (e: any)
+        {
+            // noop
+        }
+        assert(!logger.logs.includes(`${acquiredText}${taskBText}`), `${logger.logs} B does not acquire A when A is still working and B timed out`);
+
+        await wait(500); // Wait for A to finish and release the lock.
+        printWithLock(myLock, taskBText, 100, logger);
+        await wait(100); // Wait for B to finish and release the lock.
+
+        assert(logger.logs.includes(`${acquiredText}${taskBText}`), `${logger.logs} B was able to get A after A finished.`);
+        assert(firstComesBeforeSecond(logger.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${logger.logs} A acquired before B`);
+    }).timeout(10000 * 2);
+
+    test('It can communicate with another task while it is active', async () =>
+    {
+        const logger = new INodeIPCTestLogger();
+        const myLock = `ItCanCommunicateWithAnotherTaskWhileItIsActiveMutex`;
+
+        printWithLock(myLock, taskAText, 500, logger);
+        await wait(100);
+        printWithLock(myLock, taskBText, 500, logger);
+
+        await wait(500);
+
+        assert(logger.logs.includes(`${acquiredText}${taskBText}`), `${logger.logs} B was able to get the lock even if it started while A was running.`);
+        assert(firstComesBeforeSecond(logger.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${logger.logs} A acquired before B`);
+    });
+
+    test('Multiple processes share the mutex correctly', async () =>
+    {
+        const myLock = `MultipleProcessesShareTheMutexCorrectlyMutex`;
+
+        const child = fork(childTaskFile, [taskAText, '5500', myLock]);
+        child.on('message', (msg) =>
+        {
+            loggerForMultiFork.logs = loggerForMultiFork.logs.concat((msg as any).message);
+        });
+
+
+        try
+        {
+            // Fork a child process to simulate "Process B" with the default timeout
+            child.send({ run: true }); // Give it the logger so it logs to our memory, and tell it to printWithLock
+            await wait(4000);
+
+            printWithLock(myLock, taskBText, 4500, loggerForMultiFork);
+
+            await wait(7000);
+
+            assert(loggerForMultiFork.logs.includes(`${acquiredText}${taskBText}`), `${loggerForMultiFork.logs} B was able to get the lock even if it started while A was running.`);
+            assert(firstComesBeforeSecond(loggerForMultiFork.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForMultiFork.logs} A acquired before B`);
+            assert(firstComesBeforeSecond(loggerForMultiFork.logs, `${releasedText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForMultiFork.logs} A released before B acquired`);
+        }
+        finally
+        {
+            child.kill(); // Clean up the child process.
+        }
+    });
+
+    test('It can acquire if the holding process dies if it was not dead at the others first acquire attempt', async () =>
+    {
+        const myLock = `HoldingProcessDiesMutex`;
+
+        // Child is now Task A
+        const child = fork(childTaskFile, [taskAText, '5700', myLock]);
+        child.on('message', (msg) =>
+        {
+            loggerForHoldingDies.logs = loggerForHoldingDies.logs.concat((msg as any).message);
+        });
+
+        try
+        {
+            child.send({ run: true });
+            await wait(4000);
+
+            assert(loggerForHoldingDies.logs.includes(`${acquiredText}${taskAText}`), `${loggerForHoldingDies.logs} child process (A) was able to get the lock.`);
+            printWithLock(myLock, taskBText, 5500, loggerForHoldingDies);
+            child.kill('SIGKILL');
+
+            await wait(7000);
+
+            assert(firstComesBeforeSecond(loggerForHoldingDies.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForHoldingDies.logs} A acquired before B`);
+            assert(loggerForHoldingDies.logs.includes(`${acquiredText}${taskBText}`), `${loggerForHoldingDies.logs} B was able to get the lock even if A died when A had it, and A was first.`);
+            assert(!loggerForHoldingDies.logs.includes(`${releasedText}${taskAText}`), `${loggerForHoldingDies.logs} A was forcefully terminated, so it never properly released the lock.`);
+        }
+        finally
+        {
+            child.kill(); // Clean up the child process.
+        }
+    }).timeout(10000 * 2);
+
+    test('It can lock even if the holding process dies before the next process begins', async () =>
+    {
+        const myLock = `HoldingProcessDiesBeforeNextProcessBeginsMutex`;
+
+        // Child is now Task A
+        const child = fork(childTaskFile, [taskAText, '5500', myLock]);
+        child.on('message', (msg) =>
+        {
+            loggerForHoldingDiesAfter.logs = loggerForHoldingDiesAfter.logs.concat((msg as any).message);
+        });
+
+        try
+        {
+            child.send({ run: true }); // Give it the logger so it knows.
+            await wait(4000);
+
+            assert(loggerForHoldingDiesAfter.logs.includes(`${acquiredText}${taskAText}`), `${loggerForHoldingDiesAfter.logs} Child process A was able to get the lock`);
+            child.kill('SIGKILL');
+            printWithLock(myLock, taskBText, 5200, loggerForHoldingDiesAfter);
+
+            await wait(7000); // Wait for A to finish and release the lock.
+
+            assert(firstComesBeforeSecond(loggerForHoldingDiesAfter.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForHoldingDiesAfter.logs} A acquired before B`);
+            assert(loggerForHoldingDiesAfter.logs.includes(`${acquiredText}${taskBText}`), `${loggerForHoldingDiesAfter.logs} B was able to get the lock even if A died when A had it, and B started after A died.`);
+            assert(!loggerForHoldingDiesAfter.logs.includes(`${releasedText}${taskAText}`), `${loggerForHoldingDiesAfter.logs} A was forcefully terminated, so it never properly released the lock.`);
+        }
+        finally
+        {
+            child.kill(); // Clean up the child process.
+        }
+    }).timeout(10000 * 2);
+});

--- a/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
@@ -34,8 +34,10 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
 
         printWithLock(myLock, taskAText, 500, logger);
         await wait(100);
-        assert(logger.logs.includes(`${acquiredText}${taskAText}`), `${logger.logs} A acquires the lock when nobody holds it`);
-        assert(!logger.logs.includes(`${releasedText}${taskAText}`), `${logger.logs} A does not release the lock during the function execution`);
+        assert(logger.logs.includes(`${acquiredText}${taskAText}`), `${logger.logs}
+ A acquires the lock when nobody holds it`);
+        assert(!logger.logs.includes(`${releasedText}${taskAText}`), `${logger.logs}
+ A does not release the lock during the function execution`);
 
         try
         {
@@ -45,14 +47,17 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
         {
             // noop
         }
-        assert(!logger.logs.includes(`${acquiredText}${taskBText}`), `${logger.logs} B does not acquire A when A is still working and B timed out`);
+        assert(!logger.logs.includes(`${acquiredText}${taskBText}`), `${logger.logs}
+ B does not acquire A when A is still working and B timed out`);
 
         await wait(500); // Wait for A to finish and release the lock.
         printWithLock(myLock, taskBText, 100, logger);
         await wait(100); // Wait for B to finish and release the lock.
 
-        assert(logger.logs.includes(`${acquiredText}${taskBText}`), `${logger.logs} B was able to get A after A finished.`);
-        assert(firstComesBeforeSecond(logger.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${logger.logs} A acquired before B`);
+        assert(logger.logs.includes(`${acquiredText}${taskBText}`), `${logger.logs}
+ B was able to get A after A finished.`);
+        assert(firstComesBeforeSecond(logger.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${logger.logs}
+ A acquired before B`);
     }).timeout(testTimeoutMs);
 
     test('It can communicate with another task while it is active', async () =>
@@ -66,8 +71,10 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
 
         await wait(500);
 
-        assert(logger.logs.includes(`${acquiredText}${taskBText}`), `${logger.logs} B was able to get the lock even if it started while A was running.`);
-        assert(firstComesBeforeSecond(logger.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${logger.logs} A acquired before B`);
+        assert(logger.logs.includes(`${acquiredText}${taskBText}`), `${logger.logs}
+ B was able to get the lock even if it started while A was running.`);
+        assert(firstComesBeforeSecond(logger.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${logger.logs}
+ A acquired before B`);
     }).timeout(testTimeoutMs);
 
     test('Multiple processes share the mutex correctly', async () =>
@@ -91,9 +98,12 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
 
             await wait(7000);
 
-            assert(loggerForMultiFork.logs.includes(`${acquiredText}${taskBText}`), `${loggerForMultiFork.logs} B was able to get the lock even if it started while A was running.`);
-            assert(firstComesBeforeSecond(loggerForMultiFork.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForMultiFork.logs} A acquired before B`);
-            assert(firstComesBeforeSecond(loggerForMultiFork.logs, `${releasedText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForMultiFork.logs} A released before B acquired`);
+            assert(loggerForMultiFork.logs.includes(`${acquiredText}${taskBText}`), `${loggerForMultiFork.logs}
+ B was able to get the lock even if it started while A was running.`);
+            assert(firstComesBeforeSecond(loggerForMultiFork.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForMultiFork.logs}
+ A acquired before B`);
+            assert(firstComesBeforeSecond(loggerForMultiFork.logs, `${releasedText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForMultiFork.logs}
+ A released before B acquired`);
         }
         finally
         {
@@ -117,15 +127,19 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
             child.send({ run: true });
             await wait(4000);
 
-            assert(loggerForHoldingDies.logs.includes(`${acquiredText}${taskAText}`), `${loggerForHoldingDies.logs} child process (A) was able to get the lock.`);
+            assert(loggerForHoldingDies.logs.includes(`${acquiredText}${taskAText}`), `${loggerForHoldingDies.logs}
+ child process (A) was able to get the lock.`);
             printWithLock(myLock, taskBText, 5500, loggerForHoldingDies);
             child.kill('SIGKILL');
 
             await wait(7000);
 
-            assert(firstComesBeforeSecond(loggerForHoldingDies.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForHoldingDies.logs} A acquired before B`);
-            assert(loggerForHoldingDies.logs.includes(`${acquiredText}${taskBText}`), `${loggerForHoldingDies.logs} B was able to get the lock even if A died when A had it, and A was first.`);
-            assert(!loggerForHoldingDies.logs.includes(`${releasedText}${taskAText}`), `${loggerForHoldingDies.logs} A was forcefully terminated, so it never properly released the lock.`);
+            assert(firstComesBeforeSecond(loggerForHoldingDies.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForHoldingDies.logs}
+ A acquired before B`);
+            assert(loggerForHoldingDies.logs.includes(`${acquiredText}${taskBText}`), `${loggerForHoldingDies.logs}
+ B was able to get the lock even if A died when A had it, and A was first.`);
+            assert(!loggerForHoldingDies.logs.includes(`${releasedText}${taskAText}`), `${loggerForHoldingDies.logs}
+ A was forcefully terminated, so it never properly released the lock.`);
         }
         finally
         {
@@ -149,15 +163,19 @@ suite('Log Based NodeIPCMutex Unit Tests', function ()
             child.send({ run: true }); // Give it the logger so it knows.
             await wait(4000);
 
-            assert(loggerForHoldingDiesAfter.logs.includes(`${acquiredText}${taskAText}`), `${loggerForHoldingDiesAfter.logs} Child process A was able to get the lock`);
+            assert(loggerForHoldingDiesAfter.logs.includes(`${acquiredText}${taskAText}`), `${loggerForHoldingDiesAfter.logs}
+ Child process A was able to get the lock`);
             child.kill('SIGKILL');
             printWithLock(myLock, taskBText, 5200, loggerForHoldingDiesAfter);
 
             await wait(7000); // Wait for A to finish and release the lock.
 
-            assert(firstComesBeforeSecond(loggerForHoldingDiesAfter.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForHoldingDiesAfter.logs} A acquired before B`);
-            assert(loggerForHoldingDiesAfter.logs.includes(`${acquiredText}${taskBText}`), `${loggerForHoldingDiesAfter.logs} B was able to get the lock even if A died when A had it, and B started after A died.`);
-            assert(!loggerForHoldingDiesAfter.logs.includes(`${releasedText}${taskAText}`), `${loggerForHoldingDiesAfter.logs} A was forcefully terminated, so it never properly released the lock.`);
+            assert(firstComesBeforeSecond(loggerForHoldingDiesAfter.logs, `${acquiredText}${taskAText}`, `${acquiredText}${taskBText}`), `${loggerForHoldingDiesAfter.logs}
+ A acquired before B`);
+            assert(loggerForHoldingDiesAfter.logs.includes(`${acquiredText}${taskBText}`), `${loggerForHoldingDiesAfter.logs}
+ B was able to get the lock even if A died when A had it, and B started after A died.`);
+            assert(!loggerForHoldingDiesAfter.logs.includes(`${releasedText}${taskAText}`), `${loggerForHoldingDiesAfter.logs}
+ A was forcefully terminated, so it never properly released the lock.`);
         }
         finally
         {

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -115,7 +115,7 @@ export async function printWithLock(lock: string, msg: string, timeToLive: numbe
         logger.log(`${releasedText}${msg}`);
         await fn();
         return msg;
-    }, 10, timeToLive, msg);
+    }, 40, timeToLive, msg);
 
     logger.log(`After release, ${msg} returned c: ${c}`);
 }

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -3,26 +3,26 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-import * as os from 'os';
 
-import { MockWindowDisplayWorker } from '../mocks/MockWindowDisplayWorker';
-import { MockDotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext, MockInstallationValidator, MockVSCodeEnvironment, MockVSCodeExtensionContext } from '../mocks/MockObjects';
-import { IDotnetAcquireContext } from '../../IDotnetAcquireContext';
-import { IAcquisitionWorkerContext } from '../../Acquisition/IAcquisitionWorkerContext';
-import { IEventStream } from '../../EventStream/EventStream';
-import { IUtilityContext } from '../../Utils/IUtilityContext';
-import { IInstallationDirectoryProvider } from '../../Acquisition/IInstallationDirectoryProvider';
 import { directoryProviderFactory } from '../../Acquisition/DirectoryProviderFactory';
 import { DotnetInstallMode } from '../../Acquisition/DotnetInstallMode';
+import { IAcquisitionWorkerContext } from '../../Acquisition/IAcquisitionWorkerContext';
+import { IInstallationDirectoryProvider } from '../../Acquisition/IInstallationDirectoryProvider';
+import { IEventStream } from '../../EventStream/EventStream';
+import { IDotnetAcquireContext } from '../../IDotnetAcquireContext';
+import { IUtilityContext } from '../../Utils/IUtilityContext';
+import { INodeIPCMutexLogger, NodeIPCMutex } from '../../Utils/NodeIPCMutex';
+import { MockDotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext, MockInstallationValidator, MockVSCodeEnvironment, MockVSCodeExtensionContext } from '../mocks/MockObjects';
+import { MockWindowDisplayWorker } from '../mocks/MockWindowDisplayWorker';
 
 const standardTimeoutTime = 100000;
 
-export function getMockAcquisitionContext(mode: DotnetInstallMode, version : string, timeoutTime : number = standardTimeoutTime, customEventStream? : IEventStream,
-    customContext? : MockExtensionContext, arch? : string | null, directory? : IInstallationDirectoryProvider): IAcquisitionWorkerContext
+export function getMockAcquisitionContext(mode: DotnetInstallMode, version: string, timeoutTime: number = standardTimeoutTime, customEventStream?: IEventStream,
+    customContext?: MockExtensionContext, arch?: string | null, directory?: IInstallationDirectoryProvider): IAcquisitionWorkerContext
 {
     const extensionContext = customContext ?? new MockExtensionContext();
     const myEventStream = customEventStream ?? new MockEventStream();
-    const workerContext : IAcquisitionWorkerContext =
+    const workerContext: IAcquisitionWorkerContext =
     {
         storagePath: '',
         extensionState: extensionContext,
@@ -38,11 +38,11 @@ export function getMockAcquisitionContext(mode: DotnetInstallMode, version : str
     return workerContext;
 }
 
-export function getMockAcquisitionWorkerContext(acquireContext : IDotnetAcquireContext)
+export function getMockAcquisitionWorkerContext(acquireContext: IDotnetAcquireContext)
 {
     const extensionContext = new MockExtensionContext();
     const myEventStream = new MockEventStream();
-    const workerContext : IAcquisitionWorkerContext =
+    const workerContext: IAcquisitionWorkerContext =
     {
         storagePath: '',
         extensionState: extensionContext,
@@ -58,24 +58,24 @@ export function getMockAcquisitionWorkerContext(acquireContext : IDotnetAcquireC
     return workerContext;
 }
 
-export function getMockAcquisitionWorker(mockContext : IAcquisitionWorkerContext) : MockDotnetCoreAcquisitionWorker
+export function getMockAcquisitionWorker(mockContext: IAcquisitionWorkerContext): MockDotnetCoreAcquisitionWorker
 {
     const acquisitionWorker = new MockDotnetCoreAcquisitionWorker(getMockUtilityContext(), new MockVSCodeExtensionContext());
     return acquisitionWorker;
 }
 
-export function getMockUtilityContext() : IUtilityContext
+export function getMockUtilityContext(): IUtilityContext
 {
-    const utilityContext : IUtilityContext = {
-        ui : new MockWindowDisplayWorker(),
-        vsCodeEnv : new MockVSCodeEnvironment()
+    const utilityContext: IUtilityContext = {
+        ui: new MockWindowDisplayWorker(),
+        vsCodeEnv: new MockVSCodeEnvironment()
     }
     return utilityContext;
 }
 
-export function getMockAcquireContext(nextAcquiringVersion : string, arch : string | null | undefined, installMode : DotnetInstallMode) : IDotnetAcquireContext
+export function getMockAcquireContext(nextAcquiringVersion: string, arch: string | null | undefined, installMode: DotnetInstallMode): IDotnetAcquireContext
 {
-    const acquireContext : IDotnetAcquireContext =
+    const acquireContext: IDotnetAcquireContext =
     {
         version: nextAcquiringVersion,
         architecture: arch,
@@ -83,4 +83,39 @@ export function getMockAcquireContext(nextAcquiringVersion : string, arch : stri
         mode: installMode
     };
     return acquireContext;
+}
+
+export const acquiredText = 'Acquired Lock:';
+export const releasedText = 'Released Lock:';
+
+export async function wait(delayMs: number)
+{
+    return new Promise(resolve => setTimeout(resolve, delayMs));
+}
+
+export class INodeIPCTestLogger extends INodeIPCMutexLogger
+{
+    public logs: string[] = [];
+
+    public log(msg: string): void
+    {
+        this.logs.push(msg);
+    }
+}
+
+export async function printWithLock(lock: string, msg: string, timeToLive: number, logger: INodeIPCTestLogger, fn: () => Promise<void> = () => { return Promise.resolve(); }, retryDelayMs: number = 10)
+{
+    const mutex = new NodeIPCMutex(lock, logger);
+
+    const c = await mutex.acquire(async () =>
+    {
+        logger.log(`${acquiredText}${msg}`);
+        await fn();
+        await wait(timeToLive);
+        logger.log(`${releasedText}${msg}`);
+        await fn();
+        return msg;
+    }, 10, timeToLive, msg);
+
+    logger.log(`After release, ${msg} returned c: ${c}`);
 }

--- a/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
@@ -21,6 +21,7 @@ const standardTimeoutTime = 100000;
 
 suite('Windows & Mac Global Installer Tests', function ()
 {
+    this.retries(0);
     const mockVersion = '7.0.306';
     const mockUrl = 'https://download.visualstudio.microsoft.com/download/pr/4c0aaf08-3fa1-4fa0-8435-73b85eee4b32/e8264b3530b03b74b04ecfcf1666fe93/dotnet-sdk-7.0.306-win-x64.exe';
     const mockHash = '';

--- a/vscode-dotnet-runtime-library/yarn.lock
+++ b/vscode-dotnet-runtime-library/yarn.lock
@@ -717,11 +717,6 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/gopd/-/gopd-1.2.0.tgz"
   "version" "1.2.0"
 
-"graceful-fs@^4.2.4":
-  "integrity" "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz"
-  "version" "4.2.11"
-
 "growl@1.10.5":
   "integrity" "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/growl/-/growl-1.10.5.tgz"
@@ -1145,15 +1140,6 @@
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
   "version" "2.0.1"
 
-"proper-lockfile@^4.1.2":
-  "integrity" "sha1-yLneKvay8WAQZ/mOAaxmuqIjFB8="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proper-lockfile/-/proper-lockfile-4.1.2.tgz"
-  "version" "4.1.2"
-  dependencies:
-    "graceful-fs" "^4.2.4"
-    "retry" "^0.12.0"
-    "signal-exit" "^3.0.2"
-
 "proto-list@~1.2.1":
   "integrity" "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/proto-list/-/proto-list-1.2.4.tgz"
@@ -1233,11 +1219,6 @@
   dependencies:
     "onetime" "^5.1.0"
     "signal-exit" "^3.0.2"
-
-"retry@^0.12.0":
-  "integrity" "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/retry/-/retry-0.12.0.tgz"
-  "version" "0.12.0"
 
 "rimraf@3.0.2":
   "integrity" "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho="

--- a/vscode-dotnet-runtime.code-workspace
+++ b/vscode-dotnet-runtime.code-workspace
@@ -1,5 +1,5 @@
 {
-	"folders": [
+    "folders": [
         {
             "path": "vscode-dotnet-runtime-extension"
         },
@@ -19,7 +19,8 @@
             "DOTNETINSTALLMODELIST",
             "dotnets",
             "Republisher",
-            "unlocalized"
+            "unlocalized",
+            "vscd"
         ]
     }
 }


### PR DESCRIPTION
# Summary

Adds the class `NodeIPCMutex`. It is designed in such a way that it could become a portable library.
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/2221

This is a class that provides a mutex (mutual exclusion) lock using IPC (Inter-Process Communication) on Node.js.
 * It will work across multiple processes (aka multiple vs code windows) and async code in the same process.
 * Thus, node.js uses a named pipe on Windows and a file descriptor on Linux and OS X to create the lock, so that the lock can be shared across processes, and is resilient to pkill.

This approach was suggested to me after discussing with @joaomoreno, who owns windows-mutex and much of vscode. He was very helpful to talk to.

# Why are you writing all of this when it seems like this should already exist somewhere out there in node.js land?
 ### Hint: It Doesn't ( sadness, or I couldn't find it )

 * Many locking mechanisms such as lockfile and proper-lockfile run into issues when processes are killed or die unexpectedly, because they rely on the file system.
 * windows-mutex is another library, which is a wrapper around a C mutex, however it is Windows only.
 * async-mutex is another node.js library, but it stores a list of owners in memory, which may cause issues if multiple processes try to acquire the same lock.
 * Named pipes on windows die when processes die. There is no equivalent check on Linux or OS X, but IPC allows us to check whether the process is still alive or not so we don't deadlock

# How can I be reassured this wont be potentially catastrophic / have unexpected corner cases

 * Much of this code is inspired by VSCode's IPC code, which is a well tested approach. However, their approach focuses on permitting only one main VS Code Process to run at a time.
 * https://github.com/microsoft/vscode/blob/main/extensions/git/src/ipc/ipcServer.ts#L15
 * https://github.com/microsoft/vscode/blob/main/src/vs/code/electron-main/main.ts#L318

As much as I would love to have a backup option of the old code, we cannot have some code trying a backup option if it does not work, because then everything will be broken if 2 different locking mechanisms are utilized. It could be an environment flag, but I don't trust people will remember for all of the instances of vscode to set it correctly.

# Changes:

-> Rewrote the code to simply call around this wrapper without having to change any other logic.

-> The VS Code, (code) is well tested as it is run by all of the vscode instances. There is obviously an inherent risk that this may cause unexpected issues, but with some thorough testing and backup from the existence that this previous logic is good, I hope that we can trust this code.

# Examples:

In this image, I added a breakpoint to force vscode instance A, process A (right) to acquire the lock, to make sure that Instance A, process B, and Instance B is able to connect to process A, and wait. I verified that they ran in order and B waited 18 times for A to be released.
![image](https://github.com/user-attachments/assets/872c4a06-4af0-4659-961f-26513606392d)

In this image, I have 2 vscode instances on Windows. 
![image](https://github.com/user-attachments/assets/835bc3d3-f507-4b7a-b9cd-c861fdd1060a) The unshown process acquired both locks, run under admin. The left one was run as user local. I killed the admin one while the local one had connected to it and made sure it worked and detected the pkill.

I demonstrated the same on Unix here:
![image](https://github.com/user-attachments/assets/aab6cb67-50fc-43f5-b680-0b7a99e6daa1)

And my tests also validate various scenarios. I will also have the vendors run these tests with insiders/regular vscode.

# Caveats

The nodejs library / OS does have issues with certain character limits for paths - if the user has a custom /temp/ folder on Mac, especially, that is too long, they may run into issues. However, vscode runs the same logic and has worked ok. Users can set the XGD runtime dir and it is usually assigned correctly by the OS. I add the environment-variable VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX=1 to disable locking which is a concerning thing to set, but would enable us to help solve things for users in this odd case while suggesting they don't use multiple vscode instances in parallel.