### PR TITLE
Fix Linux Tests By Centralizing Distro Version Info

### DIFF
--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -653,7 +653,7 @@ Paths: 'acquire returned: ${resultForAcquiringPathSettingRuntime.dotnetPath} whi
         else
         {
             const recLinuxVersionFull = getMajorMinor(await getLinuxSupportedDotnetSDKVersion(mockAcquisitionContext), mockAcquisitionContext.eventStream, mockAcquisitionContext)
-            assert.equal(result[0].version, `${recLinuxVersionFull}.xx`, `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${JSON.stringify(await getDistroInfo(mockAcquisitionContext))}. If a new version is available, this test may need to be updated to the newest version.`);
+            assert.equal(result[0].version, `${recLinuxVersionFull}.1xx`, `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${JSON.stringify(await getDistroInfo(mockAcquisitionContext))}. If a new version is available, this test may need to be updated to the newest version.`);
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -24,7 +24,6 @@ import
     IDotnetListVersionsResult,
     IExistingPaths,
     ITelemetryEvent,
-    LinuxVersionResolver,
     LocalMemoryCacheSingleton,
     MockEnvironmentVariableCollection,
     MockEventStream,
@@ -33,8 +32,10 @@ import
     MockTelemetryReporter,
     MockWebRequestWorker,
     MockWindowDisplayWorker,
+    getDistroInfo,
     getDotnetExecutable,
     getInstallIdCustomArchitecture,
+    getLinuxSupportedDotnetSDKVersion,
     getMockAcquisitionContext,
     getMockAcquisitionWorkerContext,
     getMockUtilityContext,
@@ -650,8 +651,7 @@ Paths: 'acquire returned: ${resultForAcquiringPathSettingRuntime.dotnetPath} whi
         }
         else
         {
-            const distroVersion = await new LinuxVersionResolver(mockAcquisitionContext, getMockUtilityContext()).getRunningDistro();
-            assert.equal(result[0].version, Number(distroVersion.version) >= 22.04 ? '9.0.1xx' : '8.0.1xx', `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${distroVersion.version}. If a new version is available, this test may need to be updated to the newest version.`);
+            assert.equal(result[0].version, await getLinuxSupportedDotnetSDKVersion(mockAcquisitionContext), `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${JSON.stringify(await getDistroInfo(mockAcquisitionContext))}. If a new version is available, this test may need to be updated to the newest version.`);
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -653,7 +653,7 @@ Paths: 'acquire returned: ${resultForAcquiringPathSettingRuntime.dotnetPath} whi
         else
         {
             const recLinuxVersionFull = getMajorMinor(await getLinuxSupportedDotnetSDKVersion(mockAcquisitionContext), mockAcquisitionContext.eventStream, mockAcquisitionContext)
-            assert.equal(result[0].version, `${recLinuxVersionFull}.xx}`, `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${JSON.stringify(await getDistroInfo(mockAcquisitionContext))}. If a new version is available, this test may need to be updated to the newest version.`);
+            assert.equal(result[0].version, `${recLinuxVersionFull}.xx`, `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${JSON.stringify(await getDistroInfo(mockAcquisitionContext))}. If a new version is available, this test may need to be updated to the newest version.`);
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -36,6 +36,7 @@ import
     getDotnetExecutable,
     getInstallIdCustomArchitecture,
     getLinuxSupportedDotnetSDKVersion,
+    getMajorMinor,
     getMockAcquisitionContext,
     getMockAcquisitionWorkerContext,
     getMockUtilityContext,
@@ -651,7 +652,8 @@ Paths: 'acquire returned: ${resultForAcquiringPathSettingRuntime.dotnetPath} whi
         }
         else
         {
-            assert.equal(result[0].version, await getLinuxSupportedDotnetSDKVersion(mockAcquisitionContext), `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${JSON.stringify(await getDistroInfo(mockAcquisitionContext))}. If a new version is available, this test may need to be updated to the newest version.`);
+            const recLinuxVersionFull = getMajorMinor(await getLinuxSupportedDotnetSDKVersion(mockAcquisitionContext), mockAcquisitionContext.eventStream, mockAcquisitionContext)
+            assert.equal(result[0].version, `${recLinuxVersionFull}.xx}`, `The SDK did not recommend the version (it said ${result[0].version}) it was supposed to, which should be N.0.1xx based on surface level distro knowledge, version ${JSON.stringify(await getDistroInfo(mockAcquisitionContext))}. If a new version is available, this test may need to be updated to the newest version.`);
         }
     }).timeout(standardTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -29,6 +29,7 @@ import { IDistroDotnetSDKProvider } from './IDistroDotnetSDKProvider';
 import { RedHatDistroSDKProvider } from './RedHatDistroSDKProvider';
 import { VersionResolver } from './VersionResolver';
 import * as versionUtils from './VersionUtilities';
+import { DEBIAN_DISTRO_INFO_KEY, RED_HAT_DISTRO_INFO_KEY, UBUNTU_DISTRO_INFO_KEY } from './StringConstants';
 
 
 /**
@@ -96,7 +97,7 @@ Or, install Red Hat Enterprise Linux 8.0 or Red Hat Enterprise Linux 9.0 from ht
     protected acquireCtx: IDotnetAcquireContext | null | undefined;
 
     // This includes all distros that we officially support for this tool as a company. If a distro is not in this list, it can still have community member support.
-    public microsoftSupportedDistroIds = ['Red Hat Enterprise Linux', 'Ubuntu'];
+    public microsoftSupportedDistroIds = [RED_HAT_DISTRO_INFO_KEY, UBUNTU_DISTRO_INFO_KEY];
 
     constructor(private readonly workerContext: IAcquisitionWorkerContext, private readonly utilityContext: IUtilityContext,
         executor: ICommandExecutor | null = null, distroProvider: IDistroDotnetSDKProvider | null = null)
@@ -220,7 +221,7 @@ If you experience issues, please reach out on https://github.com/dotnet/vscode-d
                     this.unsupportedDistroErrorMessage), getInstallFromContext(this.workerContext));
                 this.workerContext.eventStream.post(unknownDistroErr);
                 throw unknownDistroErr.error;
-            case 'Red Hat Enterprise Linux':
+            case RED_HAT_DISTRO_INFO_KEY:
                 if (this.isRedHatVersion7(distroAndVersion.version))
                 {
                     const unsupportedRhelErr = new DotnetAcquisitionDistroUnknownError(new EventCancellationError(
@@ -231,7 +232,7 @@ If you experience issues, please reach out on https://github.com/dotnet/vscode-d
                     throw unsupportedRhelErr.error;
                 }
                 return new RedHatDistroSDKProvider(distroAndVersion, this.workerContext, this.utilityContext);
-            case 'Debian GNU/Linux':
+            case DEBIAN_DISTRO_INFO_KEY:
                 return new DebianDistroSDKProvider(distroAndVersion, this.workerContext, this.utilityContext);
             default:
                 return new GenericDistroSDKProvider(distroAndVersion, this.workerContext, this.utilityContext);

--- a/vscode-dotnet-runtime-library/src/Acquisition/StringConstants.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/StringConstants.ts
@@ -24,3 +24,7 @@ export function RUN_UNDER_SUDO_LOCK(sudoDirectory: string): string
 }
 
 export const UNABLE_TO_ACQUIRE_GLOBAL_LOCK_ERR = '898998';
+
+export const UBUNTU_DISTRO_INFO_KEY = 'Ubuntu';
+export const RED_HAT_DISTRO_INFO_KEY = 'Red Hat Enterprise Linux';
+export const DEBIAN_DISTRO_INFO_KEY = 'Debian GNU/Linux';

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -480,7 +480,7 @@ export class MockFileUtilities extends IFileUtilities
 
     public async realpath(filePath: string): Promise<string | null>
     {
-        return new FileUtilities().realpath(filePath);
+        return this.filePathsAndReadValues[filePath] || new FileUtilities().realpath(filePath);
     }
 
 }

--- a/vscode-dotnet-runtime-library/src/test/unit/DebianDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DebianDistroTests.test.ts
@@ -5,10 +5,10 @@
  * ------------------------------------------------------------------------------------------ */
 import * as chai from 'chai';
 import * as os from 'os';
+import { MockCommandExecutor } from '../mocks/MockObjects';
 import { DebianDistroSDKProvider } from '../../Acquisition/DebianDistroSDKProvider';
 import { DotnetInstallMode } from '../../Acquisition/DotnetInstallMode';
 import { DistroVersionPair, DotnetDistroSupportStatus, LinuxVersionResolver } from '../../Acquisition/LinuxVersionResolver';
-import { MockCommandExecutor } from '../mocks/MockObjects';
 import { getDistroInfo, getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
 import { DEBIAN_DISTRO_INFO_KEY } from '../../Acquisition/StringConstants';
 const assert = chai.assert;

--- a/vscode-dotnet-runtime-library/src/test/unit/DebianDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DebianDistroTests.test.ts
@@ -5,30 +5,36 @@
  * ------------------------------------------------------------------------------------------ */
 import * as chai from 'chai';
 import * as os from 'os';
-import { MockCommandExecutor, MockEventStream } from '../mocks/MockObjects';
 import { DebianDistroSDKProvider } from '../../Acquisition/DebianDistroSDKProvider';
 import { DotnetInstallMode } from '../../Acquisition/DotnetInstallMode';
 import { DistroVersionPair, DotnetDistroSupportStatus, LinuxVersionResolver } from '../../Acquisition/LinuxVersionResolver';
-import { getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
+import { MockCommandExecutor } from '../mocks/MockObjects';
+import { getDistroInfo, getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
+import { DEBIAN_DISTRO_INFO_KEY } from '../../Acquisition/StringConstants';
 const assert = chai.assert;
 const standardTimeoutTime = 100000;
 
 const mockVersion = '7.0.103';
 const acquisitionContext = getMockAcquisitionContext('sdk', mockVersion);
 const mockExecutor = new MockCommandExecutor(acquisitionContext, getMockUtilityContext());
-const pair: DistroVersionPair = { distro: 'Debian GNU/Linux', version: '12' };
+const pair: DistroVersionPair = { distro: DEBIAN_DISTRO_INFO_KEY, version: '12' };
 const provider: DebianDistroSDKProvider = new DebianDistroSDKProvider(pair, acquisitionContext, getMockUtilityContext(), mockExecutor);
-const shouldRun = os.platform() === 'linux';
 const installType: DotnetInstallMode = 'sdk';
 const noDotnetString = `
 dotnet: command not found
 `
 
+async function shouldRun()
+{
+    const distroInfo = await getDistroInfo(acquisitionContext);
+    return os.platform() === 'linux' && distroInfo.distro === DEBIAN_DISTRO_INFO_KEY;
+}
+
 suite('Debian Distro Logic Unit Tests', () =>
 {
     test('Recommends Correct Version', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
             assert.equal(mockExecutor.attemptedCommand,
@@ -41,7 +47,7 @@ suite('Debian Distro Logic Unit Tests', () =>
 
     test('Package Check Succeeds', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             // assert this passes : we don't want the test to be reliant on machine state for whether the package exists or not, so don't check output
             await provider.dotnetPackageExistsOnSystem(mockVersion, installType);
@@ -51,7 +57,7 @@ suite('Debian Distro Logic Unit Tests', () =>
 
     test('Support Status Check', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             const status = await provider.getDotnetVersionSupportStatus(mockVersion, installType);
             assert.equal(status, DotnetDistroSupportStatus.Microsoft);
@@ -60,7 +66,7 @@ suite('Debian Distro Logic Unit Tests', () =>
 
     test('Gets Distro Feed Install Dir', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             const distroFeedDir = await provider.getExpectedDotnetDistroFeedInstallationDirectory();
             assert.equal(distroFeedDir, '/usr/lib/dotnet');
@@ -69,7 +75,7 @@ suite('Debian Distro Logic Unit Tests', () =>
 
     test('Gets Microsoft Feed Install Dir', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             const microsoftFeedDir = await provider.getExpectedDotnetMicrosoftFeedInstallationDirectory();
             assert.equal(microsoftFeedDir, '/usr/share/dotnet');
@@ -78,7 +84,7 @@ suite('Debian Distro Logic Unit Tests', () =>
 
     test('Gets Installed SDKs', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             mockExecutor.fakeReturnValue = {
                 stdout: `
@@ -98,7 +104,7 @@ suite('Debian Distro Logic Unit Tests', () =>
 
     test('Gets Installed Runtimes', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             mockExecutor.fakeReturnValue = {
                 stdout: `
@@ -118,7 +124,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
 
     test('Looks for Global Dotnet Path Correctly', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             await provider.getInstalledGlobalDotnetPathIfExists(installType);
             assert.equal(mockExecutor.attemptedCommand, 'readlink -f /usr/bin/dotnet');
@@ -127,7 +133,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
 
     test('Finds Existing Global Dotnet Version', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             mockExecutor.fakeReturnValue = { stdout: `7.0.105`, stderr: '', status: '0' };
             let currentInfo = await provider.getInstalledGlobalDotnetVersionIfExists();
@@ -143,7 +149,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
 
     test('Gives Correct Version Support Info', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             let supported = await provider.isDotnetVersionSupported('11.0.101', installType);
             // In the mock data, 8.0 is not supported, so it should be false.
@@ -158,7 +164,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
 
     test('Runs Correct Install Command', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             await provider.installDotnet(mockVersion, installType);
             assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get -o DPkg::Lock::Timeout=180 install -y dotnet-sdk-7.0');
@@ -167,7 +173,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
 
     test('Runs Correct Uninstall Command', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             await provider.uninstallDotnet(mockVersion, installType);
             assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get -o DPkg::Lock::Timeout=180 remove -y dotnet-sdk-7.0');
@@ -176,7 +182,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
 
     test('Runs Correct Update Command', async () =>
     {
-        if (shouldRun)
+        if (await shouldRun())
         {
             await provider.upgradeDotnet(mockVersion, installType);
             assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get -o DPkg::Lock::Timeout=180 upgrade -y dotnet-sdk-7.0');

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
@@ -21,9 +21,13 @@ suite('DotnetPathFinder Unit Tests', function ()
     const installRecordPathNoArch = `/etc/dotnet/install_location`;
     const fakeDotnetPath = 'fake/dotnet';
 
-    const mockContext = getMockAcquisitionContext('sdk', '11.0');
+    const mockContext = getMockAcquisitionContext('sdk', '8.0');
     const mockUtility = getMockUtilityContext();
     const mockExecutor = new MockCommandExecutor(mockContext, mockUtility);
+    if (os.platform() !== 'win32')
+    {
+        mockExecutor.fakeReturnValue = { stdout: `8.0.101 [${fakeDotnetPath}]`, stderr: '', status: '0' };
+    }
 
     this.afterEach(async () =>
     {
@@ -35,7 +39,6 @@ suite('DotnetPathFinder Unit Tests', function ()
     test('It can find the hostfxr record on mac/linux', async () =>
     {
         // Make it look like theres an install on the host in case we want to validate it if we ever want to add win32 test like so
-        // mockExecutor.fakeReturnValue = { stdout: '8.0.101 [C:\\Program Files\\dotnet\\sdk]', stderr: '', status: '0' };
         if (os.platform() !== 'win32')
         {
             const mockFile = new MockFileUtilities();

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
@@ -26,7 +26,7 @@ suite('DotnetPathFinder Unit Tests', function ()
     const mockExecutor = new MockCommandExecutor(mockContext, mockUtility);
     if (os.platform() !== 'win32')
     {
-        mockExecutor.fakeReturnValue = { stdout: `8.0.101 [${fakeDotnetPath}/dotnet/shared/Microsoft.AspNetCore.App]`, stderr: '', status: '0' };
+        mockExecutor.fakeReturnValue = { stdout: `Microsoft.NETCore.App 8.0.10 [${fakeDotnetPath}/shared/Microsoft.NetCoreApp.App]`, stderr: '', status: '0' };
     }
 
     this.afterEach(async () =>

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
@@ -26,7 +26,7 @@ suite('DotnetPathFinder Unit Tests', function ()
     const mockExecutor = new MockCommandExecutor(mockContext, mockUtility);
     if (os.platform() !== 'win32')
     {
-        mockExecutor.fakeReturnValue = { stdout: `8.0.101 [${fakeDotnetPath}]`, stderr: '', status: '0' };
+        mockExecutor.fakeReturnValue = { stdout: `8.0.101 [${fakeDotnetPath}/dotnet/shared/Microsoft.AspNetCore.App]`, stderr: '', status: '0' };
     }
 
     this.afterEach(async () =>

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetPathFinder.test.ts
@@ -21,7 +21,7 @@ suite('DotnetPathFinder Unit Tests', function ()
     const installRecordPathNoArch = `/etc/dotnet/install_location`;
     const fakeDotnetPath = 'fake/dotnet';
 
-    const mockContext = getMockAcquisitionContext('sdk', '8.0');
+    const mockContext = getMockAcquisitionContext('sdk', '11.0');
     const mockUtility = getMockUtilityContext();
     const mockExecutor = new MockCommandExecutor(mockContext, mockUtility);
 
@@ -34,7 +34,7 @@ suite('DotnetPathFinder Unit Tests', function ()
 
     test('It can find the hostfxr record on mac/linux', async () =>
     {
-        // Make it look like theres an 8.0 install on the host in case we want to validate it if we ever want to add win32 test like so
+        // Make it look like theres an install on the host in case we want to validate it if we ever want to add win32 test like so
         // mockExecutor.fakeReturnValue = { stdout: '8.0.101 [C:\\Program Files\\dotnet\\sdk]', stderr: '', status: '0' };
         if (os.platform() !== 'win32')
         {

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -7,18 +7,20 @@ import * as chai from 'chai';
 import * as os from 'os';
 import { DotnetInstallMode } from '../../Acquisition/DotnetInstallMode';
 import { GenericDistroSDKProvider } from '../../Acquisition/GenericDistroSDKProvider';
-import { DistroVersionPair, DotnetDistroSupportStatus, LinuxVersionResolver } from '../../Acquisition/LinuxVersionResolver';
+import { DistroVersionPair, DotnetDistroSupportStatus } from '../../Acquisition/LinuxVersionResolver';
+import * as versionUtils from '../../Acquisition/VersionUtilities';
 import { LocalMemoryCacheSingleton } from '../../LocalMemoryCacheSingleton';
 import { WebRequestWorkerSingleton } from '../../Utils/WebRequestWorkerSingleton';
 import { MockCommandExecutor } from '../mocks/MockObjects';
-import { getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
+import { UBUNTU_DISTRO_INFO_KEY } from '../../Acquisition/StringConstants';
+import { getLatestLinuxDotnet, getLinuxSupportedDotnetSDKVersion, getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
 const assert = chai.assert;
 const standardTimeoutTime = 100000;
 
-const mockVersion = '7.0.103';
+const mockVersion = '8.0.103';
 const acquisitionContext = getMockAcquisitionContext('sdk', mockVersion);
 const mockExecutor = new MockCommandExecutor(acquisitionContext, getMockUtilityContext());
-const pair: DistroVersionPair = { distro: 'Ubuntu', version: '22.04' };
+const pair: DistroVersionPair = { distro: UBUNTU_DISTRO_INFO_KEY, version: '24.04' };
 const provider: GenericDistroSDKProvider = new GenericDistroSDKProvider(pair, acquisitionContext, getMockUtilityContext(), mockExecutor);
 const shouldRun = os.platform() === 'linux';
 const installType: DotnetInstallMode = 'sdk';
@@ -27,8 +29,8 @@ Command 'dotnet' not found, but can be installed with:
 
             snap install dotnet-sdk # version 7.0.304, or
 
-            apt install dotnet-host # version 6.0.118-06ubuntu1~22.04.1
-            apt install dotnet-host-7.0 # version 7.0.107-6ubuntu1~22.04.1
+            apt install dotnet-host # version 6.0.118-06ubuntu1~24.04.1
+            apt install dotnet-host-7.0 # version 7.0.107-6ubuntu1~24.04.1
             See 'snap info dotnet-sdk' for additional versions.
 `
 
@@ -47,10 +49,9 @@ suite('Linux Distro Logic Unit Tests', function ()
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
             assert.equal(mockExecutor.attemptedCommand,
-                'apt-cache -o DPkg::Lock::Timeout=180 search --names-only ^dotnet-sdk-9.0$', 'Searched for the newest package last with regex'); // this may fail if test not exec'd first
+                `apt-cache -o DPkg::Lock::Timeout=180 search --names-only ^dotnet-sdk-${versionUtils.getMajorMinor(getLatestLinuxDotnet(), acquisitionContext.eventStream, acquisitionContext)}$`, 'Searched for the newest package last with regex'); // this may fail if test not exec'd first
             // the data is cached so --version may not be executed.
-            const distroVersion = await new LinuxVersionResolver(acquisitionContext, getMockUtilityContext()).getRunningDistro();
-            assert.equal(recVersion, Number(distroVersion.version) >= 22.04 ? '9.0.1xx' : '8.0.1xx', 'Resolved the most recent available version : will eventually break if the mock data is not updated');
+            assert.equal(recVersion, await getLinuxSupportedDotnetSDKVersion(acquisitionContext), 'Resolved the most recent available version : will eventually break if the mock data is not updated');
         }
     }).timeout(standardTimeoutTime);
 
@@ -60,7 +61,8 @@ suite('Linux Distro Logic Unit Tests', function ()
         {
             // assert this passes : we don't want the test to be reliant on machine state for whether the package exists or not, so don't check output
             await provider.dotnetPackageExistsOnSystem(mockVersion, installType);
-            assert.equal(mockExecutor.attemptedCommand, 'dpkg -l dotnet-sdk-7.0');
+            const version = await getLinuxSupportedDotnetSDKVersion(acquisitionContext);
+            assert.equal(mockExecutor.attemptedCommand, `dpkg -l dotnet-sdk-${versionUtils.getMajorMinor(version, acquisitionContext.eventStream, acquisitionContext)}`);
         }
     }).timeout(standardTimeoutTime);
 
@@ -144,10 +146,10 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
     {
         if (shouldRun)
         {
-            mockExecutor.fakeReturnValue = { stdout: `7.0.105`, stderr: '', status: '0' };
+            mockExecutor.fakeReturnValue = { stdout: mockVersion, stderr: '', status: '0' };
             let currentInfo = await provider.getInstalledGlobalDotnetVersionIfExists();
             mockExecutor.resetReturnValues();
-            assert.equal(currentInfo, '7.0.105');
+            assert.equal(currentInfo, mockVersion);
 
             mockExecutor.fakeReturnValue = { stdout: noDotnetString, stderr: noDotnetString, status: '0' };
             currentInfo = await provider.getInstalledGlobalDotnetVersionIfExists();
@@ -163,10 +165,10 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
             let supported = await provider.isDotnetVersionSupported('11.0.101', installType);
             // In the mock data, 8.0 is not supported, so it should be false.
             assert.equal(supported, false);
-            supported = await provider.isDotnetVersionSupported('7.0.101', installType);
+            supported = await provider.isDotnetVersionSupported(await getLinuxSupportedDotnetSDKVersion(acquisitionContext), installType);
             assert.equal(supported, true);
             // this feature band isn't supported by most distros yet.
-            supported = await provider.isDotnetVersionSupported('7.0.201', installType);
+            supported = await provider.isDotnetVersionSupported(await getLinuxSupportedDotnetSDKVersion(acquisitionContext), installType);
             assert.equal(supported, false);
         }
     }).timeout(standardTimeoutTime);
@@ -176,7 +178,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
         if (shouldRun)
         {
             await provider.installDotnet(mockVersion, installType);
-            assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get -o DPkg::Lock::Timeout=180 install -y dotnet-sdk-7.0');
+            assert.equal(mockExecutor.attemptedCommand, `sudo apt-get -o DPkg::Lock::Timeout=180 install -y dotnet-sdk-${versionUtils.getMajorMinor(mockVersion, acquisitionContext.eventStream, acquisitionContext)}`);
         }
     }).timeout(standardTimeoutTime);
 
@@ -185,7 +187,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
         if (shouldRun)
         {
             await provider.uninstallDotnet(mockVersion, installType);
-            assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get -o DPkg::Lock::Timeout=180 remove -y dotnet-sdk-7.0');
+            assert.equal(mockExecutor.attemptedCommand, `sudo apt-get -o DPkg::Lock::Timeout=180 remove -y dotnet-sdk-${versionUtils.getMajorMinor(mockVersion, acquisitionContext.eventStream, acquisitionContext)}`);
         }
     }).timeout(standardTimeoutTime);
 
@@ -194,7 +196,7 @@ Microsoft.NETCore.App 7.0.5 [/usr/lib/dotnet/shared/Microsoft.NETCore.App]`, std
         if (shouldRun)
         {
             await provider.upgradeDotnet(mockVersion, installType);
-            assert.equal(mockExecutor.attemptedCommand, 'sudo apt-get -o DPkg::Lock::Timeout=180 upgrade -y dotnet-sdk-7.0');
+            assert.equal(mockExecutor.attemptedCommand, `sudo apt-get -o DPkg::Lock::Timeout=180 upgrade -y dotnet-sdk-${versionUtils.getMajorMinor(mockVersion, acquisitionContext.eventStream, acquisitionContext)}`);
         }
     }).timeout(standardTimeoutTime * 1000);
 });

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxVersionResolver.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxVersionResolver.test.ts
@@ -11,6 +11,7 @@ import { WebRequestWorkerSingleton } from '../../Utils/WebRequestWorkerSingleton
 import { MockCommandExecutor, MockDistroProvider } from '../mocks/MockObjects';
 import * as util from './TestUtility';
 import { getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
+import { RED_HAT_DISTRO_INFO_KEY, UBUNTU_DISTRO_INFO_KEY } from '../../Acquisition/StringConstants';
 const assert = chai.assert;
 
 
@@ -21,8 +22,8 @@ suite('Linux Version Resolver Tests', function ()
     const mockVersion = '7.0.103';
     const acquisitionContext = getMockAcquisitionContext('sdk', mockVersion);
     const mockExecutor = new MockCommandExecutor(acquisitionContext, getMockUtilityContext());
-    const pair: DistroVersionPair = { distro: 'Ubuntu', version: '22.04' };
-    const redHatPair: DistroVersionPair = { distro: 'Red Hat Enterprise Linux', version: '7.3' };
+    const pair: DistroVersionPair = { distro: UBUNTU_DISTRO_INFO_KEY, version: '24.04' };
+    const redHatPair: DistroVersionPair = { distro: RED_HAT_DISTRO_INFO_KEY, version: '7.3' };
     const shouldRun = os.platform() === 'linux';
     const context = util.getMockAcquisitionContext('sdk', mockVersion);
     const mockRedHatProvider = new MockDistroProvider(redHatPair, context, getMockUtilityContext(), mockExecutor);

--- a/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
@@ -12,13 +12,14 @@ import { LocalMemoryCacheSingleton } from '../../LocalMemoryCacheSingleton';
 import { WebRequestWorkerSingleton } from '../../Utils/WebRequestWorkerSingleton';
 import { MockCommandExecutor } from '../mocks/MockObjects';
 import { getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
+import { RED_HAT_DISTRO_INFO_KEY } from '../../Acquisition/StringConstants';
 const assert = chai.assert;
 const standardTimeoutTime = 100000;
 
 const mockVersion = '7.0.103';
 const acquisitionContext = getMockAcquisitionContext('sdk', mockVersion);
 const mockExecutor = new MockCommandExecutor(acquisitionContext, getMockUtilityContext());
-const pair: DistroVersionPair = { distro: 'Red Hat Enterprise Linux', version: '9.0' };
+const pair: DistroVersionPair = { distro: RED_HAT_DISTRO_INFO_KEY, version: '9.0' };
 const provider: RedHatDistroSDKProvider = new RedHatDistroSDKProvider(pair, acquisitionContext, getMockUtilityContext(), mockExecutor);
 const versionResolver = new LinuxVersionResolver(acquisitionContext, getMockUtilityContext(), mockExecutor);
 let shouldRun = os.platform() === 'linux';
@@ -45,7 +46,7 @@ suite('Red Hat For Linux Distro Logic Unit Tests', function ()
 
     test('Package Check Succeeds', async () =>
     {
-        shouldRun = os.platform() === 'linux' && (await versionResolver.getRunningDistro()).distro === 'Red Hat Enterprise Linux';
+        shouldRun = os.platform() === 'linux' && (await versionResolver.getRunningDistro()).distro === RED_HAT_DISTRO_INFO_KEY;
 
         if (shouldRun)
         {

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -4,8 +4,6 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { MockDotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext, MockInstallationValidator, MockVSCodeEnvironment, MockVSCodeExtensionContext } from '../mocks/MockObjects';
-import { MockWindowDisplayWorker } from '../mocks/MockWindowDisplayWorker';
 import * as os from 'os';
 import { directoryProviderFactory } from '../../Acquisition/DirectoryProviderFactory';
 import { DotnetInstallMode } from '../../Acquisition/DotnetInstallMode';
@@ -16,6 +14,8 @@ import { RED_HAT_DISTRO_INFO_KEY, UBUNTU_DISTRO_INFO_KEY } from '../../Acquisiti
 import { IEventStream } from '../../EventStream/EventStream';
 import { IDotnetAcquireContext } from '../../IDotnetAcquireContext';
 import { IUtilityContext } from '../../Utils/IUtilityContext';
+import { MockDotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext, MockInstallationValidator, MockVSCodeEnvironment, MockVSCodeExtensionContext } from '../mocks/MockObjects';
+import { MockWindowDisplayWorker } from '../mocks/MockWindowDisplayWorker';
 
 const standardTimeoutTime = 100000;
 
@@ -114,7 +114,7 @@ export async function getLinuxSupportedDotnetSDKVersion(context: IAcquisitionWor
         }
         if (distroInfo.version < '24.04')
         {
-            return '9.0.100';
+            return '8.0.100';
         }
         else
         {

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -4,6 +4,8 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+import { MockDotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext, MockInstallationValidator, MockVSCodeEnvironment, MockVSCodeExtensionContext } from '../mocks/MockObjects';
+import { MockWindowDisplayWorker } from '../mocks/MockWindowDisplayWorker';
 import { directoryProviderFactory } from '../../Acquisition/DirectoryProviderFactory';
 import { DotnetInstallMode } from '../../Acquisition/DotnetInstallMode';
 import { IAcquisitionWorkerContext } from '../../Acquisition/IAcquisitionWorkerContext';
@@ -13,8 +15,6 @@ import { RED_HAT_DISTRO_INFO_KEY, UBUNTU_DISTRO_INFO_KEY } from '../../Acquisiti
 import { IEventStream } from '../../EventStream/EventStream';
 import { IDotnetAcquireContext } from '../../IDotnetAcquireContext';
 import { IUtilityContext } from '../../Utils/IUtilityContext';
-import { MockDotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext, MockInstallationValidator, MockVSCodeEnvironment, MockVSCodeExtensionContext } from '../mocks/MockObjects';
-import { MockWindowDisplayWorker } from '../mocks/MockWindowDisplayWorker';
 
 const standardTimeoutTime = 100000;
 

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -3,26 +3,27 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-import * as os from 'os';
 
-import { MockWindowDisplayWorker } from '../mocks/MockWindowDisplayWorker';
-import { MockDotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext, MockInstallationValidator, MockVSCodeEnvironment, MockVSCodeExtensionContext } from '../mocks/MockObjects';
-import { IDotnetAcquireContext } from '../../IDotnetAcquireContext';
-import { IAcquisitionWorkerContext } from '../../Acquisition/IAcquisitionWorkerContext';
-import { IEventStream } from '../../EventStream/EventStream';
-import { IUtilityContext } from '../../Utils/IUtilityContext';
-import { IInstallationDirectoryProvider } from '../../Acquisition/IInstallationDirectoryProvider';
 import { directoryProviderFactory } from '../../Acquisition/DirectoryProviderFactory';
 import { DotnetInstallMode } from '../../Acquisition/DotnetInstallMode';
+import { IAcquisitionWorkerContext } from '../../Acquisition/IAcquisitionWorkerContext';
+import { IInstallationDirectoryProvider } from '../../Acquisition/IInstallationDirectoryProvider';
+import { DistroVersionPair, LinuxVersionResolver } from '../../Acquisition/LinuxVersionResolver';
+import { RED_HAT_DISTRO_INFO_KEY, UBUNTU_DISTRO_INFO_KEY } from '../../Acquisition/StringConstants';
+import { IEventStream } from '../../EventStream/EventStream';
+import { IDotnetAcquireContext } from '../../IDotnetAcquireContext';
+import { IUtilityContext } from '../../Utils/IUtilityContext';
+import { MockDotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext, MockInstallationValidator, MockVSCodeEnvironment, MockVSCodeExtensionContext } from '../mocks/MockObjects';
+import { MockWindowDisplayWorker } from '../mocks/MockWindowDisplayWorker';
 
 const standardTimeoutTime = 100000;
 
-export function getMockAcquisitionContext(mode: DotnetInstallMode, version : string, timeoutTime : number = standardTimeoutTime, customEventStream? : IEventStream,
-    customContext? : MockExtensionContext, arch? : string | null, directory? : IInstallationDirectoryProvider): IAcquisitionWorkerContext
+export function getMockAcquisitionContext(mode: DotnetInstallMode, version: string, timeoutTime: number = standardTimeoutTime, customEventStream?: IEventStream,
+    customContext?: MockExtensionContext, arch?: string | null, directory?: IInstallationDirectoryProvider): IAcquisitionWorkerContext
 {
     const extensionContext = customContext ?? new MockExtensionContext();
     const myEventStream = customEventStream ?? new MockEventStream();
-    const workerContext : IAcquisitionWorkerContext =
+    const workerContext: IAcquisitionWorkerContext =
     {
         storagePath: '',
         extensionState: extensionContext,
@@ -38,11 +39,11 @@ export function getMockAcquisitionContext(mode: DotnetInstallMode, version : str
     return workerContext;
 }
 
-export function getMockAcquisitionWorkerContext(acquireContext : IDotnetAcquireContext)
+export function getMockAcquisitionWorkerContext(acquireContext: IDotnetAcquireContext)
 {
     const extensionContext = new MockExtensionContext();
     const myEventStream = new MockEventStream();
-    const workerContext : IAcquisitionWorkerContext =
+    const workerContext: IAcquisitionWorkerContext =
     {
         storagePath: '',
         extensionState: extensionContext,
@@ -58,24 +59,24 @@ export function getMockAcquisitionWorkerContext(acquireContext : IDotnetAcquireC
     return workerContext;
 }
 
-export function getMockAcquisitionWorker(mockContext : IAcquisitionWorkerContext) : MockDotnetCoreAcquisitionWorker
+export function getMockAcquisitionWorker(mockContext: IAcquisitionWorkerContext): MockDotnetCoreAcquisitionWorker
 {
     const acquisitionWorker = new MockDotnetCoreAcquisitionWorker(getMockUtilityContext(), new MockVSCodeExtensionContext());
     return acquisitionWorker;
 }
 
-export function getMockUtilityContext() : IUtilityContext
+export function getMockUtilityContext(): IUtilityContext
 {
-    const utilityContext : IUtilityContext = {
-        ui : new MockWindowDisplayWorker(),
-        vsCodeEnv : new MockVSCodeEnvironment()
+    const utilityContext: IUtilityContext = {
+        ui: new MockWindowDisplayWorker(),
+        vsCodeEnv: new MockVSCodeEnvironment()
     }
     return utilityContext;
 }
 
-export function getMockAcquireContext(nextAcquiringVersion : string, arch : string | null | undefined, installMode : DotnetInstallMode) : IDotnetAcquireContext
+export function getMockAcquireContext(nextAcquiringVersion: string, arch: string | null | undefined, installMode: DotnetInstallMode): IDotnetAcquireContext
 {
-    const acquireContext : IDotnetAcquireContext =
+    const acquireContext: IDotnetAcquireContext =
     {
         version: nextAcquiringVersion,
         architecture: arch,
@@ -83,4 +84,53 @@ export function getMockAcquireContext(nextAcquiringVersion : string, arch : stri
         mode: installMode
     };
     return acquireContext;
+}
+
+export async function getDistroInfo(context: IAcquisitionWorkerContext): Promise<DistroVersionPair>
+{
+    return new LinuxVersionResolver(context, getMockUtilityContext()).getRunningDistro();
+}
+
+/**
+ *
+ * @param distroInfo The distro and version of the system
+ * @returns The built-in distro supported version of the .NET SDK.
+ * Only maintaining the microsoft supported versions for now.
+ */
+export async function getLinuxSupportedDotnetSDKVersion(context: IAcquisitionWorkerContext, distroInfo?: DistroVersionPair): Promise<string>
+{
+    distroInfo ??= await getDistroInfo(context);
+
+    if (distroInfo.distro === UBUNTU_DISTRO_INFO_KEY)
+    {
+        if (distroInfo.version < '22.04')
+        {
+            return '6.0.100';
+        }
+        if (distroInfo.version < '24.04')
+        {
+            return '7.0.100';
+        }
+        else
+        {
+            return '8.0.100';
+        }
+    }
+    else if (distroInfo.distro === RED_HAT_DISTRO_INFO_KEY)
+    {
+        if (distroInfo.version < '8.0')
+        {
+            return '7.0.100';
+        }
+        else
+        {
+            return '9.0.100';
+        }
+    }
+    return getLatestLinuxDotnet(); // best effort guess for latest 'dotnet' version atm.
+}
+
+export function getLatestLinuxDotnet()
+{
+    return '9.0.100';
 }

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -6,6 +6,7 @@
 
 import { MockDotnetCoreAcquisitionWorker, MockEventStream, MockExtensionContext, MockInstallationValidator, MockVSCodeEnvironment, MockVSCodeExtensionContext } from '../mocks/MockObjects';
 import { MockWindowDisplayWorker } from '../mocks/MockWindowDisplayWorker';
+import * as os from 'os';
 import { directoryProviderFactory } from '../../Acquisition/DirectoryProviderFactory';
 import { DotnetInstallMode } from '../../Acquisition/DotnetInstallMode';
 import { IAcquisitionWorkerContext } from '../../Acquisition/IAcquisitionWorkerContext';

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -109,7 +109,8 @@ export async function getLinuxSupportedDotnetSDKVersion(context: IAcquisitionWor
         }
         if (distroInfo.version < '24.04')
         {
-            return '7.0.100';
+            return '9.0.100';
+
         }
         else
         {

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -88,6 +88,10 @@ export function getMockAcquireContext(nextAcquiringVersion: string, arch: string
 
 export async function getDistroInfo(context: IAcquisitionWorkerContext): Promise<DistroVersionPair>
 {
+    if (os.platform() !== 'linux')
+    {
+        return { distro: '', version: '' };
+    }
     return new LinuxVersionResolver(context, getMockUtilityContext()).getRunningDistro();
 }
 
@@ -110,7 +114,6 @@ export async function getLinuxSupportedDotnetSDKVersion(context: IAcquisitionWor
         if (distroInfo.version < '24.04')
         {
             return '9.0.100';
-
         }
         else
         {


### PR DESCRIPTION
The tests are conditioned to check the support status of dotnet, etc. Last night the CI runners got updated to Ubuntu 24.04. 24.04 does not have .NET 9 support built-in, which means the versions of dotnet either went up or down.

The old logic was somewhat spread out.
This is still not ideal but this at least reduces the points of contact that need updated. Maybe this is a bit too extensive of code cleanup for fixing a breaking pipeline, though I'm the only one who will be blocked by this for now, so I think it's ok.

Some of the strings that got updated were just placeholder data.