### PR TITLE
Fix Linux Mutex Utilization

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -133,7 +133,7 @@ export class DotnetPathFinder implements IDotnetPathFinder
 
         else
         {
-            this.executor?.execute(CommandExecutor.makeCommand('env', []), { dotnetInstallToolCacheTtlMs: DOTNET_INFORMATION_CACHE_DURATION_MS }, false)
+            this.executor?.execute(CommandExecutor.makeCommand('echo', ['PATH']), { dotnetInstallToolCacheTtlMs: DOTNET_INFORMATION_CACHE_DURATION_MS }, false)
                 .then((result) =>
                 {
                     // Log the default shell state
@@ -143,7 +143,7 @@ export class DotnetPathFinder implements IDotnetPathFinder
 
             if (!(options.shell === '/bin/bash'))
             {
-                this.executor?.execute(CommandExecutor.makeCommand('env', []), { shell: 'bin/bash', dotnetInstallToolCacheTtlMs: SYS_CMD_SEARCH_CACHE_DURATION_MS }, false)
+                this.executor?.execute(CommandExecutor.makeCommand('echo', ['PATH']), { shell: 'bin/bash', dotnetInstallToolCacheTtlMs: SYS_CMD_SEARCH_CACHE_DURATION_MS }, false)
                     .then((result) =>
                     {
                         this.workerContext.eventStream.post(new DotnetFindPathLookupPATH(`Execution Path (Unix Bash): ${result?.stdout}`));

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -1173,6 +1173,11 @@ export class SudoDirCreationFailed extends DotnetCustomMessageEvent
     public readonly eventName = 'SudoDirCreationFailed';
 }
 
+export class SudoDirDeletionFailed extends DotnetCustomMessageEvent
+{
+    public readonly eventName = 'SudoDirDeletionFailed';
+}
+
 export class DotnetFindPathOnFileSystem extends DotnetCustomMessageEvent
 {
     public readonly eventName = 'DotnetFindPathOnFileSystem';

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -1535,6 +1535,10 @@ export class NetInstallerEndExecutionEvent extends DotnetCustomMessageEvent
     public readonly eventName = 'NetInstallerEndExecutionEvent';
 }
 
+export class FailedToRunSudoCommand extends DotnetCustomMessageEvent
+{
+    public readonly eventName = 'FailedToRunSudoCommand';
+}
 
 export class DotnetInstallLinuxChecks extends DotnetCustomMessageEvent
 {

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -1168,6 +1168,11 @@ export class DotnetFindPathNoHostOnRegistry extends DotnetCustomMessageEvent
     public readonly eventName = 'DotnetFindPathNoHostOnRegistry';
 }
 
+export class SudoDirCreationFailed extends DotnetCustomMessageEvent
+{
+    public readonly eventName = 'SudoDirCreationFailed';
+}
+
 export class DotnetFindPathOnFileSystem extends DotnetCustomMessageEvent
 {
     public readonly eventName = 'DotnetFindPathOnFileSystem';

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -99,10 +99,12 @@ export class CommandExecutor extends ICommandExecutor
         catch (error: any)
         {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            error.message = error.message + `\nFailed to create ${this.sudoProcessCommunicationDir}. Please check your permissions or install dotnet manually.`;
+            error.message = error?.message + `\nFailed to create ${this.sudoProcessCommunicationDir}. Please check your permissions or install dotnet manually.`;
             this.context?.eventStream.post(new SudoDirCreationFailed(`The command ${fullCommandString} failed, as no directory could be made: ${JSON.stringify(error)}`));
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             if (error?.code !== 'EEXIST')
             {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 if (error?.code === 'EPERM' || error?.code === 'EACCES')
                 {
                     this.sudoProcessCommunicationDir = path.dirname(this.sudoProcessScript);

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -145,7 +145,7 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
         }
         else
         {
-            if (await this.sudoProcIsLive(false, fullCommandString, 2000)) // If the sudo process was spawned by another instance of code, we do not want to have 2 at once but also do not waste a lot of time checking
+            if (await this.sudoProcIsLive(false, fullCommandString, 500)) // If the sudo process was spawned by another instance of code, we do not want to have 2 at once but also do not waste a lot of time checking
             // As it should not be in the middle of an operation which may cause it to take a while, unless it was pkilled.
             {
                 return '0';

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -281,11 +281,12 @@ ${stderr}`));
 
 
         const waitTimeMs = this.context?.timeoutSeconds ? (Math.max(this.context?.timeoutSeconds * 1000, 1000)) : 600000;
-        await loopWithTimeoutOnCond(100, waitTimeMs,
+        const sampleRateMs = 100;
+        await loopWithTimeoutOnCond(sampleRateMs, waitTimeMs,
             function ProcessFinishedExecutingAndWroteOutput(): boolean { return fs.existsSync(outputFile) },
             function doNothing(): void { ; },
             this.context.eventStream,
-            new SudoProcCommandExchangePing(`Ping : Waiting. ${new Date().toISOString()}`)
+            new SudoProcCommandExchangePing(`Ping : Waiting, at rate ${sampleRateMs} with timeout ${waitTimeMs} ${new Date().toISOString()}`)
         )
             .catch(error =>
             {

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -98,6 +98,7 @@ export class CommandExecutor extends ICommandExecutor
         }
         catch (error: any)
         {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             error.message = error.message + `\nFailed to create ${this.sudoProcessCommunicationDir}. Please check your permissions or install dotnet manually.`;
             this.context?.eventStream.post(new SudoDirCreationFailed(`The command ${fullCommandString} failed, as no directory could be made: ${JSON.stringify(error)}`));
         }

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -101,6 +101,17 @@ export class CommandExecutor extends ICommandExecutor
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             error.message = error.message + `\nFailed to create ${this.sudoProcessCommunicationDir}. Please check your permissions or install dotnet manually.`;
             this.context?.eventStream.post(new SudoDirCreationFailed(`The command ${fullCommandString} failed, as no directory could be made: ${JSON.stringify(error)}`));
+            if (error?.code !== 'EEXIST')
+            {
+                if (error?.code === 'EPERM' || error?.code === 'EACCES')
+                {
+                    this.sudoProcessCommunicationDir = path.dirname(this.sudoProcessScript);
+                }
+                else
+                {
+                    throw error;
+                }
+            }
         }
 
         if (await isRunningUnderWSL(this.context, this.utilityContext, this))

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -393,6 +393,19 @@ ${stderr}`));
                 eventStream.post(new TriedToExitMasterSudoProcess(`Tried to exit sudo master process: exit code ${LockUsedByThisInstanceSingleton.getInstance().hasSpawnedSudoSuccessfullyWithoutDeath()}`));
             });
 
+        try
+        {
+            fs.rmdirSync(this.sudoProcessCommunicationDir, { recursive: true });
+        }
+        catch (error: any)
+        {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            if (error?.code !== 'ENOENT')
+            {
+                eventStream.post(new SudoDirCreationFailed(`The command ${this.sudoProcessCommunicationDir} failed to rm the sudo directory: ${JSON.stringify(error)}`));
+            }
+        }
+
         return LockUsedByThisInstanceSingleton.getInstance().hasSpawnedSudoSuccessfullyWithoutDeath() ? 1 : 0;
     }
 

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -144,14 +144,6 @@ Please install the .NET SDK manually by following https://learn.microsoft.com/en
                 return '0';
             }
         }
-        else
-        {
-            if (await this.sudoProcIsLive(false, fullCommandString, 500)) // If the sudo process was spawned by another instance of code, we do not want to have 2 at once but also do not waste a lot of time checking
-            // As it should not be in the middle of an operation which may cause it to take a while, unless it was pkilled.
-            {
-                return '0';
-            }
-        }
 
         // Launch the process under sudo
         this.context?.eventStream.post(new CommandExecutionUserAskDialogueEvent(`Prompting user for command ${fullCommandString} under sudo.`));

--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -96,8 +96,15 @@ export class FileUtilities extends IFileUtilities
 
     public async read(filePath: string): Promise<string>
     {
-        const output = await fs.promises.readFile(filePath, 'utf8');
-        return output;
+        try
+        {
+            const output = await fs.promises.readFile(filePath, 'utf8');
+            return output;
+        }
+        catch (error: any)
+        {
+            return `File ${filePath} does not exist or is not readable : ${error?.message}`;
+        }
     }
 
     public async exists(filePath: string): Promise<boolean>

--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -104,6 +104,7 @@ export class FileUtilities extends IFileUtilities
         catch (error: any)
         {
             throw new Error(`Failed to read file ${filePath}: ${error?.message}`);
+        }
     }
 
     public async exists(filePath: string): Promise<boolean>

--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -103,6 +103,7 @@ export class FileUtilities extends IFileUtilities
         }
         catch (error: any)
         {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             return `File ${filePath} does not exist or is not readable : ${error?.message}`;
         }
     }

--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -103,9 +103,7 @@ export class FileUtilities extends IFileUtilities
         }
         catch (error: any)
         {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            return `File ${filePath} does not exist or is not readable : ${error?.message}`;
-        }
+            throw new Error(`Failed to read file ${filePath}: ${error?.message}`);
     }
 
     public async exists(filePath: string): Promise<boolean>

--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -103,6 +103,7 @@ export class FileUtilities extends IFileUtilities
         }
         catch (error: any)
         {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             throw new Error(`Failed to read file ${filePath}: ${error?.message}`);
         }
     }

--- a/vscode-dotnet-runtime-library/src/Utils/LockUsedByThisInstanceSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/LockUsedByThisInstanceSingleton.ts
@@ -11,6 +11,8 @@ export class LockUsedByThisInstanceSingleton
     private currentAliveStatus = false;
     private sudoError: any = null;
 
+    public static readonly SUDO_SESSION_ID = crypto.randomUUID().substring(0, 8);
+
     protected constructor(protected lockStringAndThisVsCodeInstanceOwnsIt: { [lockString: string]: boolean } = {})
     {
 

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -108,7 +108,7 @@ export class NodeIPCMutex
             catch (error: any)
             {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                if (error?.code === 'EADDRINUSE') //  We couldn't acquire the lock, even though nobody else is using it.
+                if (error?.code === 'EADDRINUSE' || error?.code === 'EEXIST' || error?.code === 'EACCESS')
                 {
                     if (retries >= maxRetryCountToEndAtRoughlyTimeoutTime)
                     {

--- a/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
@@ -25,12 +25,12 @@ export async function loopWithTimeoutOnCond(sampleRatePerMs: number, durationToW
         if (conditionToStop())
         {
             doAfterStop();
-            return;
+            return Promise.resolve();
         }
         eventStream?.post(waitEvent);
         await new Promise(waitAndResolve => setTimeout(waitAndResolve, sampleRatePerMs));
     }
-    throw new Error('The promise timed out.');
+    throw new Error(`The promise timed out at ${durationToWaitBeforeTimeoutMs}.`);
 }
 
 /**

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -149,6 +149,10 @@ export async function getLinuxSupportedDotnetSDKVersion(context: IAcquisitionWor
         {
             return '6.0.100';
         }
+        if (distroInfo.version < '22.06')
+        {
+            return '9.0.100';
+        }
         if (distroInfo.version < '24.04')
         {
             return '8.0.100';


### PR DESCRIPTION
Now that the mutex is implemented correctly, I can check that the code which uses the mutex is all correct.
An issue I discovered, is that on Linux, we use a sudo process folder to exchange files with a master sudo process. 
This folder is shared across all instances of vscode. If you kill vscode, the sudo process does not go away.

When a new instance checks if it should spawn a master sudo process, it tries to communicate with the old one. But the old one may be busy, and the old logic only waited 1 second. The sudo process may be busy for multiple minutes. This can result in race conditions where the old sudo process and new one are doing some of the same tasks. Now, I've given each vscode instance its own folder to run sudo commands under.

The script that runs these commands is still in the same protected location. It will only run authorized and approved commands by us, so spawning a new directory is OK.

Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/2224