### PR TITLE
2.3.3 Branding, Bump Minimum VS Code Version

### DIFF
--- a/sample/package.json
+++ b/sample/package.json
@@ -7,7 +7,7 @@
 		"url": "https://github.com/dotnet/vscode-dotnet-runtime.git"
 	},
 	"license": "MIT",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"publisher": "ms-dotnettools",
 	"engines": {
 		"vscode": "^1.75.0"

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -2314,7 +2314,7 @@
 
 "vscode-dotnet-runtime@file:../vscode-dotnet-runtime-extension":
   "resolved" "file:../vscode-dotnet-runtime-extension"
-  "version" "2.3.2"
+  "version" "2.3.3"
   dependencies:
     "@types/chai-as-promised" "^7.1.8"
     "@vscode/test-electron" "^2.3.9"

--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
-## [2.3.2] - TBD
+## [2.3.3] - 2025-4
+
+- Performance improvements.
+- Fixes to locking issues, with listen errors.
+
+## [2.3.2] - 2025-4-10
 
 - Adds Automated SDK Installation community support for Debian : thank you @curllog for your help!
 - Fixes an issue with install scripts on validating the dotnet install.

--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-dotnet-runtime",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-dotnet-runtime",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "license": "MIT",
             "dependencies": {
                 "@types/chai-as-promised": "^7.1.8",
@@ -38,7 +38,7 @@
                 "webpack-cli": "^4.9.1"
             },
             "engines": {
-                "vscode": "^1.81.1"
+                "vscode": "^1.99.0"
             }
         },
         "../vscode-dotnet-runtime-library": {
@@ -277,13 +277,10 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.17.28",
-            "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-20.17.28.tgz",
-            "integrity": "sha1-wQQ286PJlvU1kZqbCC4sR/GcQKE=",
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.19.2"
-            }
+            "version": "20.0.0",
+            "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-20.0.0.tgz",
+            "integrity": "sha1-CB2a/ShCG+lWwaR87RyaADS0Z+I=",
+            "license": "MIT"
         },
         "node_modules/@types/rimraf": {
             "version": "3.0.2",
@@ -3543,12 +3540,6 @@
             "engines": {
                 "node": ">=14.17"
             }
-        },
-        "node_modules/undici-types": {
-            "version": "6.19.8",
-            "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici-types/-/undici-types-6.19.8.tgz",
-            "integrity": "sha1-NREcnRQ3q4OnzcCrri8m2I7aCgI=",
-            "license": "MIT"
         },
         "node_modules/unit-compare": {
             "version": "1.0.1",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -13,10 +13,10 @@
     "description": "This extension installs and manages different versions of the .NET SDK and Runtime.",
     "connectionString": "InstrumentationKey=02dc18e0-7494-43b2-b2a3-18ada5fcb522;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/;ApplicationId=e8e56970-a18a-4101-b7d1-1c5dd7c29eeb",
     "icon": "images/dotnetIcon.png",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "publisher": "ms-dotnettools",
     "engines": {
-        "vscode": "^1.81.1"
+        "vscode": "^1.99.0"
     },
     "categories": [
         "Other"
@@ -141,7 +141,7 @@
     "devDependencies": {
         "@types/chai": "^4.3.5",
         "@types/mocha": "^9.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "20.18.3",
         "@types/rimraf": "3.0.2",
         "@types/source-map-support": "^0.5.10",
         "@types/vscode": "1.74.0",

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -141,7 +141,7 @@
     "devDependencies": {
         "@types/chai": "^4.3.5",
         "@types/mocha": "^9.0.0",
-        "@types/node": "20.18.3",
+        "@types/node": "^20.0.0",
         "@types/rimraf": "3.0.2",
         "@types/source-map-support": "^0.5.10",
         "@types/vscode": "1.74.0",

--- a/vscode-dotnet-runtime-extension/yarn.lock
+++ b/vscode-dotnet-runtime-extension/yarn.lock
@@ -132,11 +132,9 @@
   "version" "9.1.1"
 
 "@types/node@*", "@types/node@^20.0.0":
-  "integrity" "sha1-wQQ286PJlvU1kZqbCC4sR/GcQKE="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-20.17.28.tgz"
-  "version" "20.17.28"
-  dependencies:
-    "undici-types" "~6.19.2"
+  "integrity" "sha1-CB2a/ShCG+lWwaR87RyaADS0Z+I="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-20.0.0.tgz"
+  "version" "20.0.0"
 
 "@types/rimraf@3.0.2":
   "integrity" "sha1-pj0XWzMXSOUiCtSMkB17vx9E7vg="
@@ -2030,11 +2028,6 @@
   "integrity" "sha1-gXCzcC90t52y5aliB8FeZYB5meQ="
   "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-5.8.2.tgz"
   "version" "5.8.2"
-
-"undici-types@~6.19.2":
-  "integrity" "sha1-NREcnRQ3q4OnzcCrri8m2I7aCgI="
-  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici-types/-/undici-types-6.19.8.tgz"
-  "version" "6.19.8"
 
 "unit-compare@^1.0.1":
   "integrity" "sha1-DHRZ8OW/U2N+qHPKPO4Y3i7so4Y="

--- a/vscode-dotnet-runtime-library/package.json
+++ b/vscode-dotnet-runtime-library/package.json
@@ -8,7 +8,7 @@
 	},
 	"license": "MIT",
 	"engines": {
-		"vscode": "^1.74.0"
+		"vscode": "^1.99.0"
 	},
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/vscode-dotnet-runtime-library/src/Utils/LockUsedByThisInstanceSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/LockUsedByThisInstanceSingleton.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+import * as crypto from 'crypto';
+
 export class LockUsedByThisInstanceSingleton
 {
     protected static instance: LockUsedByThisInstanceSingleton;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,25 +3,25 @@
 
 
 "@azure/abort-controller@^2.0.0":
-  version "2.1.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz"
-  integrity sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=
+  "integrity" "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz"
+  "version" "2.1.2"
   dependencies:
-    tslib "^2.6.2"
+    "tslib" "^2.6.2"
 
 "@azure/core-auth@^1.4.0", "@azure/core-auth@^1.8.0", "@azure/core-auth@^1.9.0":
-  version "1.9.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-auth/-/core-auth-1.9.0.tgz"
-  integrity sha1-rHJbA/q+PIkjcQZe6eIEG+4P0aw=
+  "integrity" "sha1-rHJbA/q+PIkjcQZe6eIEG+4P0aw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-auth/-/core-auth-1.9.0.tgz"
+  "version" "1.9.0"
   dependencies:
     "@azure/abort-controller" "^2.0.0"
     "@azure/core-util" "^1.11.0"
-    tslib "^2.6.2"
+    "tslib" "^2.6.2"
 
 "@azure/core-client@^1.9.2":
-  version "1.9.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-client/-/core-client-1.9.2.tgz"
-  integrity sha1-b8ac7igWiDq2xc3WU+5PL/l3T3Q=
+  "integrity" "sha1-nKjzvccw0Q1Y9lycLJypkrwVu2c="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-client/-/core-client-1.9.3.tgz"
+  "version" "1.9.3"
   dependencies:
     "@azure/abort-controller" "^2.0.0"
     "@azure/core-auth" "^1.4.0"
@@ -29,41 +29,41 @@
     "@azure/core-tracing" "^1.0.0"
     "@azure/core-util" "^1.6.1"
     "@azure/logger" "^1.0.0"
-    tslib "^2.6.2"
+    "tslib" "^2.6.2"
 
 "@azure/core-rest-pipeline@^1.17.0", "@azure/core-rest-pipeline@^1.9.1":
-  version "1.18.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.18.2.tgz"
-  integrity sha1-+jqDtBLUs+M+3KMKcbHVg4MGwHU=
+  "integrity" "sha1-50BnZER3egTcVWVthmATHf2SaSQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.19.1.tgz"
+  "version" "1.19.1"
   dependencies:
     "@azure/abort-controller" "^2.0.0"
     "@azure/core-auth" "^1.8.0"
     "@azure/core-tracing" "^1.0.1"
     "@azure/core-util" "^1.11.0"
     "@azure/logger" "^1.0.0"
-    http-proxy-agent "^7.0.0"
-    https-proxy-agent "^7.0.0"
-    tslib "^2.6.2"
+    "http-proxy-agent" "^7.0.0"
+    "https-proxy-agent" "^7.0.0"
+    "tslib" "^2.6.2"
 
 "@azure/core-tracing@^1.0.0", "@azure/core-tracing@^1.0.1":
-  version "1.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-tracing/-/core-tracing-1.2.0.tgz"
-  integrity sha1-e+XVPDUi1jnPGQQsvNsZ9xvDWrI=
+  "integrity" "sha1-e+XVPDUi1jnPGQQsvNsZ9xvDWrI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-tracing/-/core-tracing-1.2.0.tgz"
+  "version" "1.2.0"
   dependencies:
-    tslib "^2.6.2"
+    "tslib" "^2.6.2"
 
 "@azure/core-util@^1.11.0", "@azure/core-util@^1.6.1":
-  version "1.11.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-util/-/core-util-1.11.0.tgz"
-  integrity sha1-9TD8Z+c4rqhy+90cyEFucCGfrac=
+  "integrity" "sha1-9TD8Z+c4rqhy+90cyEFucCGfrac="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-util/-/core-util-1.11.0.tgz"
+  "version" "1.11.0"
   dependencies:
     "@azure/abort-controller" "^2.0.0"
-    tslib "^2.6.2"
+    "tslib" "^2.6.2"
 
 "@azure/identity@^4.1.0":
-  version "4.6.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/identity/-/identity-4.6.0.tgz"
-  integrity sha1-J2lXtZ/tls9I1eUPxyjDwibk8QU=
+  "integrity" "sha1-aGaCaDpHDM9NuyWX7iNPnFxIOkA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/identity/-/identity-4.8.0.tgz"
+  "version" "4.8.0"
   dependencies:
     "@azure/abort-controller" "^2.0.0"
     "@azure/core-auth" "^1.9.0"
@@ -72,280 +72,287 @@
     "@azure/core-tracing" "^1.0.0"
     "@azure/core-util" "^1.11.0"
     "@azure/logger" "^1.0.0"
-    "@azure/msal-browser" "^4.0.1"
-    "@azure/msal-node" "^2.15.0"
-    events "^3.0.0"
-    jws "^4.0.0"
-    open "^8.0.0"
-    stoppable "^1.1.0"
-    tslib "^2.2.0"
+    "@azure/msal-browser" "^4.2.0"
+    "@azure/msal-node" "^3.2.3"
+    "events" "^3.0.0"
+    "jws" "^4.0.0"
+    "open" "^10.1.0"
+    "stoppable" "^1.1.0"
+    "tslib" "^2.2.0"
 
 "@azure/logger@^1.0.0":
-  version "1.1.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/logger/-/logger-1.1.4.tgz"
-  integrity sha1-Ijy/K0JN+mZHjOmk9XX1nG83l2g=
+  "integrity" "sha1-Ijy/K0JN+mZHjOmk9XX1nG83l2g="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/logger/-/logger-1.1.4.tgz"
+  "version" "1.1.4"
   dependencies:
-    tslib "^2.6.2"
+    "tslib" "^2.6.2"
 
-"@azure/msal-browser@^4.0.1":
-  version "4.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-browser/-/msal-browser-4.0.2.tgz"
-  integrity sha1-1YuexxdWsOfQzUaUH0htX7N30JI=
+"@azure/msal-browser@^4.2.0":
+  "integrity" "sha1-vr7oC3PE0WHw2cibDDdzvZqjuek="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-browser/-/msal-browser-4.9.1.tgz"
+  "version" "4.9.1"
   dependencies:
-    "@azure/msal-common" "15.0.2"
+    "@azure/msal-common" "15.4.0"
 
-"@azure/msal-common@14.16.0":
-  version "14.16.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-common/-/msal-common-14.16.0.tgz"
-  integrity sha1-80cPyux4jb5QhZlSzUmTQL2iPXo=
+"@azure/msal-common@15.4.0":
+  "integrity" "sha1-MAd5uIAmq31gtOnDaFCaLsDCBhc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-common/-/msal-common-15.4.0.tgz"
+  "version" "15.4.0"
 
-"@azure/msal-common@15.0.2":
-  version "15.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-common/-/msal-common-15.0.2.tgz"
-  integrity sha1-P7UtcwCoOr0DJxU0FxzR89xDmec=
-
-"@azure/msal-node@^2.15.0":
-  version "2.16.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-node/-/msal-node-2.16.2.tgz"
-  integrity sha1-Prdo02iD6m+ak5wLW0Z7UY54//w=
+"@azure/msal-node@^3.2.3":
+  "integrity" "sha1-g428PeP+ja6Rmy3iDDANO5sP9CU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-node/-/msal-node-3.4.1.tgz"
+  "version" "3.4.1"
   dependencies:
-    "@azure/msal-common" "14.16.0"
-    jsonwebtoken "^9.0.0"
-    uuid "^8.3.0"
+    "@azure/msal-common" "15.4.0"
+    "jsonwebtoken" "^9.0.0"
+    "uuid" "^8.3.0"
 
 "@babel/code-frame@^7.0.0":
-  version "7.26.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/code-frame/-/code-frame-7.26.2.tgz"
-  integrity sha1-S1+rl9MzOO/5FiNQVfDrwh5XOoU=
+  "integrity" "sha1-S1+rl9MzOO/5FiNQVfDrwh5XOoU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/code-frame/-/code-frame-7.26.2.tgz"
+  "version" "7.26.2"
   dependencies:
     "@babel/helper-validator-identifier" "^7.25.9"
-    js-tokens "^4.0.0"
-    picocolors "^1.0.0"
+    "js-tokens" "^4.0.0"
+    "picocolors" "^1.0.0"
 
 "@babel/helper-validator-identifier@^7.25.9":
-  version "7.25.9"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz"
-  integrity sha1-JLZOLD7HzTs8VHcpuNFocfIsvcc=
+  "integrity" "sha1-JLZOLD7HzTs8VHcpuNFocfIsvcc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz"
+  "version" "7.25.9"
 
 "@es-joy/jsdoccomment@~0.49.0":
-  version "0.49.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@es-joy/jsdoccomment/-/jsdoccomment-0.49.0.tgz"
-  integrity sha1-5ewe2oN8gC7KZ9Oynldxl/FLods=
+  "integrity" "sha1-5ewe2oN8gC7KZ9Oynldxl/FLods="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@es-joy/jsdoccomment/-/jsdoccomment-0.49.0.tgz"
+  "version" "0.49.0"
   dependencies:
-    comment-parser "1.4.1"
-    esquery "^1.6.0"
-    jsdoc-type-pratt-parser "~4.1.0"
+    "comment-parser" "1.4.1"
+    "esquery" "^1.6.0"
+    "jsdoc-type-pratt-parser" "~4.1.0"
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
-  version "4.4.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz"
-  integrity sha1-0RRb8sIBMtZABJXW30v1k2L9nVY=
+  "integrity" "sha1-sPx+BtDJT4AVN/1CN+3CcG07jkw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz"
+  "version" "4.5.1"
   dependencies:
-    eslint-visitor-keys "^3.4.3"
+    "eslint-visitor-keys" "^3.4.3"
 
 "@eslint-community/regexpp@^4.10.0", "@eslint-community/regexpp@^4.6.1":
-  version "4.12.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/regexpp/-/regexpp-4.12.1.tgz"
-  integrity sha1-z8bP/jnfOQo4Qc3iq8z5Lqp64OA=
+  "integrity" "sha1-z8bP/jnfOQo4Qc3iq8z5Lqp64OA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/regexpp/-/regexpp-4.12.1.tgz"
+  "version" "4.12.1"
 
 "@eslint/eslintrc@^2.1.4":
-  version "2.1.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint/eslintrc/-/eslintrc-2.1.4.tgz"
-  integrity sha1-OIomnw8lwbatwxe1osVXFIlMcK0=
+  "integrity" "sha1-OIomnw8lwbatwxe1osVXFIlMcK0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint/eslintrc/-/eslintrc-2.1.4.tgz"
+  "version" "2.1.4"
   dependencies:
-    ajv "^6.12.4"
-    debug "^4.3.2"
-    espree "^9.6.0"
-    globals "^13.19.0"
-    ignore "^5.2.0"
-    import-fresh "^3.2.1"
-    js-yaml "^4.1.0"
-    minimatch "^3.1.2"
-    strip-json-comments "^3.1.1"
+    "ajv" "^6.12.4"
+    "debug" "^4.3.2"
+    "espree" "^9.6.0"
+    "globals" "^13.19.0"
+    "ignore" "^5.2.0"
+    "import-fresh" "^3.2.1"
+    "js-yaml" "^4.1.0"
+    "minimatch" "^3.1.2"
+    "strip-json-comments" "^3.1.1"
 
 "@eslint/js@8.57.1":
-  version "8.57.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint/js/-/js-8.57.1.tgz"
-  integrity sha1-3mM9s+wu9qPIni8ZA4Bj6KEi4sI=
+  "integrity" "sha1-3mM9s+wu9qPIni8ZA4Bj6KEi4sI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint/js/-/js-8.57.1.tgz"
+  "version" "8.57.1"
 
 "@humanwhocodes/config-array@^0.13.0":
-  version "0.13.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/config-array/-/config-array-0.13.0.tgz"
-  integrity sha1-+5B2JN8yVtBLmqLfUNeql+xkh0g=
+  "integrity" "sha1-+5B2JN8yVtBLmqLfUNeql+xkh0g="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/config-array/-/config-array-0.13.0.tgz"
+  "version" "0.13.0"
   dependencies:
     "@humanwhocodes/object-schema" "^2.0.3"
-    debug "^4.3.1"
-    minimatch "^3.0.5"
+    "debug" "^4.3.1"
+    "minimatch" "^3.0.5"
 
 "@humanwhocodes/module-importer@^1.0.1":
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz"
-  integrity sha1-r1smkaIrRL6EewyoFkHF+2rQFyw=
+  "integrity" "sha1-r1smkaIrRL6EewyoFkHF+2rQFyw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz"
+  "version" "1.0.1"
 
 "@humanwhocodes/object-schema@^2.0.3":
-  version "2.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz"
-  integrity sha1-Siho111taWPkI7z5C3/RvjQ0CdM=
+  "integrity" "sha1-Siho111taWPkI7z5C3/RvjQ0CdM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz"
+  "version" "2.0.3"
 
 "@nodelib/fs.scandir@2.1.5":
-  version "2.1.5"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
-  integrity sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=
+  "integrity" "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
+  "version" "2.1.5"
   dependencies:
     "@nodelib/fs.stat" "2.0.5"
-    run-parallel "^1.1.9"
+    "run-parallel" "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.5"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
-  integrity sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+  "integrity" "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
+  "version" "2.0.5"
 
 "@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
-  version "1.2.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz"
-  integrity sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=
+  "integrity" "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz"
+  "version" "1.2.8"
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
-    fastq "^1.6.0"
+    "fastq" "^1.6.0"
 
 "@nolyfill/is-core-module@1.0.39":
-  version "1.0.39"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
-  integrity sha1-PcNboPHma0A8ALOTRPhwKY67HI4=
+  "integrity" "sha1-PcNboPHma0A8ALOTRPhwKY67HI4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
+  "version" "1.0.39"
 
 "@pkgr/core@^0.1.0":
-  version "0.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@pkgr/core/-/core-0.1.1.tgz"
-  integrity sha1-HsF+LtvsJcgwbUJOz78Tx94aqjE=
+  "integrity" "sha1-HPlQgLtwcvr6o8sTtEL6tGlcOJM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@pkgr/core/-/core-0.1.2.tgz"
+  "version" "0.1.2"
+
+"@pkgr/core@^0.2.0":
+  "integrity" "sha1-jf9hA4y1iEeJ2LMj2YaeU2O5dvc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@pkgr/core/-/core-0.2.0.tgz"
+  "version" "0.2.0"
 
 "@rtsao/scc@^1.1.0":
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rtsao/scc/-/scc-1.1.0.tgz"
-  integrity sha1-kn3S+um8M2FAOsLHoAwy3c6a1+g=
+  "integrity" "sha1-kn3S+um8M2FAOsLHoAwy3c6a1+g="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rtsao/scc/-/scc-1.1.0.tgz"
+  "version" "1.1.0"
 
 "@types/json-schema@^7.0.12":
-  version "7.0.15"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz"
-  integrity sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=
+  "integrity" "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz"
+  "version" "7.0.15"
 
 "@types/json5@^0.0.29":
-  version "0.0.29"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json5/-/json5-0.0.29.tgz"
-  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+  "integrity" "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/json5/-/json5-0.0.29.tgz"
+  "version" "0.0.29"
+
+"@types/node@^22.14.0":
+  "integrity" "sha1-07+jk2/vDbrNeeo+sX1SHGKLtH4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-22.14.0.tgz"
+  "version" "22.14.0"
+  dependencies:
+    "undici-types" "~6.21.0"
 
 "@types/semver@^7.5.0":
-  version "7.5.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/semver/-/semver-7.5.8.tgz"
-  integrity sha1-gmioxXo+Sr0lwWXs02I323lIpV4=
+  "integrity" "sha1-ZMRBva4DOzeLbu99DD13wym5N44="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/semver/-/semver-7.7.0.tgz"
+  "version" "7.7.0"
 
 "@types/source-map-support@^0.5.6":
-  version "0.5.10"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/source-map-support/-/source-map-support-0.5.10.tgz"
-  integrity sha1-gk3O+YlJa66Y6dBMjcGsHXDhvTk=
+  "integrity" "sha1-gk3O+YlJa66Y6dBMjcGsHXDhvTk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/source-map-support/-/source-map-support-0.5.10.tgz"
+  "version" "0.5.10"
   dependencies:
-    source-map "^0.6.0"
+    "source-map" "^0.6.0"
 
 "@typescript-eslint/eslint-plugin-tslint@^7.0.2":
-  version "7.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-7.0.2.tgz"
-  integrity sha1-1gkemoA0MLYe+0DnkKtH1ieOEnY=
+  "integrity" "sha1-1gkemoA0MLYe+0DnkKtH1ieOEnY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-7.0.2.tgz"
+  "version" "7.0.2"
   dependencies:
     "@typescript-eslint/utils" "7.0.2"
 
 "@typescript-eslint/eslint-plugin@^8.0.0":
-  version "8.22.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.22.0.tgz"
-  integrity sha1-Y6Gw0k2FqXGUn41x1pMBn1jS6GE=
+  "integrity" "sha1-rRRlqm/n6TeAHCkWSN7JUcTcOOY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.28.0.tgz"
+  "version" "8.28.0"
   dependencies:
     "@eslint-community/regexpp" "^4.10.0"
-    "@typescript-eslint/scope-manager" "8.22.0"
-    "@typescript-eslint/type-utils" "8.22.0"
-    "@typescript-eslint/utils" "8.22.0"
-    "@typescript-eslint/visitor-keys" "8.22.0"
-    graphemer "^1.4.0"
-    ignore "^5.3.1"
-    natural-compare "^1.4.0"
-    ts-api-utils "^2.0.0"
+    "@typescript-eslint/scope-manager" "8.28.0"
+    "@typescript-eslint/type-utils" "8.28.0"
+    "@typescript-eslint/utils" "8.28.0"
+    "@typescript-eslint/visitor-keys" "8.28.0"
+    "graphemer" "^1.4.0"
+    "ignore" "^5.3.1"
+    "natural-compare" "^1.4.0"
+    "ts-api-utils" "^2.0.1"
 
-"@typescript-eslint/parser@^8.0.0":
-  version "8.22.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/parser/-/parser-8.22.0.tgz"
-  integrity sha1-8hxdskJx8YLru0uox60+t25fXzo=
+"@typescript-eslint/parser@^8.0.0", "@typescript-eslint/parser@^8.0.0 || ^8.0.0-alpha.0":
+  "integrity" "sha1-hTIXB+hxHA5mqUnqIoIkrzX0XJg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/parser/-/parser-8.28.0.tgz"
+  "version" "8.28.0"
   dependencies:
-    "@typescript-eslint/scope-manager" "8.22.0"
-    "@typescript-eslint/types" "8.22.0"
-    "@typescript-eslint/typescript-estree" "8.22.0"
-    "@typescript-eslint/visitor-keys" "8.22.0"
-    debug "^4.3.4"
+    "@typescript-eslint/scope-manager" "8.28.0"
+    "@typescript-eslint/types" "8.28.0"
+    "@typescript-eslint/typescript-estree" "8.28.0"
+    "@typescript-eslint/visitor-keys" "8.28.0"
+    "debug" "^4.3.4"
 
 "@typescript-eslint/scope-manager@7.0.2":
-  version "7.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-7.0.2.tgz"
-  integrity sha1-bsTMA3UnWN3R/arm+9Dtmiyk/mM=
+  "integrity" "sha1-bsTMA3UnWN3R/arm+9Dtmiyk/mM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-7.0.2.tgz"
+  "version" "7.0.2"
   dependencies:
     "@typescript-eslint/types" "7.0.2"
     "@typescript-eslint/visitor-keys" "7.0.2"
 
-"@typescript-eslint/scope-manager@8.22.0":
-  version "8.22.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.22.0.tgz"
-  integrity sha1-6Fg23euOrnFfhwYovMMv6WqvTQ4=
+"@typescript-eslint/scope-manager@8.28.0":
+  "integrity" "sha1-5JWyBDijeH4ASYd01WJeYg1o+f4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.28.0.tgz"
+  "version" "8.28.0"
   dependencies:
-    "@typescript-eslint/types" "8.22.0"
-    "@typescript-eslint/visitor-keys" "8.22.0"
+    "@typescript-eslint/types" "8.28.0"
+    "@typescript-eslint/visitor-keys" "8.28.0"
 
-"@typescript-eslint/type-utils@8.22.0":
-  version "8.22.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.22.0.tgz"
-  integrity sha1-zZ8jwj8CE1fvC6o0kNTZbtzJdQk=
+"@typescript-eslint/type-utils@8.28.0":
+  "integrity" "sha1-/FZUFOvBbeH8ZeDdhlLOAseMph8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.28.0.tgz"
+  "version" "8.28.0"
   dependencies:
-    "@typescript-eslint/typescript-estree" "8.22.0"
-    "@typescript-eslint/utils" "8.22.0"
-    debug "^4.3.4"
-    ts-api-utils "^2.0.0"
+    "@typescript-eslint/typescript-estree" "8.28.0"
+    "@typescript-eslint/utils" "8.28.0"
+    "debug" "^4.3.4"
+    "ts-api-utils" "^2.0.1"
 
 "@typescript-eslint/types@7.0.2":
-  version "7.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/types/-/types-7.0.2.tgz"
-  integrity sha1-tu3RCGSAKBlOshOIfY1Dq1dQNRw=
+  "integrity" "sha1-tu3RCGSAKBlOshOIfY1Dq1dQNRw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/types/-/types-7.0.2.tgz"
+  "version" "7.0.2"
 
-"@typescript-eslint/types@8.22.0":
-  version "8.22.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/types/-/types-8.22.0.tgz"
-  integrity sha1-2d7HEWR5rQOutsisnFIjxMec82A=
+"@typescript-eslint/types@8.28.0":
+  "integrity" "sha1-fHOHg4Xt/ZZ0x6oQl15sSEtPiW4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/types/-/types-8.28.0.tgz"
+  "version" "8.28.0"
 
 "@typescript-eslint/typescript-estree@7.0.2":
-  version "7.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.2.tgz"
-  integrity sha1-PG3Io7l5n0737KDSJN7QGXTkyzk=
+  "integrity" "sha1-PG3Io7l5n0737KDSJN7QGXTkyzk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.2.tgz"
+  "version" "7.0.2"
   dependencies:
     "@typescript-eslint/types" "7.0.2"
     "@typescript-eslint/visitor-keys" "7.0.2"
-    debug "^4.3.4"
-    globby "^11.1.0"
-    is-glob "^4.0.3"
-    minimatch "9.0.3"
-    semver "^7.5.4"
-    ts-api-utils "^1.0.1"
+    "debug" "^4.3.4"
+    "globby" "^11.1.0"
+    "is-glob" "^4.0.3"
+    "minimatch" "9.0.3"
+    "semver" "^7.5.4"
+    "ts-api-utils" "^1.0.1"
 
-"@typescript-eslint/typescript-estree@8.22.0":
-  version "8.22.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.22.0.tgz"
-  integrity sha1-wYjD4ZUp1bMUVXfAvZZ+JoOxFN8=
+"@typescript-eslint/typescript-estree@8.28.0":
+  "integrity" "sha1-VrmZ8m98pnudddamevXIuOToARQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.28.0.tgz"
+  "version" "8.28.0"
   dependencies:
-    "@typescript-eslint/types" "8.22.0"
-    "@typescript-eslint/visitor-keys" "8.22.0"
-    debug "^4.3.4"
-    fast-glob "^3.3.2"
-    is-glob "^4.0.3"
-    minimatch "^9.0.4"
-    semver "^7.6.0"
-    ts-api-utils "^2.0.0"
+    "@typescript-eslint/types" "8.28.0"
+    "@typescript-eslint/visitor-keys" "8.28.0"
+    "debug" "^4.3.4"
+    "fast-glob" "^3.3.2"
+    "is-glob" "^4.0.3"
+    "minimatch" "^9.0.4"
+    "semver" "^7.6.0"
+    "ts-api-utils" "^2.0.1"
 
 "@typescript-eslint/utils@7.0.2":
-  version "7.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/utils/-/utils-7.0.2.tgz"
-  integrity sha1-h1YSMFTNk0yLp9tqbP+8ZUsQtcQ=
+  "integrity" "sha1-h1YSMFTNk0yLp9tqbP+8ZUsQtcQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/utils/-/utils-7.0.2.tgz"
+  "version" "7.0.2"
   dependencies:
     "@eslint-community/eslint-utils" "^4.4.0"
     "@types/json-schema" "^7.0.12"
@@ -353,88 +360,53 @@
     "@typescript-eslint/scope-manager" "7.0.2"
     "@typescript-eslint/types" "7.0.2"
     "@typescript-eslint/typescript-estree" "7.0.2"
-    semver "^7.5.4"
+    "semver" "^7.5.4"
 
-"@typescript-eslint/utils@8.22.0":
-  version "8.22.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/utils/-/utils-8.22.0.tgz"
-  integrity sha1-yMxOUqnHEa+KdBqC3F1yQreo3UQ=
+"@typescript-eslint/utils@8.28.0":
+  "integrity" "sha1-eFCFZiColresYhrBLUnCgq77tSg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/utils/-/utils-8.28.0.tgz"
+  "version" "8.28.0"
   dependencies:
     "@eslint-community/eslint-utils" "^4.4.0"
-    "@typescript-eslint/scope-manager" "8.22.0"
-    "@typescript-eslint/types" "8.22.0"
-    "@typescript-eslint/typescript-estree" "8.22.0"
+    "@typescript-eslint/scope-manager" "8.28.0"
+    "@typescript-eslint/types" "8.28.0"
+    "@typescript-eslint/typescript-estree" "8.28.0"
 
 "@typescript-eslint/visitor-keys@7.0.2":
-  version "7.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.2.tgz"
-  integrity sha1-KJm3FgU61wlJYr64ldETlvwSr8c=
+  "integrity" "sha1-KJm3FgU61wlJYr64ldETlvwSr8c="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.2.tgz"
+  "version" "7.0.2"
   dependencies:
     "@typescript-eslint/types" "7.0.2"
-    eslint-visitor-keys "^3.4.1"
+    "eslint-visitor-keys" "^3.4.1"
 
-"@typescript-eslint/visitor-keys@8.22.0":
-  version "8.22.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.22.0.tgz"
-  integrity sha1-AswAUBTDcgM+uRceInW3bLpyKj8=
+"@typescript-eslint/visitor-keys@8.28.0":
+  "integrity" "sha1-GOuaJcydrbAng1xY7+k6XE7oGWk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.28.0.tgz"
+  "version" "8.28.0"
   dependencies:
-    "@typescript-eslint/types" "8.22.0"
-    eslint-visitor-keys "^4.2.0"
+    "@typescript-eslint/types" "8.28.0"
+    "eslint-visitor-keys" "^4.2.0"
 
 "@ungap/structured-clone@^1.2.0":
-  version "1.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
-  integrity sha1-0Gu7OE689sUF/eHD0O1N3/4Kr/g=
+  "integrity" "sha1-0Gu7OE689sUF/eHD0O1N3/4Kr/g="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
+  "version" "1.3.0"
 
-"@vscode/vsce-sign-alpine-arm64@2.0.2":
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.2.tgz#4accc485e55aa6ff04b195b47f722ead57daa58e"
-  integrity sha1-SszEheVapv8EsZW0f3IurVfapY4=
-
-"@vscode/vsce-sign-alpine-x64@2.0.2":
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.2.tgz#4a4b7b505b4cc0f58596394897c49a0bce0e540c"
-  integrity sha1-Skt7UFtMwPWFljlIl8SaC84OVAw=
-
-"@vscode/vsce-sign-darwin-arm64@2.0.2":
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.2.tgz#10aa69feb7f81a3dc68c242038ca03eaff19c12e"
-  integrity sha1-EKpp/rf4Gj3GjCQgOMoD6v8ZwS4=
-
-"@vscode/vsce-sign-darwin-x64@2.0.2":
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.2.tgz#3315528f3ea1007a648b3320bff36a33a9e07aa5"
-  integrity sha1-MxVSjz6hAHpkizMgv/NqM6ngeqU=
-
-"@vscode/vsce-sign-linux-arm64@2.0.2":
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.2.tgz#ce5c5cfc99e3454b4fb770405812b46bd6dca870"
-  integrity sha1-zlxc/JnjRUtPt3BAWBK0a9bcqHA=
-
-"@vscode/vsce-sign-linux-arm@2.0.2":
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.2.tgz#4142fda83e7130b31aedd8aa81e4daa6334323c2"
-  integrity sha1-QUL9qD5xMLMa7diqgeTapjNDI8I=
-
-"@vscode/vsce-sign-linux-x64@2.0.2":
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.2.tgz#59ab93f322efb3cf49166d4e2e812789c3117428"
-  integrity sha1-WauT8yLvs89JFm1OLoEnicMRdCg=
-
-"@vscode/vsce-sign-win32-arm64@2.0.2":
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.2.tgz#d095704a14b0404c0b6f696e9889e9a51b31a86c"
-  integrity sha1-0JVwShSwQEwLb2lumInppRsxqGw=
+"@unrs/resolver-binding-win32-x64-msvc@1.3.2":
+  "integrity" "sha1-dtAqJi0Vhlu36lEGDGyBbKlq7K8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.3.2.tgz"
+  "version" "1.3.2"
 
 "@vscode/vsce-sign-win32-x64@2.0.2":
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.2.tgz"
-  integrity sha1-KU6nK0T+3WlNSfXO9MVb84dtwlc=
+  "integrity" "sha1-KU6nK0T+3WlNSfXO9MVb84dtwlc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.2.tgz"
+  "version" "2.0.2"
 
 "@vscode/vsce-sign@^2.0.0":
-  version "2.0.5"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign/-/vsce-sign-2.0.5.tgz"
-  integrity sha1-iFADZHbcDU4IDZwtgyXj6X7/UZM=
+  "integrity" "sha1-iFADZHbcDU4IDZwtgyXj6X7/UZM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign/-/vsce-sign-2.0.5.tgz"
+  "version" "2.0.5"
   optionalDependencies:
     "@vscode/vsce-sign-alpine-arm64" "2.0.2"
     "@vscode/vsce-sign-alpine-x64" "2.0.2"
@@ -447,848 +419,860 @@
     "@vscode/vsce-sign-win32-x64" "2.0.2"
 
 "@vscode/vsce@^2.26.1":
-  version "2.32.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce/-/vsce-2.32.0.tgz"
-  integrity sha1-/JD8KNyCYUqKtTfeWR4IS0atIHA=
+  "integrity" "sha1-/JD8KNyCYUqKtTfeWR4IS0atIHA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce/-/vsce-2.32.0.tgz"
+  "version" "2.32.0"
   dependencies:
     "@azure/identity" "^4.1.0"
     "@vscode/vsce-sign" "^2.0.0"
-    azure-devops-node-api "^12.5.0"
-    chalk "^2.4.2"
-    cheerio "^1.0.0-rc.9"
-    cockatiel "^3.1.2"
-    commander "^6.2.1"
-    form-data "^4.0.0"
-    glob "^7.0.6"
-    hosted-git-info "^4.0.2"
-    jsonc-parser "^3.2.0"
-    leven "^3.1.0"
-    markdown-it "^12.3.2"
-    mime "^1.3.4"
-    minimatch "^3.0.3"
-    parse-semver "^1.1.1"
-    read "^1.0.7"
-    semver "^7.5.2"
-    tmp "^0.2.1"
-    typed-rest-client "^1.8.4"
-    url-join "^4.0.1"
-    xml2js "^0.5.0"
-    yauzl "^2.3.1"
-    yazl "^2.2.2"
+    "azure-devops-node-api" "^12.5.0"
+    "chalk" "^2.4.2"
+    "cheerio" "^1.0.0-rc.9"
+    "cockatiel" "^3.1.2"
+    "commander" "^6.2.1"
+    "form-data" "^4.0.0"
+    "glob" "^7.0.6"
+    "hosted-git-info" "^4.0.2"
+    "jsonc-parser" "^3.2.0"
+    "leven" "^3.1.0"
+    "markdown-it" "^12.3.2"
+    "mime" "^1.3.4"
+    "minimatch" "^3.0.3"
+    "parse-semver" "^1.1.1"
+    "read" "^1.0.7"
+    "semver" "^7.5.2"
+    "tmp" "^0.2.1"
+    "typed-rest-client" "^1.8.4"
+    "url-join" "^4.0.1"
+    "xml2js" "^0.5.0"
+    "yauzl" "^2.3.1"
+    "yazl" "^2.2.2"
   optionalDependencies:
-    keytar "^7.7.0"
+    "keytar" "^7.7.0"
 
-acorn-jsx@^5.3.2:
-  version "5.3.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
-  integrity sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=
+"acorn-jsx@^5.3.2":
+  "integrity" "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
+  "version" "5.3.2"
 
-acorn@^8.14.0, acorn@^8.9.0:
-  version "8.14.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn/-/acorn-8.14.0.tgz"
-  integrity sha1-Bj4scMrF+09kZ/CxEVLgTGgnlbA=
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", "acorn@^8.14.0", "acorn@^8.9.0":
+  "integrity" "sha1-ch1dwQ99W1YJqJF3PUdzF5aTXfs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn/-/acorn-8.14.1.tgz"
+  "version" "8.14.1"
 
-agent-base@^7.1.0, agent-base@^7.1.2:
-  version "7.1.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/agent-base/-/agent-base-7.1.3.tgz"
-  integrity sha1-KUNeuCG8QZRjOluJ5bxHA7r8JaE=
+"agent-base@^7.1.0", "agent-base@^7.1.2":
+  "integrity" "sha1-KUNeuCG8QZRjOluJ5bxHA7r8JaE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/agent-base/-/agent-base-7.1.3.tgz"
+  "version" "7.1.3"
 
-ajv@^6.12.4:
-  version "6.12.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv/-/ajv-6.12.6.tgz"
-  integrity sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=
+"ajv@^6.12.4":
+  "integrity" "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ajv/-/ajv-6.12.6.tgz"
+  "version" "6.12.6"
   dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
+    "fast-deep-equal" "^3.1.1"
+    "fast-json-stable-stringify" "^2.0.0"
+    "json-schema-traverse" "^0.4.1"
+    "uri-js" "^4.2.2"
 
-ansi-regex@^5.0.1:
-  version "5.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz"
-  integrity sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=
+"ansi-regex@^5.0.1":
+  "integrity" "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz"
+  "version" "5.0.1"
 
-ansi-styles@^3.2.1:
-  version "3.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz"
-  integrity sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=
+"ansi-styles@^3.2.1":
+  "integrity" "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz"
+  "version" "3.2.1"
   dependencies:
-    color-convert "^1.9.0"
+    "color-convert" "^1.9.0"
 
-ansi-styles@^4.1.0:
-  version "4.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz"
-  integrity sha1-7dgDYornHATIWuegkG7a00tkiTc=
+"ansi-styles@^4.1.0":
+  "integrity" "sha1-7dgDYornHATIWuegkG7a00tkiTc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz"
+  "version" "4.3.0"
   dependencies:
-    color-convert "^2.0.1"
+    "color-convert" "^2.0.1"
 
-are-docs-informative@^0.0.2:
-  version "0.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/are-docs-informative/-/are-docs-informative-0.0.2.tgz"
-  integrity sha1-OH8Ok/XUUoA3PTh6WdNMltsyGWM=
+"are-docs-informative@^0.0.2":
+  "integrity" "sha1-OH8Ok/XUUoA3PTh6WdNMltsyGWM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/are-docs-informative/-/are-docs-informative-0.0.2.tgz"
+  "version" "0.0.2"
 
-argparse@^1.0.7:
-  version "1.0.10"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-1.0.10.tgz"
-  integrity sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=
+"argparse@^1.0.7":
+  "integrity" "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-1.0.10.tgz"
+  "version" "1.0.10"
   dependencies:
-    sprintf-js "~1.0.2"
+    "sprintf-js" "~1.0.2"
 
-argparse@^2.0.1:
-  version "2.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz"
-  integrity sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=
+"argparse@^2.0.1":
+  "integrity" "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz"
+  "version" "2.0.1"
 
-array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz"
-  integrity sha1-OE0So3KVrsN2mrAirTI6GKUcz4s=
+"array-buffer-byte-length@^1.0.1", "array-buffer-byte-length@^1.0.2":
+  "integrity" "sha1-OE0So3KVrsN2mrAirTI6GKUcz4s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz"
+  "version" "1.0.2"
   dependencies:
-    call-bound "^1.0.3"
-    is-array-buffer "^3.0.5"
+    "call-bound" "^1.0.3"
+    "is-array-buffer" "^3.0.5"
 
-array-includes@^3.1.8:
-  version "3.1.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array-includes/-/array-includes-3.1.8.tgz"
-  integrity sha1-XjcMvhcv3V3WUwwdSq3aJSgbqX0=
+"array-includes@^3.1.8":
+  "integrity" "sha1-XjcMvhcv3V3WUwwdSq3aJSgbqX0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array-includes/-/array-includes-3.1.8.tgz"
+  "version" "3.1.8"
   dependencies:
-    call-bind "^1.0.7"
-    define-properties "^1.2.1"
-    es-abstract "^1.23.2"
-    es-object-atoms "^1.0.0"
-    get-intrinsic "^1.2.4"
-    is-string "^1.0.7"
+    "call-bind" "^1.0.7"
+    "define-properties" "^1.2.1"
+    "es-abstract" "^1.23.2"
+    "es-object-atoms" "^1.0.0"
+    "get-intrinsic" "^1.2.4"
+    "is-string" "^1.0.7"
 
-array-union@^2.1.0:
-  version "2.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array-union/-/array-union-2.1.0.tgz"
-  integrity sha1-t5hCCtvrHego2ErNii4j0+/oXo0=
+"array-union@^2.1.0":
+  "integrity" "sha1-t5hCCtvrHego2ErNii4j0+/oXo0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array-union/-/array-union-2.1.0.tgz"
+  "version" "2.1.0"
 
-array.prototype.findlastindex@^1.2.5:
-  version "1.2.5"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz"
-  integrity sha1-jDWnVccpCHGUU/hxRcoBHjkzTQ0=
+"array.prototype.findlastindex@^1.2.5":
+  "integrity" "sha1-z6EGXIHctk40VXybgdAS9qQhxWQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz"
+  "version" "1.2.6"
   dependencies:
-    call-bind "^1.0.7"
-    define-properties "^1.2.1"
-    es-abstract "^1.23.2"
-    es-errors "^1.3.0"
-    es-object-atoms "^1.0.0"
-    es-shim-unscopables "^1.0.2"
+    "call-bind" "^1.0.8"
+    "call-bound" "^1.0.4"
+    "define-properties" "^1.2.1"
+    "es-abstract" "^1.23.9"
+    "es-errors" "^1.3.0"
+    "es-object-atoms" "^1.1.1"
+    "es-shim-unscopables" "^1.1.0"
 
-array.prototype.flat@^1.3.2:
-  version "1.3.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz"
-  integrity sha1-U0qvnm6N15+2uamRf4Oe8exjr+U=
+"array.prototype.flat@^1.3.2":
+  "integrity" "sha1-U0qvnm6N15+2uamRf4Oe8exjr+U="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz"
+  "version" "1.3.3"
   dependencies:
-    call-bind "^1.0.8"
-    define-properties "^1.2.1"
-    es-abstract "^1.23.5"
-    es-shim-unscopables "^1.0.2"
+    "call-bind" "^1.0.8"
+    "define-properties" "^1.2.1"
+    "es-abstract" "^1.23.5"
+    "es-shim-unscopables" "^1.0.2"
 
-array.prototype.flatmap@^1.3.2:
-  version "1.3.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz"
-  integrity sha1-cSzHkq5wNwrkBYYmRinjOqtd04s=
+"array.prototype.flatmap@^1.3.2":
+  "integrity" "sha1-cSzHkq5wNwrkBYYmRinjOqtd04s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz"
+  "version" "1.3.3"
   dependencies:
-    call-bind "^1.0.8"
-    define-properties "^1.2.1"
-    es-abstract "^1.23.5"
-    es-shim-unscopables "^1.0.2"
+    "call-bind" "^1.0.8"
+    "define-properties" "^1.2.1"
+    "es-abstract" "^1.23.5"
+    "es-shim-unscopables" "^1.0.2"
 
-arraybuffer.prototype.slice@^1.0.4:
-  version "1.0.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz"
-  integrity sha1-nXYNhNvdBtDL+SyISWFaGnqzGDw=
+"arraybuffer.prototype.slice@^1.0.4":
+  "integrity" "sha1-nXYNhNvdBtDL+SyISWFaGnqzGDw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz"
+  "version" "1.0.4"
   dependencies:
-    array-buffer-byte-length "^1.0.1"
-    call-bind "^1.0.8"
-    define-properties "^1.2.1"
-    es-abstract "^1.23.5"
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.6"
-    is-array-buffer "^3.0.4"
+    "array-buffer-byte-length" "^1.0.1"
+    "call-bind" "^1.0.8"
+    "define-properties" "^1.2.1"
+    "es-abstract" "^1.23.5"
+    "es-errors" "^1.3.0"
+    "get-intrinsic" "^1.2.6"
+    "is-array-buffer" "^3.0.4"
 
-async-function@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/async-function/-/async-function-1.0.0.tgz"
-  integrity sha1-UJyfymDq+FA0xoKYOBiOTkyP+ys=
+"async-function@^1.0.0":
+  "integrity" "sha1-UJyfymDq+FA0xoKYOBiOTkyP+ys="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/async-function/-/async-function-1.0.0.tgz"
+  "version" "1.0.0"
 
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz"
-  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+"asynckit@^0.4.0":
+  "integrity" "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz"
+  "version" "0.4.0"
 
-available-typed-arrays@^1.0.7:
-  version "1.0.7"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz"
-  integrity sha1-pcw3XWoDwu/IelU/PgsVIt7xSEY=
+"available-typed-arrays@^1.0.7":
+  "integrity" "sha1-pcw3XWoDwu/IelU/PgsVIt7xSEY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz"
+  "version" "1.0.7"
   dependencies:
-    possible-typed-array-names "^1.0.0"
+    "possible-typed-array-names" "^1.0.0"
 
-azure-devops-node-api@^12.5.0:
-  version "12.5.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz"
-  integrity sha1-OLnv18WsdDVP5Ojb5CaX2wuOhaU=
+"azure-devops-node-api@^12.5.0":
+  "integrity" "sha1-OLnv18WsdDVP5Ojb5CaX2wuOhaU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz"
+  "version" "12.5.0"
   dependencies:
-    tunnel "0.0.6"
-    typed-rest-client "^1.8.4"
+    "tunnel" "0.0.6"
+    "typed-rest-client" "^1.8.4"
 
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz"
-  integrity sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=
+"balanced-match@^1.0.0":
+  "integrity" "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz"
+  "version" "1.0.2"
 
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/base64-js/-/base64-js-1.5.1.tgz"
-  integrity sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=
+"base64-js@^1.3.1":
+  "integrity" "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/base64-js/-/base64-js-1.5.1.tgz"
+  "version" "1.5.1"
 
-bl@^4.0.3:
-  version "4.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bl/-/bl-4.1.0.tgz"
-  integrity sha1-RRU1JkGCvsL7vIOmKrmM8R2fezo=
+"bl@^4.0.3":
+  "integrity" "sha1-RRU1JkGCvsL7vIOmKrmM8R2fezo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bl/-/bl-4.1.0.tgz"
+  "version" "4.1.0"
   dependencies:
-    buffer "^5.5.0"
-    inherits "^2.0.4"
-    readable-stream "^3.4.0"
+    "buffer" "^5.5.0"
+    "inherits" "^2.0.4"
+    "readable-stream" "^3.4.0"
 
-boolbase@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/boolbase/-/boolbase-1.0.0.tgz"
-  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+"boolbase@^1.0.0":
+  "integrity" "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/boolbase/-/boolbase-1.0.0.tgz"
+  "version" "1.0.0"
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz"
-  integrity sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=
+"brace-expansion@^1.1.7":
+  "integrity" "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz"
+  "version" "1.1.11"
   dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
+    "balanced-match" "^1.0.0"
+    "concat-map" "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz"
-  integrity sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=
+"brace-expansion@^2.0.1":
+  "integrity" "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz"
+  "version" "2.0.1"
   dependencies:
-    balanced-match "^1.0.0"
+    "balanced-match" "^1.0.0"
 
-braces@^3.0.3:
-  version "3.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/braces/-/braces-3.0.3.tgz"
-  integrity sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=
+"braces@^3.0.3":
+  "integrity" "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/braces/-/braces-3.0.3.tgz"
+  "version" "3.0.3"
   dependencies:
-    fill-range "^7.1.1"
+    "fill-range" "^7.1.1"
 
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
-  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+"buffer-crc32@~0.2.3":
+  "integrity" "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
+  "version" "0.2.13"
 
-buffer-equal-constant-time@1.0.1:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
-  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+"buffer-equal-constant-time@1.0.1":
+  "integrity" "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
+  "version" "1.0.1"
 
-buffer@^5.5.0:
-  version "5.7.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer/-/buffer-5.7.1.tgz"
-  integrity sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=
+"buffer@^5.5.0":
+  "integrity" "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/buffer/-/buffer-5.7.1.tgz"
+  "version" "5.7.1"
   dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.1.13"
+    "base64-js" "^1.3.1"
+    "ieee754" "^1.1.13"
 
-builtin-modules@^1.1.1:
-  version "1.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz"
-  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
+"builtin-modules@^1.1.1":
+  "integrity" "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz"
+  "version" "1.1.1"
 
-call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz"
-  integrity sha1-MuWJLmNhspsLVFum93YzeNrKKEA=
+"bundle-name@^4.1.0":
+  "integrity" "sha1-87lrNBYNZDGhnXaIE1r3z7h5eIk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/bundle-name/-/bundle-name-4.1.0.tgz"
+  "version" "4.1.0"
   dependencies:
-    es-errors "^1.3.0"
-    function-bind "^1.1.2"
+    "run-applescript" "^7.0.0"
 
-call-bind@^1.0.7, call-bind@^1.0.8:
-  version "1.0.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind/-/call-bind-1.0.8.tgz"
-  integrity sha1-BzapZg9TfjOIgm9EDV7EX3ROqkw=
+"call-bind-apply-helpers@^1.0.0", "call-bind-apply-helpers@^1.0.1", "call-bind-apply-helpers@^1.0.2":
+  "integrity" "sha1-S1QowiK+mF15w9gmV0edvgtZstY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz"
+  "version" "1.0.2"
   dependencies:
-    call-bind-apply-helpers "^1.0.0"
-    es-define-property "^1.0.0"
-    get-intrinsic "^1.2.4"
-    set-function-length "^1.2.2"
+    "es-errors" "^1.3.0"
+    "function-bind" "^1.1.2"
 
-call-bound@^1.0.2, call-bound@^1.0.3:
-  version "1.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bound/-/call-bound-1.0.3.tgz"
-  integrity sha1-Qc/QMrWT45F2pxUzq084SqBP1oE=
+"call-bind@^1.0.7", "call-bind@^1.0.8":
+  "integrity" "sha1-BzapZg9TfjOIgm9EDV7EX3ROqkw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bind/-/call-bind-1.0.8.tgz"
+  "version" "1.0.8"
   dependencies:
-    call-bind-apply-helpers "^1.0.1"
-    get-intrinsic "^1.2.6"
+    "call-bind-apply-helpers" "^1.0.0"
+    "es-define-property" "^1.0.0"
+    "get-intrinsic" "^1.2.4"
+    "set-function-length" "^1.2.2"
 
-callsites@^3.0.0:
-  version "3.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/callsites/-/callsites-3.1.0.tgz"
-  integrity sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=
-
-chalk@^2.3.0, chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz"
-  integrity sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=
+"call-bound@^1.0.2", "call-bound@^1.0.3", "call-bound@^1.0.4":
+  "integrity" "sha1-I43pNdKippKSjFOMfM+pEGf9Bio="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/call-bound/-/call-bound-1.0.4.tgz"
+  "version" "1.0.4"
   dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
+    "call-bind-apply-helpers" "^1.0.2"
+    "get-intrinsic" "^1.3.0"
 
-chalk@^4.0.0:
-  version "4.1.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-4.1.2.tgz"
-  integrity sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=
+"callsites@^3.0.0":
+  "integrity" "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/callsites/-/callsites-3.1.0.tgz"
+  "version" "3.1.0"
+
+"chalk@^2.3.0", "chalk@^2.4.2":
+  "integrity" "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-2.4.2.tgz"
+  "version" "2.4.2"
   dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
+    "ansi-styles" "^3.2.1"
+    "escape-string-regexp" "^1.0.5"
+    "supports-color" "^5.3.0"
 
-cheerio-select@^2.1.0:
-  version "2.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cheerio-select/-/cheerio-select-2.1.0.tgz"
-  integrity sha1-TYZzKGuBJsoqjkJ0DV48SISuIbQ=
+"chalk@^4.0.0":
+  "integrity" "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chalk/-/chalk-4.1.2.tgz"
+  "version" "4.1.2"
   dependencies:
-    boolbase "^1.0.0"
-    css-select "^5.1.0"
-    css-what "^6.1.0"
-    domelementtype "^2.3.0"
-    domhandler "^5.0.3"
-    domutils "^3.0.1"
+    "ansi-styles" "^4.1.0"
+    "supports-color" "^7.1.0"
 
-cheerio@^1.0.0-rc.9:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cheerio/-/cheerio-1.0.0.tgz"
-  integrity sha1-Ht5IlagvJuivcQCflhqbjLYNaoE=
+"cheerio-select@^2.1.0":
+  "integrity" "sha1-TYZzKGuBJsoqjkJ0DV48SISuIbQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cheerio-select/-/cheerio-select-2.1.0.tgz"
+  "version" "2.1.0"
   dependencies:
-    cheerio-select "^2.1.0"
-    dom-serializer "^2.0.0"
-    domhandler "^5.0.3"
-    domutils "^3.1.0"
-    encoding-sniffer "^0.2.0"
-    htmlparser2 "^9.1.0"
-    parse5 "^7.1.2"
-    parse5-htmlparser2-tree-adapter "^7.0.0"
-    parse5-parser-stream "^7.1.2"
-    undici "^6.19.5"
-    whatwg-mimetype "^4.0.0"
+    "boolbase" "^1.0.0"
+    "css-select" "^5.1.0"
+    "css-what" "^6.1.0"
+    "domelementtype" "^2.3.0"
+    "domhandler" "^5.0.3"
+    "domutils" "^3.0.1"
 
-chownr@^1.1.1:
-  version "1.1.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chownr/-/chownr-1.1.4.tgz"
-  integrity sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=
-
-cockatiel@^3.1.2:
-  version "3.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cockatiel/-/cockatiel-3.2.1.tgz"
-  integrity sha1-V1+Te8QECiCuJzUqbQfJxadBmB8=
-
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz"
-  integrity sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=
+"cheerio@^1.0.0-rc.9":
+  "integrity" "sha1-Ht5IlagvJuivcQCflhqbjLYNaoE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cheerio/-/cheerio-1.0.0.tgz"
+  "version" "1.0.0"
   dependencies:
-    color-name "1.1.3"
+    "cheerio-select" "^2.1.0"
+    "dom-serializer" "^2.0.0"
+    "domhandler" "^5.0.3"
+    "domutils" "^3.1.0"
+    "encoding-sniffer" "^0.2.0"
+    "htmlparser2" "^9.1.0"
+    "parse5" "^7.1.2"
+    "parse5-htmlparser2-tree-adapter" "^7.0.0"
+    "parse5-parser-stream" "^7.1.2"
+    "undici" "^6.19.5"
+    "whatwg-mimetype" "^4.0.0"
 
-color-convert@^2.0.1:
-  version "2.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz"
-  integrity sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=
+"chownr@^1.1.1":
+  "integrity" "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/chownr/-/chownr-1.1.4.tgz"
+  "version" "1.1.4"
+
+"cockatiel@^3.1.2":
+  "integrity" "sha1-V1+Te8QECiCuJzUqbQfJxadBmB8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cockatiel/-/cockatiel-3.2.1.tgz"
+  "version" "3.2.1"
+
+"color-convert@^1.9.0":
+  "integrity" "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz"
+  "version" "1.9.3"
   dependencies:
-    color-name "~1.1.4"
+    "color-name" "1.1.3"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
-
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.4.tgz"
-  integrity sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=
-
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz"
-  integrity sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=
+"color-convert@^2.0.1":
+  "integrity" "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz"
+  "version" "2.0.1"
   dependencies:
-    delayed-stream "~1.0.0"
+    "color-name" "~1.1.4"
 
-commander@^2.12.1:
-  version "2.20.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-2.20.3.tgz"
-  integrity sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=
+"color-name@~1.1.4":
+  "integrity" "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.4.tgz"
+  "version" "1.1.4"
 
-commander@^6.2.1:
-  version "6.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-6.2.1.tgz"
-  integrity sha1-B5LraC37wyWZm7K4T93duhEKxzw=
+"color-name@1.1.3":
+  "integrity" "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/color-name/-/color-name-1.1.3.tgz"
+  "version" "1.1.3"
 
-comment-parser@1.4.1:
-  version "1.4.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/comment-parser/-/comment-parser-1.4.1.tgz"
-  integrity sha1-va/q03lhrAeb4R637GXE0CHq+cw=
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
-
-cross-spawn@^7.0.2:
-  version "7.0.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz"
-  integrity sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=
+"combined-stream@^1.0.8":
+  "integrity" "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz"
+  "version" "1.0.8"
   dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
+    "delayed-stream" "~1.0.0"
 
-css-select@^5.1.0:
-  version "5.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-select/-/css-select-5.1.0.tgz"
-  integrity sha1-uOvWVUw2N8zHZoiAStP2pv2uqKY=
+"commander@^2.12.1":
+  "integrity" "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-2.20.3.tgz"
+  "version" "2.20.3"
+
+"commander@^6.2.1":
+  "integrity" "sha1-B5LraC37wyWZm7K4T93duhEKxzw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-6.2.1.tgz"
+  "version" "6.2.1"
+
+"comment-parser@1.4.1":
+  "integrity" "sha1-va/q03lhrAeb4R637GXE0CHq+cw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/comment-parser/-/comment-parser-1.4.1.tgz"
+  "version" "1.4.1"
+
+"concat-map@0.0.1":
+  "integrity" "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz"
+  "version" "0.0.1"
+
+"cross-spawn@^7.0.2":
+  "integrity" "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz"
+  "version" "7.0.6"
   dependencies:
-    boolbase "^1.0.0"
-    css-what "^6.1.0"
-    domhandler "^5.0.2"
-    domutils "^3.0.1"
-    nth-check "^2.0.1"
+    "path-key" "^3.1.0"
+    "shebang-command" "^2.0.0"
+    "which" "^2.0.1"
 
-css-what@^6.1.0:
-  version "6.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-what/-/css-what-6.1.0.tgz"
-  integrity sha1-+17/z3bx3eosgb36pN5E55uscPQ=
-
-data-view-buffer@^1.0.2:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/data-view-buffer/-/data-view-buffer-1.0.2.tgz"
-  integrity sha1-IRoDupXsr3eYqMcZjXlTYhH4hXA=
+"css-select@^5.1.0":
+  "integrity" "sha1-uOvWVUw2N8zHZoiAStP2pv2uqKY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-select/-/css-select-5.1.0.tgz"
+  "version" "5.1.0"
   dependencies:
-    call-bound "^1.0.3"
-    es-errors "^1.3.0"
-    is-data-view "^1.0.2"
+    "boolbase" "^1.0.0"
+    "css-what" "^6.1.0"
+    "domhandler" "^5.0.2"
+    "domutils" "^3.0.1"
+    "nth-check" "^2.0.1"
 
-data-view-byte-length@^1.0.2:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz"
-  integrity sha1-noD3ylJFPOPpPSWjUxh2fqdwRzU=
+"css-what@^6.1.0":
+  "integrity" "sha1-+17/z3bx3eosgb36pN5E55uscPQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-what/-/css-what-6.1.0.tgz"
+  "version" "6.1.0"
+
+"data-view-buffer@^1.0.2":
+  "integrity" "sha1-IRoDupXsr3eYqMcZjXlTYhH4hXA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/data-view-buffer/-/data-view-buffer-1.0.2.tgz"
+  "version" "1.0.2"
   dependencies:
-    call-bound "^1.0.3"
-    es-errors "^1.3.0"
-    is-data-view "^1.0.2"
+    "call-bound" "^1.0.3"
+    "es-errors" "^1.3.0"
+    "is-data-view" "^1.0.2"
 
-data-view-byte-offset@^1.0.1:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz"
-  integrity sha1-BoMH+bcat2274QKROJ4CCFZgYZE=
+"data-view-byte-length@^1.0.2":
+  "integrity" "sha1-noD3ylJFPOPpPSWjUxh2fqdwRzU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz"
+  "version" "1.0.2"
   dependencies:
-    call-bound "^1.0.2"
-    es-errors "^1.3.0"
-    is-data-view "^1.0.1"
+    "call-bound" "^1.0.3"
+    "es-errors" "^1.3.0"
+    "is-data-view" "^1.0.2"
 
-debug@4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.6, debug@^4.3.7:
-  version "4.4.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.4.0.tgz"
-  integrity sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=
+"data-view-byte-offset@^1.0.1":
+  "integrity" "sha1-BoMH+bcat2274QKROJ4CCFZgYZE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz"
+  "version" "1.0.1"
   dependencies:
-    ms "^2.1.3"
+    "call-bound" "^1.0.2"
+    "es-errors" "^1.3.0"
+    "is-data-view" "^1.0.1"
 
-debug@^3.2.7:
-  version "3.2.7"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-3.2.7.tgz"
-  integrity sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=
+"debug@^3.2.7":
+  "integrity" "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-3.2.7.tgz"
+  "version" "3.2.7"
   dependencies:
-    ms "^2.1.1"
+    "ms" "^2.1.1"
 
-decompress-response@^6.0.0:
-  version "6.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz"
-  integrity sha1-yjh2Et234QS9FthaqwDV7PCcZvw=
+"debug@^4.3.1", "debug@^4.3.2", "debug@^4.3.4", "debug@^4.3.6", "debug@^4.4.0", "debug@4":
+  "integrity" "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.4.0.tgz"
+  "version" "4.4.0"
   dependencies:
-    mimic-response "^3.1.0"
+    "ms" "^2.1.3"
 
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-extend/-/deep-extend-0.6.0.tgz"
-  integrity sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=
-
-deep-is@^0.1.3:
-  version "0.1.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-is/-/deep-is-0.1.4.tgz"
-  integrity sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=
-
-define-data-property@^1.0.1, define-data-property@^1.1.4:
-  version "1.1.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-data-property/-/define-data-property-1.1.4.tgz"
-  integrity sha1-iU3BQbt9MGCuQ2b2oBB+aPvkjF4=
+"decompress-response@^6.0.0":
+  "integrity" "sha1-yjh2Et234QS9FthaqwDV7PCcZvw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    es-define-property "^1.0.0"
-    es-errors "^1.3.0"
-    gopd "^1.0.1"
+    "mimic-response" "^3.1.0"
 
-define-lazy-prop@^2.0.0:
-  version "2.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz"
-  integrity sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8=
+"deep-extend@^0.6.0":
+  "integrity" "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-extend/-/deep-extend-0.6.0.tgz"
+  "version" "0.6.0"
 
-define-properties@^1.2.1:
-  version "1.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-properties/-/define-properties-1.2.1.tgz"
-  integrity sha1-EHgcxhbrlRqAoDS6/Kpzd/avK2w=
+"deep-is@^0.1.3":
+  "integrity" "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-is/-/deep-is-0.1.4.tgz"
+  "version" "0.1.4"
+
+"default-browser-id@^5.0.0":
+  "integrity" "sha1-odmL+WDBUILYo/pp6DFQzMzDryY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/default-browser-id/-/default-browser-id-5.0.0.tgz"
+  "version" "5.0.0"
+
+"default-browser@^5.2.1":
+  "integrity" "sha1-e3umEgT/PkJbVWhprm0+nZ8XEs8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/default-browser/-/default-browser-5.2.1.tgz"
+  "version" "5.2.1"
   dependencies:
-    define-data-property "^1.0.1"
-    has-property-descriptors "^1.0.0"
-    object-keys "^1.1.1"
+    "bundle-name" "^4.1.0"
+    "default-browser-id" "^5.0.0"
 
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz"
-  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-
-detect-libc@^2.0.0:
-  version "2.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.0.3.tgz"
-  integrity sha1-8M1QO0D5k5uJRpfRmtUIleMM9wA=
-
-diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-4.0.2.tgz"
-  integrity sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=
-
-dir-glob@^3.0.1:
-  version "3.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dir-glob/-/dir-glob-3.0.1.tgz"
-  integrity sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=
+"define-data-property@^1.0.1", "define-data-property@^1.1.4":
+  "integrity" "sha1-iU3BQbt9MGCuQ2b2oBB+aPvkjF4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-data-property/-/define-data-property-1.1.4.tgz"
+  "version" "1.1.4"
   dependencies:
-    path-type "^4.0.0"
+    "es-define-property" "^1.0.0"
+    "es-errors" "^1.3.0"
+    "gopd" "^1.0.1"
 
-doctrine@^2.1.0:
-  version "2.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/doctrine/-/doctrine-2.1.0.tgz"
-  integrity sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=
+"define-lazy-prop@^3.0.0":
+  "integrity" "sha1-27Ga37dG1/xtc0oGty9KANAhJV8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz"
+  "version" "3.0.0"
+
+"define-properties@^1.2.1":
+  "integrity" "sha1-EHgcxhbrlRqAoDS6/Kpzd/avK2w="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-properties/-/define-properties-1.2.1.tgz"
+  "version" "1.2.1"
   dependencies:
-    esutils "^2.0.2"
+    "define-data-property" "^1.0.1"
+    "has-property-descriptors" "^1.0.0"
+    "object-keys" "^1.1.1"
 
-doctrine@^3.0.0:
-  version "3.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/doctrine/-/doctrine-3.0.0.tgz"
-  integrity sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=
+"delayed-stream@~1.0.0":
+  "integrity" "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz"
+  "version" "1.0.0"
+
+"detect-libc@^2.0.0":
+  "integrity" "sha1-8M1QO0D5k5uJRpfRmtUIleMM9wA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.0.3.tgz"
+  "version" "2.0.3"
+
+"diff@^4.0.1":
+  "integrity" "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/diff/-/diff-4.0.2.tgz"
+  "version" "4.0.2"
+
+"dir-glob@^3.0.1":
+  "integrity" "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dir-glob/-/dir-glob-3.0.1.tgz"
+  "version" "3.0.1"
   dependencies:
-    esutils "^2.0.2"
+    "path-type" "^4.0.0"
 
-dom-serializer@^2.0.0:
-  version "2.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dom-serializer/-/dom-serializer-2.0.0.tgz"
-  integrity sha1-5BuALh7t+fbK4YPOXmIteJ19jlM=
+"doctrine@^2.1.0":
+  "integrity" "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/doctrine/-/doctrine-2.1.0.tgz"
+  "version" "2.1.0"
   dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.2"
-    entities "^4.2.0"
+    "esutils" "^2.0.2"
 
-domelementtype@^2.3.0:
-  version "2.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domelementtype/-/domelementtype-2.3.0.tgz"
-  integrity sha1-XEXo6GmVJiYzHXqrMm0B2vZdWJ0=
-
-domhandler@^5.0.2, domhandler@^5.0.3:
-  version "5.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domhandler/-/domhandler-5.0.3.tgz"
-  integrity sha1-zDhff3UfHR/GUMITdIBCVFOMfTE=
+"doctrine@^3.0.0":
+  "integrity" "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/doctrine/-/doctrine-3.0.0.tgz"
+  "version" "3.0.0"
   dependencies:
-    domelementtype "^2.3.0"
+    "esutils" "^2.0.2"
 
-domutils@^3.0.1, domutils@^3.1.0:
-  version "3.2.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domutils/-/domutils-3.2.2.tgz"
-  integrity sha1-7b/itmiwwdl8JLrw8QYrEyIhvHg=
+"dom-serializer@^2.0.0":
+  "integrity" "sha1-5BuALh7t+fbK4YPOXmIteJ19jlM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dom-serializer/-/dom-serializer-2.0.0.tgz"
+  "version" "2.0.0"
   dependencies:
-    dom-serializer "^2.0.0"
-    domelementtype "^2.3.0"
-    domhandler "^5.0.3"
+    "domelementtype" "^2.3.0"
+    "domhandler" "^5.0.2"
+    "entities" "^4.2.0"
 
-dunder-proto@^1.0.0, dunder-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz"
-  integrity sha1-165mfh3INIL4tw/Q9u78UNow9Yo=
+"domelementtype@^2.3.0":
+  "integrity" "sha1-XEXo6GmVJiYzHXqrMm0B2vZdWJ0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domelementtype/-/domelementtype-2.3.0.tgz"
+  "version" "2.3.0"
+
+"domhandler@^5.0.2", "domhandler@^5.0.3":
+  "integrity" "sha1-zDhff3UfHR/GUMITdIBCVFOMfTE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domhandler/-/domhandler-5.0.3.tgz"
+  "version" "5.0.3"
   dependencies:
-    call-bind-apply-helpers "^1.0.1"
-    es-errors "^1.3.0"
-    gopd "^1.2.0"
+    "domelementtype" "^2.3.0"
 
-ecdsa-sig-formatter@1.0.11:
-  version "1.0.11"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz"
-  integrity sha1-rg8PothQRe8UqBfao86azQSJ5b8=
+"domutils@^3.0.1", "domutils@^3.1.0":
+  "integrity" "sha1-7b/itmiwwdl8JLrw8QYrEyIhvHg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domutils/-/domutils-3.2.2.tgz"
+  "version" "3.2.2"
   dependencies:
-    safe-buffer "^5.0.1"
+    "dom-serializer" "^2.0.0"
+    "domelementtype" "^2.3.0"
+    "domhandler" "^5.0.3"
 
-encoding-sniffer@^0.2.0:
-  version "0.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz"
-  integrity sha1-eZVp1m1EO6voKvGMn0A0mDZe8dU=
+"dunder-proto@^1.0.0", "dunder-proto@^1.0.1":
+  "integrity" "sha1-165mfh3INIL4tw/Q9u78UNow9Yo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz"
+  "version" "1.0.1"
   dependencies:
-    iconv-lite "^0.6.3"
-    whatwg-encoding "^3.1.1"
+    "call-bind-apply-helpers" "^1.0.1"
+    "es-errors" "^1.3.0"
+    "gopd" "^1.2.0"
 
-end-of-stream@^1.1.0, end-of-stream@^1.4.1:
-  version "1.4.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz"
-  integrity sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=
+"ecdsa-sig-formatter@1.0.11":
+  "integrity" "sha1-rg8PothQRe8UqBfao86azQSJ5b8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz"
+  "version" "1.0.11"
   dependencies:
-    once "^1.4.0"
+    "safe-buffer" "^5.0.1"
 
-enhanced-resolve@^5.15.0:
-  version "5.18.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz"
-  integrity sha1-kesdsZOJa5gBJR7v8caYAnix5AQ=
+"encoding-sniffer@^0.2.0":
+  "integrity" "sha1-eZVp1m1EO6voKvGMn0A0mDZe8dU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz"
+  "version" "0.2.0"
   dependencies:
-    graceful-fs "^4.2.4"
-    tapable "^2.2.0"
+    "iconv-lite" "^0.6.3"
+    "whatwg-encoding" "^3.1.1"
 
-entities@^4.2.0, entities@^4.5.0:
-  version "4.5.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-4.5.0.tgz"
-  integrity sha1-XSaOpecRPsdMTQM7eepaNaSI+0g=
-
-entities@~2.1.0:
-  version "2.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-2.1.0.tgz"
-  integrity sha1-mS0xKc999ocLlsV4WMJJoSD4uLU=
-
-es-abstract@^1.23.2, es-abstract@^1.23.5, es-abstract@^1.23.9:
-  version "1.23.9"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-abstract/-/es-abstract-1.23.9.tgz"
-  integrity sha1-W0WZS33nja2lwb6/E3lkazK51gY=
+"end-of-stream@^1.1.0", "end-of-stream@^1.4.1":
+  "integrity" "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz"
+  "version" "1.4.4"
   dependencies:
-    array-buffer-byte-length "^1.0.2"
-    arraybuffer.prototype.slice "^1.0.4"
-    available-typed-arrays "^1.0.7"
-    call-bind "^1.0.8"
-    call-bound "^1.0.3"
-    data-view-buffer "^1.0.2"
-    data-view-byte-length "^1.0.2"
-    data-view-byte-offset "^1.0.1"
-    es-define-property "^1.0.1"
-    es-errors "^1.3.0"
-    es-object-atoms "^1.0.0"
-    es-set-tostringtag "^2.1.0"
-    es-to-primitive "^1.3.0"
-    function.prototype.name "^1.1.8"
-    get-intrinsic "^1.2.7"
-    get-proto "^1.0.0"
-    get-symbol-description "^1.1.0"
-    globalthis "^1.0.4"
-    gopd "^1.2.0"
-    has-property-descriptors "^1.0.2"
-    has-proto "^1.2.0"
-    has-symbols "^1.1.0"
-    hasown "^2.0.2"
-    internal-slot "^1.1.0"
-    is-array-buffer "^3.0.5"
-    is-callable "^1.2.7"
-    is-data-view "^1.0.2"
-    is-regex "^1.2.1"
-    is-shared-array-buffer "^1.0.4"
-    is-string "^1.1.1"
-    is-typed-array "^1.1.15"
-    is-weakref "^1.1.0"
-    math-intrinsics "^1.1.0"
-    object-inspect "^1.13.3"
-    object-keys "^1.1.1"
-    object.assign "^4.1.7"
-    own-keys "^1.0.1"
-    regexp.prototype.flags "^1.5.3"
-    safe-array-concat "^1.1.3"
-    safe-push-apply "^1.0.0"
-    safe-regex-test "^1.1.0"
-    set-proto "^1.0.0"
-    string.prototype.trim "^1.2.10"
-    string.prototype.trimend "^1.0.9"
-    string.prototype.trimstart "^1.0.8"
-    typed-array-buffer "^1.0.3"
-    typed-array-byte-length "^1.0.3"
-    typed-array-byte-offset "^1.0.4"
-    typed-array-length "^1.0.7"
-    unbox-primitive "^1.1.0"
-    which-typed-array "^1.1.18"
+    "once" "^1.4.0"
 
-es-define-property@^1.0.0, es-define-property@^1.0.1:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz"
-  integrity sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=
+"entities@^4.2.0", "entities@^4.5.0":
+  "integrity" "sha1-XSaOpecRPsdMTQM7eepaNaSI+0g="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-4.5.0.tgz"
+  "version" "4.5.0"
 
-es-errors@^1.3.0:
-  version "1.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-errors/-/es-errors-1.3.0.tgz"
-  integrity sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=
+"entities@~2.1.0":
+  "integrity" "sha1-mS0xKc999ocLlsV4WMJJoSD4uLU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-2.1.0.tgz"
+  "version" "2.1.0"
 
-es-module-lexer@^1.5.3:
-  version "1.6.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-module-lexer/-/es-module-lexer-1.6.0.tgz"
-  integrity sha1-2kn1h/2eaO4kBP5OJWwMfTqBviE=
-
-es-object-atoms@^1.0.0:
-  version "1.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz"
-  integrity sha1-HE8sSDcydZfOadLKGQp/3RcjOME=
+"es-abstract@^1.23.2", "es-abstract@^1.23.5", "es-abstract@^1.23.9":
+  "integrity" "sha1-W0WZS33nja2lwb6/E3lkazK51gY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-abstract/-/es-abstract-1.23.9.tgz"
+  "version" "1.23.9"
   dependencies:
-    es-errors "^1.3.0"
+    "array-buffer-byte-length" "^1.0.2"
+    "arraybuffer.prototype.slice" "^1.0.4"
+    "available-typed-arrays" "^1.0.7"
+    "call-bind" "^1.0.8"
+    "call-bound" "^1.0.3"
+    "data-view-buffer" "^1.0.2"
+    "data-view-byte-length" "^1.0.2"
+    "data-view-byte-offset" "^1.0.1"
+    "es-define-property" "^1.0.1"
+    "es-errors" "^1.3.0"
+    "es-object-atoms" "^1.0.0"
+    "es-set-tostringtag" "^2.1.0"
+    "es-to-primitive" "^1.3.0"
+    "function.prototype.name" "^1.1.8"
+    "get-intrinsic" "^1.2.7"
+    "get-proto" "^1.0.0"
+    "get-symbol-description" "^1.1.0"
+    "globalthis" "^1.0.4"
+    "gopd" "^1.2.0"
+    "has-property-descriptors" "^1.0.2"
+    "has-proto" "^1.2.0"
+    "has-symbols" "^1.1.0"
+    "hasown" "^2.0.2"
+    "internal-slot" "^1.1.0"
+    "is-array-buffer" "^3.0.5"
+    "is-callable" "^1.2.7"
+    "is-data-view" "^1.0.2"
+    "is-regex" "^1.2.1"
+    "is-shared-array-buffer" "^1.0.4"
+    "is-string" "^1.1.1"
+    "is-typed-array" "^1.1.15"
+    "is-weakref" "^1.1.0"
+    "math-intrinsics" "^1.1.0"
+    "object-inspect" "^1.13.3"
+    "object-keys" "^1.1.1"
+    "object.assign" "^4.1.7"
+    "own-keys" "^1.0.1"
+    "regexp.prototype.flags" "^1.5.3"
+    "safe-array-concat" "^1.1.3"
+    "safe-push-apply" "^1.0.0"
+    "safe-regex-test" "^1.1.0"
+    "set-proto" "^1.0.0"
+    "string.prototype.trim" "^1.2.10"
+    "string.prototype.trimend" "^1.0.9"
+    "string.prototype.trimstart" "^1.0.8"
+    "typed-array-buffer" "^1.0.3"
+    "typed-array-byte-length" "^1.0.3"
+    "typed-array-byte-offset" "^1.0.4"
+    "typed-array-length" "^1.0.7"
+    "unbox-primitive" "^1.1.0"
+    "which-typed-array" "^1.1.18"
 
-es-set-tostringtag@^2.1.0:
-  version "2.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz"
-  integrity sha1-8x274MGDsAptJutjJcgQwP0YvU0=
+"es-define-property@^1.0.0", "es-define-property@^1.0.1":
+  "integrity" "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz"
+  "version" "1.0.1"
+
+"es-errors@^1.3.0":
+  "integrity" "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-errors/-/es-errors-1.3.0.tgz"
+  "version" "1.3.0"
+
+"es-module-lexer@^1.5.3":
+  "integrity" "sha1-2kn1h/2eaO4kBP5OJWwMfTqBviE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-module-lexer/-/es-module-lexer-1.6.0.tgz"
+  "version" "1.6.0"
+
+"es-object-atoms@^1.0.0", "es-object-atoms@^1.1.1":
+  "integrity" "sha1-HE8sSDcydZfOadLKGQp/3RcjOME="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz"
+  "version" "1.1.1"
   dependencies:
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.6"
-    has-tostringtag "^1.0.2"
-    hasown "^2.0.2"
+    "es-errors" "^1.3.0"
 
-es-shim-unscopables@^1.0.2:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz"
-  integrity sha1-H2lC5x7MeDXtHIqDAG2HcaY6N2M=
+"es-set-tostringtag@^2.1.0":
+  "integrity" "sha1-8x274MGDsAptJutjJcgQwP0YvU0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz"
+  "version" "2.1.0"
   dependencies:
-    hasown "^2.0.0"
+    "es-errors" "^1.3.0"
+    "get-intrinsic" "^1.2.6"
+    "has-tostringtag" "^1.0.2"
+    "hasown" "^2.0.2"
 
-es-to-primitive@^1.3.0:
-  version "1.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-to-primitive/-/es-to-primitive-1.3.0.tgz"
-  integrity sha1-lsicgsxJ/YeUokg1uj4f+H8hThg=
+"es-shim-unscopables@^1.0.2", "es-shim-unscopables@^1.1.0":
+  "integrity" "sha1-Q43zVSDaxdEF85Q9knVJ6jsA9LU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz"
+  "version" "1.1.0"
   dependencies:
-    is-callable "^1.2.7"
-    is-date-object "^1.0.5"
-    is-symbol "^1.0.4"
+    "hasown" "^2.0.2"
 
-escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
-escape-string-regexp@^4.0.0:
-  version "4.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
-  integrity sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=
-
-eslint-config-prettier@^9.1.0:
-  version "9.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz"
-  integrity sha1-Ma89lFeGRZZsCC/LcaWEbTyUhn8=
-
-eslint-import-resolver-node@^0.3.9:
-  version "0.3.9"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz"
-  integrity sha1-1OqsUrii58PNGQPrAPfgUzVhGKw=
+"es-to-primitive@^1.3.0":
+  "integrity" "sha1-lsicgsxJ/YeUokg1uj4f+H8hThg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/es-to-primitive/-/es-to-primitive-1.3.0.tgz"
+  "version" "1.3.0"
   dependencies:
-    debug "^3.2.7"
-    is-core-module "^2.13.0"
-    resolve "^1.22.4"
+    "is-callable" "^1.2.7"
+    "is-date-object" "^1.0.5"
+    "is-symbol" "^1.0.4"
 
-eslint-import-resolver-typescript@^3.6.3:
-  version "3.7.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.7.0.tgz"
-  integrity sha1-5pklk2p3Gpyy3kGMzrxM32wIGKo=
+"escape-string-regexp@^1.0.5":
+  "integrity" "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+  "version" "1.0.5"
+
+"escape-string-regexp@^4.0.0":
+  "integrity" "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
+  "version" "4.0.0"
+
+"eslint-config-prettier@^9.1.0", "eslint-config-prettier@>= 7.0.0 <10.0.0 || >=10.1.0":
+  "integrity" "sha1-Ma89lFeGRZZsCC/LcaWEbTyUhn8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz"
+  "version" "9.1.0"
+
+"eslint-import-resolver-node@^0.3.9":
+  "integrity" "sha1-1OqsUrii58PNGQPrAPfgUzVhGKw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz"
+  "version" "0.3.9"
+  dependencies:
+    "debug" "^3.2.7"
+    "is-core-module" "^2.13.0"
+    "resolve" "^1.22.4"
+
+"eslint-import-resolver-typescript@^3.6.3":
+  "integrity" "sha1-W8pMV54XF06Vv2dSa0JNB7RsNS4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.0.tgz"
+  "version" "3.10.0"
   dependencies:
     "@nolyfill/is-core-module" "1.0.39"
-    debug "^4.3.7"
-    enhanced-resolve "^5.15.0"
-    fast-glob "^3.3.2"
-    get-tsconfig "^4.7.5"
-    is-bun-module "^1.0.2"
-    is-glob "^4.0.3"
-    stable-hash "^0.0.4"
+    "debug" "^4.4.0"
+    "get-tsconfig" "^4.10.0"
+    "is-bun-module" "^2.0.0"
+    "stable-hash" "^0.0.5"
+    "tinyglobby" "^0.2.12"
+    "unrs-resolver" "^1.3.2"
 
-eslint-module-utils@^2.12.0:
-  version "2.12.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz"
-  integrity sha1-/kz7lI1h9JID17CIcZgrZbmvCws=
+"eslint-module-utils@^2.12.0":
+  "integrity" "sha1-/kz7lI1h9JID17CIcZgrZbmvCws="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz"
+  "version" "2.12.0"
   dependencies:
-    debug "^3.2.7"
+    "debug" "^3.2.7"
 
-eslint-plugin-import@^2.30.0:
-  version "2.31.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz"
-  integrity sha1-MQzn5yDKHZwLs/aa39HGvdfZ4Oc=
+"eslint-plugin-import@*", "eslint-plugin-import@^2.30.0":
+  "integrity" "sha1-MQzn5yDKHZwLs/aa39HGvdfZ4Oc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz"
+  "version" "2.31.0"
   dependencies:
     "@rtsao/scc" "^1.1.0"
-    array-includes "^3.1.8"
-    array.prototype.findlastindex "^1.2.5"
-    array.prototype.flat "^1.3.2"
-    array.prototype.flatmap "^1.3.2"
-    debug "^3.2.7"
-    doctrine "^2.1.0"
-    eslint-import-resolver-node "^0.3.9"
-    eslint-module-utils "^2.12.0"
-    hasown "^2.0.2"
-    is-core-module "^2.15.1"
-    is-glob "^4.0.3"
-    minimatch "^3.1.2"
-    object.fromentries "^2.0.8"
-    object.groupby "^1.0.3"
-    object.values "^1.2.0"
-    semver "^6.3.1"
-    string.prototype.trimend "^1.0.8"
-    tsconfig-paths "^3.15.0"
+    "array-includes" "^3.1.8"
+    "array.prototype.findlastindex" "^1.2.5"
+    "array.prototype.flat" "^1.3.2"
+    "array.prototype.flatmap" "^1.3.2"
+    "debug" "^3.2.7"
+    "doctrine" "^2.1.0"
+    "eslint-import-resolver-node" "^0.3.9"
+    "eslint-module-utils" "^2.12.0"
+    "hasown" "^2.0.2"
+    "is-core-module" "^2.15.1"
+    "is-glob" "^4.0.3"
+    "minimatch" "^3.1.2"
+    "object.fromentries" "^2.0.8"
+    "object.groupby" "^1.0.3"
+    "object.values" "^1.2.0"
+    "semver" "^6.3.1"
+    "string.prototype.trimend" "^1.0.8"
+    "tsconfig-paths" "^3.15.0"
 
-eslint-plugin-jsdoc@^50.2.2:
-  version "50.6.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.6.3.tgz"
-  integrity sha1-Zo3E0y6CPITt5zEM/79wydNw0pE=
+"eslint-plugin-jsdoc@^50.2.2":
+  "integrity" "sha1-tK/AYRCVi5xSVFa2xDSL8U4hwpg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.6.9.tgz"
+  "version" "50.6.9"
   dependencies:
     "@es-joy/jsdoccomment" "~0.49.0"
-    are-docs-informative "^0.0.2"
-    comment-parser "1.4.1"
-    debug "^4.3.6"
-    escape-string-regexp "^4.0.0"
-    espree "^10.1.0"
-    esquery "^1.6.0"
-    parse-imports "^2.1.1"
-    semver "^7.6.3"
-    spdx-expression-parse "^4.0.0"
-    synckit "^0.9.1"
+    "are-docs-informative" "^0.0.2"
+    "comment-parser" "1.4.1"
+    "debug" "^4.3.6"
+    "escape-string-regexp" "^4.0.0"
+    "espree" "^10.1.0"
+    "esquery" "^1.6.0"
+    "parse-imports" "^2.1.1"
+    "semver" "^7.6.3"
+    "spdx-expression-parse" "^4.0.0"
+    "synckit" "^0.9.1"
 
-eslint-plugin-prefer-arrow@^1.2.3:
-  version "1.2.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz"
-  integrity sha1-5/uz+kzYT/EBW5xRrYZVDlUEEEE=
+"eslint-plugin-prefer-arrow@^1.2.3":
+  "integrity" "sha1-5/uz+kzYT/EBW5xRrYZVDlUEEEE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz"
+  "version" "1.2.3"
 
-eslint-plugin-prettier@^5.2.1:
-  version "5.2.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.3.tgz"
-  integrity sha1-xK8BaRpvqZBSB/D7ug176gkCzOU=
+"eslint-plugin-prettier@^5.2.1":
+  "integrity" "sha1-D/ALFvTIDM2v1qJKJj7/uhcACH4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.5.tgz"
+  "version" "5.2.5"
   dependencies:
-    prettier-linter-helpers "^1.0.0"
-    synckit "^0.9.1"
+    "prettier-linter-helpers" "^1.0.0"
+    "synckit" "^0.10.2"
 
-eslint-scope@^7.2.2:
-  version "7.2.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-scope/-/eslint-scope-7.2.2.tgz"
-  integrity sha1-3rT5JWM5DzIAaJSvYqItuhxGQj8=
+"eslint-scope@^7.2.2":
+  "integrity" "sha1-3rT5JWM5DzIAaJSvYqItuhxGQj8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-scope/-/eslint-scope-7.2.2.tgz"
+  "version" "7.2.2"
   dependencies:
-    esrecurse "^4.3.0"
-    estraverse "^5.2.0"
+    "esrecurse" "^4.3.0"
+    "estraverse" "^5.2.0"
 
-eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
-  version "3.4.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
-  integrity sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=
+"eslint-visitor-keys@^3.4.1", "eslint-visitor-keys@^3.4.3":
+  "integrity" "sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
+  "version" "3.4.3"
 
-eslint-visitor-keys@^4.2.0:
-  version "4.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz"
-  integrity sha1-aHussq+IT83aim59ZcYG9GoUzUU=
+"eslint-visitor-keys@^4.2.0":
+  "integrity" "sha1-aHussq+IT83aim59ZcYG9GoUzUU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz"
+  "version" "4.2.0"
 
-eslint@^8.57.0:
-  version "8.57.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint/-/eslint-8.57.1.tgz"
-  integrity sha1-ffEJZUq6fju+XI6uUzxeRh08bKk=
+"eslint@*", "eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^7.0.0 || ^8.0.0 || ^9.0.0", "eslint@^8.56.0", "eslint@^8.57.0", "eslint@^8.57.0 || ^9.0.0", "eslint@>=2.0.0", "eslint@>=7.0.0", "eslint@>=8.0.0":
+  "integrity" "sha1-ffEJZUq6fju+XI6uUzxeRh08bKk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint/-/eslint-8.57.1.tgz"
+  "version" "8.57.1"
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.6.1"
@@ -1298,1980 +1282,2080 @@ eslint@^8.57.0:
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
     "@ungap/structured-clone" "^1.2.0"
-    ajv "^6.12.4"
-    chalk "^4.0.0"
-    cross-spawn "^7.0.2"
-    debug "^4.3.2"
-    doctrine "^3.0.0"
-    escape-string-regexp "^4.0.0"
-    eslint-scope "^7.2.2"
-    eslint-visitor-keys "^3.4.3"
-    espree "^9.6.1"
-    esquery "^1.4.2"
-    esutils "^2.0.2"
-    fast-deep-equal "^3.1.3"
-    file-entry-cache "^6.0.1"
-    find-up "^5.0.0"
-    glob-parent "^6.0.2"
-    globals "^13.19.0"
-    graphemer "^1.4.0"
-    ignore "^5.2.0"
-    imurmurhash "^0.1.4"
-    is-glob "^4.0.0"
-    is-path-inside "^3.0.3"
-    js-yaml "^4.1.0"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.4.1"
-    lodash.merge "^4.6.2"
-    minimatch "^3.1.2"
-    natural-compare "^1.4.0"
-    optionator "^0.9.3"
-    strip-ansi "^6.0.1"
-    text-table "^0.2.0"
+    "ajv" "^6.12.4"
+    "chalk" "^4.0.0"
+    "cross-spawn" "^7.0.2"
+    "debug" "^4.3.2"
+    "doctrine" "^3.0.0"
+    "escape-string-regexp" "^4.0.0"
+    "eslint-scope" "^7.2.2"
+    "eslint-visitor-keys" "^3.4.3"
+    "espree" "^9.6.1"
+    "esquery" "^1.4.2"
+    "esutils" "^2.0.2"
+    "fast-deep-equal" "^3.1.3"
+    "file-entry-cache" "^6.0.1"
+    "find-up" "^5.0.0"
+    "glob-parent" "^6.0.2"
+    "globals" "^13.19.0"
+    "graphemer" "^1.4.0"
+    "ignore" "^5.2.0"
+    "imurmurhash" "^0.1.4"
+    "is-glob" "^4.0.0"
+    "is-path-inside" "^3.0.3"
+    "js-yaml" "^4.1.0"
+    "json-stable-stringify-without-jsonify" "^1.0.1"
+    "levn" "^0.4.1"
+    "lodash.merge" "^4.6.2"
+    "minimatch" "^3.1.2"
+    "natural-compare" "^1.4.0"
+    "optionator" "^0.9.3"
+    "strip-ansi" "^6.0.1"
+    "text-table" "^0.2.0"
 
-espree@^10.1.0:
-  version "10.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/espree/-/espree-10.3.0.tgz"
-  integrity sha1-KSZ89bDLmHNbZeZLoH4O1J0e7Yo=
+"espree@^10.1.0":
+  "integrity" "sha1-KSZ89bDLmHNbZeZLoH4O1J0e7Yo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/espree/-/espree-10.3.0.tgz"
+  "version" "10.3.0"
   dependencies:
-    acorn "^8.14.0"
-    acorn-jsx "^5.3.2"
-    eslint-visitor-keys "^4.2.0"
+    "acorn" "^8.14.0"
+    "acorn-jsx" "^5.3.2"
+    "eslint-visitor-keys" "^4.2.0"
 
-espree@^9.6.0, espree@^9.6.1:
-  version "9.6.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/espree/-/espree-9.6.1.tgz"
-  integrity sha1-oqF7jkNGkKVDLy+AGM5x0zGkjG8=
+"espree@^9.6.0", "espree@^9.6.1":
+  "integrity" "sha1-oqF7jkNGkKVDLy+AGM5x0zGkjG8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/espree/-/espree-9.6.1.tgz"
+  "version" "9.6.1"
   dependencies:
-    acorn "^8.9.0"
-    acorn-jsx "^5.3.2"
-    eslint-visitor-keys "^3.4.1"
+    "acorn" "^8.9.0"
+    "acorn-jsx" "^5.3.2"
+    "eslint-visitor-keys" "^3.4.1"
 
-esprima@^4.0.0:
-  version "4.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz"
-  integrity sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=
+"esprima@^4.0.0":
+  "integrity" "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esprima/-/esprima-4.0.1.tgz"
+  "version" "4.0.1"
 
-esquery@^1.4.2, esquery@^1.6.0:
-  version "1.6.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esquery/-/esquery-1.6.0.tgz"
-  integrity sha1-kUGSNPgE2FKoLc7sPhbNwiz52uc=
+"esquery@^1.4.2", "esquery@^1.6.0":
+  "integrity" "sha1-kUGSNPgE2FKoLc7sPhbNwiz52uc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esquery/-/esquery-1.6.0.tgz"
+  "version" "1.6.0"
   dependencies:
-    estraverse "^5.1.0"
+    "estraverse" "^5.1.0"
 
-esrecurse@^4.3.0:
-  version "4.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz"
-  integrity sha1-eteWTWeauyi+5yzsY3WLHF0smSE=
+"esrecurse@^4.3.0":
+  "integrity" "sha1-eteWTWeauyi+5yzsY3WLHF0smSE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz"
+  "version" "4.3.0"
   dependencies:
-    estraverse "^5.2.0"
+    "estraverse" "^5.2.0"
 
-estraverse@^5.1.0, estraverse@^5.2.0:
-  version "5.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-5.3.0.tgz"
-  integrity sha1-LupSkHAvJquP5TcDcP+GyWXSESM=
+"estraverse@^5.1.0", "estraverse@^5.2.0":
+  "integrity" "sha1-LupSkHAvJquP5TcDcP+GyWXSESM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-5.3.0.tgz"
+  "version" "5.3.0"
 
-esutils@^2.0.2:
-  version "2.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esutils/-/esutils-2.0.3.tgz"
-  integrity sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=
+"esutils@^2.0.2":
+  "integrity" "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esutils/-/esutils-2.0.3.tgz"
+  "version" "2.0.3"
 
-events@^3.0.0:
-  version "3.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/events/-/events-3.3.0.tgz"
-  integrity sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=
+"events@^3.0.0":
+  "integrity" "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/events/-/events-3.3.0.tgz"
+  "version" "3.3.0"
 
-expand-template@^2.0.3:
-  version "2.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/expand-template/-/expand-template-2.0.3.tgz"
-  integrity sha1-bhSz/O4POmNA7LV9LokYaSBSpHw=
+"expand-template@^2.0.3":
+  "integrity" "sha1-bhSz/O4POmNA7LV9LokYaSBSpHw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/expand-template/-/expand-template-2.0.3.tgz"
+  "version" "2.0.3"
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
-  version "3.1.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
-  integrity sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=
+"fast-deep-equal@^3.1.1", "fast-deep-equal@^3.1.3":
+  "integrity" "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
+  "version" "3.1.3"
 
-fast-diff@^1.1.2:
-  version "1.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-diff/-/fast-diff-1.3.0.tgz"
-  integrity sha1-7OQH+lUKZNY4U2zXJ+EpxhYW4PA=
+"fast-diff@^1.1.2":
+  "integrity" "sha1-7OQH+lUKZNY4U2zXJ+EpxhYW4PA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-diff/-/fast-diff-1.3.0.tgz"
+  "version" "1.3.0"
 
-fast-glob@^3.2.9, fast-glob@^3.3.2:
-  version "3.3.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz"
-  integrity sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=
+"fast-glob@^3.2.9", "fast-glob@^3.3.2":
+  "integrity" "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz"
+  "version" "3.3.3"
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.8"
-
-fast-json-stable-stringify@^2.0.0:
-  version "2.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
-  integrity sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=
-
-fast-levenshtein@^2.0.6:
-  version "2.0.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
-  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
-
-fastq@^1.6.0:
-  version "1.18.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fastq/-/fastq-1.18.0.tgz"
-  integrity sha1-1jHX4l+v/qgYh/5eqMkBDhs2/uA=
-  dependencies:
-    reusify "^1.0.4"
-
-fd-slicer@~1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fd-slicer/-/fd-slicer-1.1.0.tgz"
-  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
-  dependencies:
-    pend "~1.2.0"
-
-file-entry-cache@^6.0.1:
-  version "6.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
-  integrity sha1-IRst2WWcsDlLBz5zI6w8kz1SICc=
-  dependencies:
-    flat-cache "^3.0.4"
-
-fill-range@^7.1.1:
-  version "7.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fill-range/-/fill-range-7.1.1.tgz"
-  integrity sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=
-  dependencies:
-    to-regex-range "^5.0.1"
-
-find-up@^5.0.0:
-  version "5.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz"
-  integrity sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=
-  dependencies:
-    locate-path "^6.0.0"
-    path-exists "^4.0.0"
-
-flat-cache@^3.0.4:
-  version "3.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat-cache/-/flat-cache-3.2.0.tgz"
-  integrity sha1-LAwtUEDJmxYydxqdEFclwBFTY+4=
-  dependencies:
-    flatted "^3.2.9"
-    keyv "^4.5.3"
-    rimraf "^3.0.2"
-
-flatted@^3.2.9:
-  version "3.3.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flatted/-/flatted-3.3.2.tgz"
-  integrity sha1-rboUSKmEG+xytCxTLqI9u+3vGic=
-
-for-each@^0.3.3:
-  version "0.3.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/for-each/-/for-each-0.3.4.tgz"
-  integrity sha1-gUUX/8MD0TmbJWTYFlMY5zXQNBw=
-  dependencies:
-    is-callable "^1.2.7"
-
-form-data@^4.0.0:
-  version "4.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/form-data/-/form-data-4.0.1.tgz"
-  integrity sha1-uhB22qqlv9fpnBpssCqgpc/5DUg=
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
-fs-constants@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz"
-  integrity sha1-a+Dem+mYzhavivwkSXue6bfM2a0=
-
-fs.realpath@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz"
-  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
-
-function-bind@^1.1.2:
-  version "1.1.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.2.tgz"
-  integrity sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=
-
-function.prototype.name@^1.1.6, function.prototype.name@^1.1.8:
-  version "1.1.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function.prototype.name/-/function.prototype.name-1.1.8.tgz"
-  integrity sha1-5o4d97JZpclJ7u+Vzb3lPt/6u3g=
-  dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.3"
-    define-properties "^1.2.1"
-    functions-have-names "^1.2.3"
-    hasown "^2.0.2"
-    is-callable "^1.2.7"
-
-functions-have-names@^1.2.3:
-  version "1.2.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/functions-have-names/-/functions-have-names-1.2.3.tgz"
-  integrity sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ=
-
-get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7:
-  version "1.2.7"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.2.7.tgz"
-  integrity sha1-3PyzPTJy4V9EXRUSS8CiFhibkEQ=
-  dependencies:
-    call-bind-apply-helpers "^1.0.1"
-    es-define-property "^1.0.1"
-    es-errors "^1.3.0"
-    es-object-atoms "^1.0.0"
-    function-bind "^1.1.2"
-    get-proto "^1.0.0"
-    gopd "^1.2.0"
-    has-symbols "^1.1.0"
-    hasown "^2.0.2"
-    math-intrinsics "^1.1.0"
-
-get-proto@^1.0.0, get-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-proto/-/get-proto-1.0.1.tgz"
-  integrity sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=
-  dependencies:
-    dunder-proto "^1.0.1"
-    es-object-atoms "^1.0.0"
-
-get-symbol-description@^1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-symbol-description/-/get-symbol-description-1.1.0.tgz"
-  integrity sha1-e91U4L7+j/yfO04gMiDZ8eiBtu4=
-  dependencies:
-    call-bound "^1.0.3"
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.6"
-
-get-tsconfig@^4.7.5:
-  version "4.10.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-tsconfig/-/get-tsconfig-4.10.0.tgz"
-  integrity sha1-QDpoKzc6gjYSR1pMKSjHMm/A9rs=
-  dependencies:
-    resolve-pkg-maps "^1.0.0"
-
-github-from-package@0.0.0:
-  version "0.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/github-from-package/-/github-from-package-0.0.0.tgz"
-  integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
-
-glob-parent@^5.1.2:
-  version "5.1.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz"
-  integrity sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=
-  dependencies:
-    is-glob "^4.0.1"
-
-glob-parent@^6.0.2:
-  version "6.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz"
-  integrity sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=
-  dependencies:
-    is-glob "^4.0.3"
-
-glob@^7.0.6, glob@^7.1.1, glob@^7.1.3:
-  version "7.2.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.3.tgz"
-  integrity sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.1.1"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-globals@^13.19.0:
-  version "13.24.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globals/-/globals-13.24.0.tgz"
-  integrity sha1-hDKhnXjODB6DOUnDats0VAC7EXE=
-  dependencies:
-    type-fest "^0.20.2"
-
-globalthis@^1.0.4:
-  version "1.0.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globalthis/-/globalthis-1.0.4.tgz"
-  integrity sha1-dDDtOpddl7+1m8zkH1yruvplEjY=
-  dependencies:
-    define-properties "^1.2.1"
-    gopd "^1.0.1"
-
-globby@^11.1.0:
-  version "11.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globby/-/globby-11.1.0.tgz"
-  integrity sha1-vUvpi7BC+D15b344EZkfvoKg00s=
-  dependencies:
-    array-union "^2.1.0"
-    dir-glob "^3.0.1"
-    fast-glob "^3.2.9"
-    ignore "^5.2.0"
-    merge2 "^1.4.1"
-    slash "^3.0.0"
-
-gopd@^1.0.1, gopd@^1.2.0:
-  version "1.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/gopd/-/gopd-1.2.0.tgz"
-  integrity sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=
-
-graceful-fs@^4.2.4:
-  version "4.2.11"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz"
-  integrity sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=
-
-graphemer@^1.4.0:
-  version "1.4.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/graphemer/-/graphemer-1.4.0.tgz"
-  integrity sha1-+y8dVeDjoYSa7/yQxPoN1ToOZsY=
-
-has-bigints@^1.0.2:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-bigints/-/has-bigints-1.1.0.tgz"
-  integrity sha1-KGB+llrJZ+A80qLHCiY2oe2tSf4=
-
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
-
-has-flag@^4.0.0:
-  version "4.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz"
-  integrity sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=
-
-has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.2:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz"
-  integrity sha1-lj7X0HHce/XwhMW/vg0bYiJYaFQ=
-  dependencies:
-    es-define-property "^1.0.0"
-
-has-proto@^1.2.0:
-  version "1.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-proto/-/has-proto-1.2.0.tgz"
-  integrity sha1-XeWm6r2V/f/ZgYtDBV6AZeOf6dU=
-  dependencies:
-    dunder-proto "^1.0.0"
-
-has-symbols@^1.0.3, has-symbols@^1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz"
-  integrity sha1-/JxqeDoISVHQuXH+EBjegTcHozg=
-
-has-tostringtag@^1.0.2:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz"
-  integrity sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=
-  dependencies:
-    has-symbols "^1.0.3"
-
-hasown@^2.0.0, hasown@^2.0.2:
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hasown/-/hasown-2.0.2.tgz"
-  integrity sha1-AD6vkb563DcuhOxZ3DclLO24AAM=
-  dependencies:
-    function-bind "^1.1.2"
-
-hosted-git-info@^4.0.2:
-  version "4.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hosted-git-info/-/hosted-git-info-4.1.0.tgz"
-  integrity sha1-gnuChn6f8cjQxNnVOIA5fSyG0iQ=
-  dependencies:
-    lru-cache "^6.0.0"
-
-htmlparser2@^9.1.0:
-  version "9.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/htmlparser2/-/htmlparser2-9.1.0.tgz"
-  integrity sha1-zbSY2KdaUfc5th0/cYE2w2m8jCM=
-  dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.3"
-    domutils "^3.1.0"
-    entities "^4.5.0"
-
-http-proxy-agent@^7.0.0:
-  version "7.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz"
-  integrity sha1-mosfJGhmwChQlIZYX2K48sGMJw4=
-  dependencies:
-    agent-base "^7.1.0"
-    debug "^4.3.4"
-
-https-proxy-agent@^7.0.0:
-  version "7.0.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz"
-  integrity sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=
-  dependencies:
-    agent-base "^7.1.2"
-    debug "4"
-
-iconv-lite@0.6.3, iconv-lite@^0.6.3:
-  version "0.6.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz"
-  integrity sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3.0.0"
-
-ieee754@^1.1.13:
-  version "1.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ieee754/-/ieee754-1.2.1.tgz"
-  integrity sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=
-
-ignore@^5.2.0, ignore@^5.3.1:
-  version "5.3.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ignore/-/ignore-5.3.2.tgz"
-  integrity sha1-PNQOcp82Q/2HywTlC/DrcivFlvU=
-
-import-fresh@^3.2.1:
-  version "3.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/import-fresh/-/import-fresh-3.3.0.tgz"
-  integrity sha1-NxYsJfy566oublPVtNiM4X2eDCs=
-  dependencies:
-    parent-module "^1.0.0"
-    resolve-from "^4.0.0"
-
-imurmurhash@^0.1.4:
-  version "0.1.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz"
-  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
-
-inflight@^1.0.4:
-  version "1.0.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz"
-  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
-  dependencies:
-    once "^1.3.0"
-    wrappy "1"
-
-inherits@2, inherits@^2.0.3, inherits@^2.0.4:
-  version "2.0.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inherits/-/inherits-2.0.4.tgz"
-  integrity sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=
-
-ini@~1.3.0:
-  version "1.3.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ini/-/ini-1.3.8.tgz"
-  integrity sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw=
-
-internal-slot@^1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/internal-slot/-/internal-slot-1.1.0.tgz"
-  integrity sha1-HqyRdilH0vcFa8g42T4TsulgSWE=
-  dependencies:
-    es-errors "^1.3.0"
-    hasown "^2.0.2"
-    side-channel "^1.1.0"
-
-is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
-  version "3.0.5"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-array-buffer/-/is-array-buffer-3.0.5.tgz"
-  integrity sha1-ZXQuHmh70sxmYlMGj9hwf+TUQoA=
-  dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.3"
-    get-intrinsic "^1.2.6"
-
-is-async-function@^2.0.0:
-  version "2.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-async-function/-/is-async-function-2.1.1.tgz"
-  integrity sha1-PmkBjI4E5ztzh5PQIL/ohLn9NSM=
-  dependencies:
-    async-function "^1.0.0"
-    call-bound "^1.0.3"
-    get-proto "^1.0.1"
-    has-tostringtag "^1.0.2"
-    safe-regex-test "^1.1.0"
-
-is-bigint@^1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-bigint/-/is-bigint-1.1.0.tgz"
-  integrity sha1-3aejRF31ekJYPbQihoLrp8QXBnI=
-  dependencies:
-    has-bigints "^1.0.2"
-
-is-boolean-object@^1.2.1:
-  version "1.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-boolean-object/-/is-boolean-object-1.2.1.tgz"
-  integrity sha1-wg0MZUvgXaT7wjxWJjXAGek9r4k=
-  dependencies:
-    call-bound "^1.0.2"
-    has-tostringtag "^1.0.2"
-
-is-bun-module@^1.0.2:
-  version "1.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-bun-module/-/is-bun-module-1.3.0.tgz"
-  integrity sha1-6k0k/ev87MmOgby8tQaCf+4oh2A=
-  dependencies:
-    semver "^7.6.3"
-
-is-callable@^1.2.7:
-  version "1.2.7"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-callable/-/is-callable-1.2.7.tgz"
-  integrity sha1-O8KoXqdC2eNiBdys3XLKH9xRsFU=
-
-is-core-module@^2.13.0, is-core-module@^2.15.1, is-core-module@^2.16.0:
-  version "2.16.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-core-module/-/is-core-module-2.16.1.tgz"
-  integrity sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ=
-  dependencies:
-    hasown "^2.0.2"
-
-is-data-view@^1.0.1, is-data-view@^1.0.2:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-data-view/-/is-data-view-1.0.2.tgz"
-  integrity sha1-uuCkG5aImGwhiN2mZX5WuPnmO44=
-  dependencies:
-    call-bound "^1.0.2"
-    get-intrinsic "^1.2.6"
-    is-typed-array "^1.1.13"
-
-is-date-object@^1.0.5, is-date-object@^1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-date-object/-/is-date-object-1.1.0.tgz"
-  integrity sha1-rYVUGZb8eqiycpcB0ntzGfldgvc=
-  dependencies:
-    call-bound "^1.0.2"
-    has-tostringtag "^1.0.2"
-
-is-docker@^2.0.0, is-docker@^2.1.1:
-  version "2.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-2.2.1.tgz"
-  integrity sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=
-
-is-extglob@^2.1.1:
-  version "2.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz"
-  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
-
-is-finalizationregistry@^1.1.0:
-  version "1.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz"
-  integrity sha1-7v3NxslN3QZ02chYh7+T+USpfJA=
-  dependencies:
-    call-bound "^1.0.3"
-
-is-generator-function@^1.0.10:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-generator-function/-/is-generator-function-1.1.0.tgz"
-  integrity sha1-vz7tqTEgE5T1e126KAD5GiODCco=
-  dependencies:
-    call-bound "^1.0.3"
-    get-proto "^1.0.0"
-    has-tostringtag "^1.0.2"
-    safe-regex-test "^1.1.0"
-
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
-  version "4.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz"
-  integrity sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=
-  dependencies:
-    is-extglob "^2.1.1"
-
-is-map@^2.0.3:
-  version "2.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-map/-/is-map-2.0.3.tgz"
-  integrity sha1-7elrf+HicLPERl46RlZYdkkm1i4=
-
-is-number-object@^1.1.1:
-  version "1.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number-object/-/is-number-object-1.1.1.tgz"
-  integrity sha1-FEsh6VobwUggXcwoFKkTTsQbJUE=
-  dependencies:
-    call-bound "^1.0.3"
-    has-tostringtag "^1.0.2"
-
-is-number@^7.0.0:
-  version "7.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz"
-  integrity sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=
-
-is-path-inside@^3.0.3:
-  version "3.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-path-inside/-/is-path-inside-3.0.3.tgz"
-  integrity sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=
-
-is-regex@^1.2.1:
-  version "1.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-regex/-/is-regex-1.2.1.tgz"
-  integrity sha1-dtcKPtEO+b5I61d4h9dCBb8MrSI=
-  dependencies:
-    call-bound "^1.0.2"
-    gopd "^1.2.0"
-    has-tostringtag "^1.0.2"
-    hasown "^2.0.2"
-
-is-set@^2.0.3:
-  version "2.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-set/-/is-set-2.0.3.tgz"
-  integrity sha1-irIJ6kJGCBQTct7W4MsgDvHZ0B0=
-
-is-shared-array-buffer@^1.0.4:
-  version "1.0.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz"
-  integrity sha1-m2eES9m38ka6BwjDqT40Jpx3T28=
-  dependencies:
-    call-bound "^1.0.3"
-
-is-string@^1.0.7, is-string@^1.1.1:
-  version "1.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-string/-/is-string-1.1.1.tgz"
-  integrity sha1-kuo/PVxbbgOcqGd+WsjQfqdzy7k=
-  dependencies:
-    call-bound "^1.0.3"
-    has-tostringtag "^1.0.2"
-
-is-symbol@^1.0.4, is-symbol@^1.1.1:
-  version "1.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-symbol/-/is-symbol-1.1.1.tgz"
-  integrity sha1-9HdhJ59TLisFpwJKdQbbvtrNBjQ=
-  dependencies:
-    call-bound "^1.0.2"
-    has-symbols "^1.1.0"
-    safe-regex-test "^1.1.0"
-
-is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15:
-  version "1.1.15"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-typed-array/-/is-typed-array-1.1.15.tgz"
-  integrity sha1-S/tKRbYc7oOlpG+6d45OjVnAzgs=
-  dependencies:
-    which-typed-array "^1.1.16"
-
-is-weakmap@^2.0.2:
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-weakmap/-/is-weakmap-2.0.2.tgz"
-  integrity sha1-v3JhXWSd/l9pkHnFS4PkfRrhnP0=
-
-is-weakref@^1.0.2, is-weakref@^1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-weakref/-/is-weakref-1.1.0.tgz"
-  integrity sha1-R+NHKulaY/qc8lZgvPDBgcOXcO8=
-  dependencies:
-    call-bound "^1.0.2"
-
-is-weakset@^2.0.3:
-  version "2.0.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-weakset/-/is-weakset-2.0.4.tgz"
-  integrity sha1-yfXesLwZBsbW8QJ/KE3fRZJJ2so=
-  dependencies:
-    call-bound "^1.0.3"
-    get-intrinsic "^1.2.6"
-
-is-wsl@^2.2.0:
-  version "2.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz"
-  integrity sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=
-  dependencies:
-    is-docker "^2.0.0"
-
-isarray@^2.0.5:
-  version "2.0.5"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isarray/-/isarray-2.0.5.tgz"
-  integrity sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=
-
-isexe@^2.0.0:
-  version "2.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz"
-  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
-
-js-tokens@^4.0.0:
-  version "4.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz"
-  integrity sha1-GSA/tZmR35jjoocFDUZHzerzJJk=
-
-js-yaml@^3.13.1:
-  version "3.14.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz"
-  integrity sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz"
-  integrity sha1-wftl+PUBeQHN0slRhkuhhFihBgI=
-  dependencies:
-    argparse "^2.0.1"
-
-jsdoc-type-pratt-parser@~4.1.0:
-  version "4.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz"
-  integrity sha1-/2tKPzOcNKbBiMv1ChYIeFjSIRM=
-
-json-buffer@3.0.1:
-  version "3.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz"
-  integrity sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=
-
-json-schema-traverse@^0.4.1:
-  version "0.4.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
-  integrity sha1-afaofZUTq4u4/mO9sJecRI5oRmA=
-
-json-stable-stringify-without-jsonify@^1.0.1:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
-  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
-
-json5@^1.0.2:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json5/-/json5-1.0.2.tgz"
-  integrity sha1-Y9mNYPIbMTt3xNbaGL+mnYDh1ZM=
-  dependencies:
-    minimist "^1.2.0"
-
-jsonc-parser@^3.2.0:
-  version "3.3.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsonc-parser/-/jsonc-parser-3.3.1.tgz"
-  integrity sha1-8qUktPf9EePXkeVZl3rWC5i3mLQ=
-
-jsonwebtoken@^9.0.0:
-  version "9.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz"
-  integrity sha1-Zf+R9KvvF4RpfUCVK7GZjFBMqvM=
-  dependencies:
-    jws "^3.2.2"
-    lodash.includes "^4.3.0"
-    lodash.isboolean "^3.0.3"
-    lodash.isinteger "^4.0.4"
-    lodash.isnumber "^3.0.3"
-    lodash.isplainobject "^4.0.6"
-    lodash.isstring "^4.0.1"
-    lodash.once "^4.0.0"
-    ms "^2.1.1"
-    semver "^7.5.4"
-
-jwa@^1.4.1:
-  version "1.4.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jwa/-/jwa-1.4.1.tgz"
-  integrity sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=
-  dependencies:
-    buffer-equal-constant-time "1.0.1"
-    ecdsa-sig-formatter "1.0.11"
-    safe-buffer "^5.0.1"
-
-jwa@^2.0.0:
-  version "2.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jwa/-/jwa-2.0.0.tgz"
-  integrity sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=
-  dependencies:
-    buffer-equal-constant-time "1.0.1"
-    ecdsa-sig-formatter "1.0.11"
-    safe-buffer "^5.0.1"
-
-jws@^3.2.2:
-  version "3.2.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jws/-/jws-3.2.2.tgz"
-  integrity sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=
-  dependencies:
-    jwa "^1.4.1"
-    safe-buffer "^5.0.1"
-
-jws@^4.0.0:
-  version "4.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jws/-/jws-4.0.0.tgz"
-  integrity sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=
-  dependencies:
-    jwa "^2.0.0"
-    safe-buffer "^5.0.1"
-
-keytar@^7.7.0:
-  version "7.9.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keytar/-/keytar-7.9.0.tgz"
-  integrity sha1-TGIlcI9RtQy/d8Wq6BchlkwpGMs=
-  dependencies:
-    node-addon-api "^4.3.0"
-    prebuild-install "^7.0.1"
-
-keyv@^4.5.3:
-  version "4.5.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.5.4.tgz"
-  integrity sha1-qHmpnilFL5QkOfKkBeOvizHU3pM=
-  dependencies:
-    json-buffer "3.0.1"
-
-leven@^3.1.0:
-  version "3.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/leven/-/leven-3.1.0.tgz"
-  integrity sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=
-
-levn@^0.4.1:
-  version "0.4.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/levn/-/levn-0.4.1.tgz"
-  integrity sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=
-  dependencies:
-    prelude-ls "^1.2.1"
-    type-check "~0.4.0"
-
-linkify-it@^3.0.1:
-  version "3.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/linkify-it/-/linkify-it-3.0.3.tgz"
-  integrity sha1-qYuvRM5FpVDvtNScdp0HUkzC+i4=
-  dependencies:
-    uc.micro "^1.0.1"
-
-locate-path@^6.0.0:
-  version "6.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz"
-  integrity sha1-VTIeswn+u8WcSAHZMackUqaB0oY=
-  dependencies:
-    p-locate "^5.0.0"
-
-lodash.includes@^4.3.0:
-  version "4.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz"
-  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
-
-lodash.isboolean@^3.0.3:
-  version "3.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz"
-  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
-
-lodash.isinteger@^4.0.4:
-  version "4.0.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz"
-  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
-
-lodash.isnumber@^3.0.3:
-  version "3.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz"
-  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
-
-lodash.isplainobject@^4.0.6:
-  version "4.0.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz"
-  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
-
-lodash.isstring@^4.0.1:
-  version "4.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz"
-  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
-
-lodash.merge@^4.6.2:
-  version "4.6.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.merge/-/lodash.merge-4.6.2.tgz"
-  integrity sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=
-
-lodash.once@^4.0.0:
-  version "4.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz"
-  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz"
-  integrity sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=
-  dependencies:
-    yallist "^4.0.0"
-
-markdown-it@^12.3.2:
-  version "12.3.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/markdown-it/-/markdown-it-12.3.2.tgz"
-  integrity sha1-v5Kskig/6YP+Tej/ir+1rXLNDJA=
-  dependencies:
-    argparse "^2.0.1"
-    entities "~2.1.0"
-    linkify-it "^3.0.1"
-    mdurl "^1.0.1"
-    uc.micro "^1.0.5"
-
-math-intrinsics@^1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz"
-  integrity sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=
-
-mdurl@^1.0.1:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mdurl/-/mdurl-1.0.1.tgz"
-  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
-
-merge2@^1.3.0, merge2@^1.4.1:
-  version "1.4.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/merge2/-/merge2-1.4.1.tgz"
-  integrity sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=
-
-micromatch@^4.0.8:
-  version "4.0.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/micromatch/-/micromatch-4.0.8.tgz"
-  integrity sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=
-  dependencies:
-    braces "^3.0.3"
-    picomatch "^2.3.1"
-
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-db/-/mime-db-1.52.0.tgz"
-  integrity sha1-u6vNwChZ9JhzAchW4zh85exDv3A=
-
-mime-types@^2.1.12:
-  version "2.1.35"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-types/-/mime-types-2.1.35.tgz"
-  integrity sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=
-  dependencies:
-    mime-db "1.52.0"
-
-mime@^1.3.4:
-  version "1.6.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime/-/mime-1.6.0.tgz"
-  integrity sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=
-
-mimic-response@^3.1.0:
-  version "3.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz"
-  integrity sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k=
-
-minimatch@9.0.3:
-  version "9.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-9.0.3.tgz"
-  integrity sha1-puAMPeRMOlQr+q5wq/wiQgptqCU=
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz"
-  integrity sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^9.0.4:
-  version "9.0.5"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-9.0.5.tgz"
-  integrity sha1-10+d1rV9g9jpjPuCEzsDl4vJKeU=
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6:
-  version "1.2.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.8.tgz"
-  integrity sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=
-
-mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
-  version "0.5.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz"
-  integrity sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM=
-
-mkdirp@^0.5.3:
-  version "0.5.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz"
-  integrity sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=
-  dependencies:
-    minimist "^1.2.6"
-
-ms@^2.1.1, ms@^2.1.3:
-  version "2.1.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz"
-  integrity sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=
-
-mute-stream@~0.0.4:
-  version "0.0.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mute-stream/-/mute-stream-0.0.8.tgz"
-  integrity sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=
-
-napi-build-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/napi-build-utils/-/napi-build-utils-2.0.0.tgz"
-  integrity sha1-E8IsAYf8/MzhRhhEE2NypH3cAn4=
-
-natural-compare@^1.4.0:
-  version "1.4.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz"
-  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-
-node-abi@^3.3.0:
-  version "3.73.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.73.0.tgz"
-  integrity sha1-RFnqd+cZae26hYg4fuywXiws/zs=
-  dependencies:
-    semver "^7.3.5"
-
-node-addon-api@^4.3.0:
-  version "4.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-addon-api/-/node-addon-api-4.3.0.tgz"
-  integrity sha1-UqGgtHUZPgko6Y4EJqDRJUeCt38=
-
-nth-check@^2.0.1:
-  version "2.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nth-check/-/nth-check-2.1.1.tgz"
-  integrity sha1-yeq0KO/842zWuSySS9sADvHx7R0=
-  dependencies:
-    boolbase "^1.0.0"
-
-object-inspect@^1.13.3:
-  version "1.13.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-inspect/-/object-inspect-1.13.3.tgz"
-  integrity sha1-8UwYPeURMCQ9bRiuFJN1/1DqSIo=
-
-object-keys@^1.1.1:
-  version "1.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-keys/-/object-keys-1.1.1.tgz"
-  integrity sha1-HEfyct8nfzsdrwYWd9nILiMixg4=
-
-object.assign@^4.1.7:
-  version "4.1.7"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object.assign/-/object.assign-4.1.7.tgz"
-  integrity sha1-jBTKGkJMalYbC7KiL2b1BJqUXT0=
-  dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.3"
-    define-properties "^1.2.1"
-    es-object-atoms "^1.0.0"
-    has-symbols "^1.1.0"
-    object-keys "^1.1.1"
-
-object.fromentries@^2.0.8:
-  version "2.0.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object.fromentries/-/object.fromentries-2.0.8.tgz"
-  integrity sha1-9xldipuXvZXLwZmeqTns0aKwDGU=
-  dependencies:
-    call-bind "^1.0.7"
-    define-properties "^1.2.1"
-    es-abstract "^1.23.2"
-    es-object-atoms "^1.0.0"
-
-object.groupby@^1.0.3:
-  version "1.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object.groupby/-/object.groupby-1.0.3.tgz"
-  integrity sha1-mxJcNiOBKfb3thlUoecXYUjVAC4=
-  dependencies:
-    call-bind "^1.0.7"
-    define-properties "^1.2.1"
-    es-abstract "^1.23.2"
-
-object.values@^1.2.0:
-  version "1.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object.values/-/object.values-1.2.1.tgz"
-  integrity sha1-3u1SClCAn/f3Wnz9S8ZMegOMYhY=
-  dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.3"
-    define-properties "^1.2.1"
-    es-object-atoms "^1.0.0"
-
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
-  version "1.4.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/once/-/once-1.4.0.tgz"
-  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
-  dependencies:
-    wrappy "1"
-
-open@^8.0.0:
-  version "8.4.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-8.4.2.tgz"
-  integrity sha1-W1/+Ko95Pc0qrXPlUMuHtZywhPk=
-  dependencies:
-    define-lazy-prop "^2.0.0"
-    is-docker "^2.1.1"
-    is-wsl "^2.2.0"
-
-optionator@^0.9.3:
-  version "0.9.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/optionator/-/optionator-0.9.4.tgz"
-  integrity sha1-fqHBpdkddk+yghOciP4R4YKjpzQ=
-  dependencies:
-    deep-is "^0.1.3"
-    fast-levenshtein "^2.0.6"
-    levn "^0.4.1"
-    prelude-ls "^1.2.1"
-    type-check "^0.4.0"
-    word-wrap "^1.2.5"
-
-own-keys@^1.0.1:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/own-keys/-/own-keys-1.0.1.tgz"
-  integrity sha1-5ABpEKK/kTWFKJZ27r1vOQz1E1g=
-  dependencies:
-    get-intrinsic "^1.2.6"
-    object-keys "^1.1.1"
-    safe-push-apply "^1.0.0"
-
-p-limit@^3.0.2:
-  version "3.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz"
-  integrity sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=
-  dependencies:
-    yocto-queue "^0.1.0"
-
-p-locate@^5.0.0:
-  version "5.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz"
-  integrity sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=
-  dependencies:
-    p-limit "^3.0.2"
-
-parent-module@^1.0.0:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parent-module/-/parent-module-1.0.1.tgz"
-  integrity sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=
-  dependencies:
-    callsites "^3.0.0"
-
-parse-imports@^2.1.1:
-  version "2.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse-imports/-/parse-imports-2.2.1.tgz"
-  integrity sha1-Cm6LUxa+tcmQX1DrK7uMZKSAVkI=
-  dependencies:
-    es-module-lexer "^1.5.3"
-    slashes "^3.0.12"
-
-parse-semver@^1.1.1:
-  version "1.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse-semver/-/parse-semver-1.1.1.tgz"
-  integrity sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=
-  dependencies:
-    semver "^5.1.0"
-
-parse5-htmlparser2-tree-adapter@^7.0.0:
-  version "7.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz"
-  integrity sha1-tagGVI7Yk6Q+JMy0L7t4BpMR6Bs=
-  dependencies:
-    domhandler "^5.0.3"
-    parse5 "^7.0.0"
-
-parse5-parser-stream@^7.1.2:
-  version "7.1.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz"
-  integrity sha1-18IOrcN5aNJy4sAmYP/5LdJ+YOE=
-  dependencies:
-    parse5 "^7.0.0"
-
-parse5@^7.0.0, parse5@^7.1.2:
-  version "7.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse5/-/parse5-7.2.1.tgz"
-  integrity sha1-iSj1WRXmEl9DDMRDCXZb8XVWozo=
-  dependencies:
-    entities "^4.5.0"
-
-path-exists@^4.0.0:
-  version "4.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz"
-  integrity sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=
-
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
-
-path-key@^3.1.0:
-  version "3.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz"
-  integrity sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=
-
-path-parse@^1.0.7:
-  version "1.0.7"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz"
-  integrity sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=
-
-path-type@^4.0.0:
-  version "4.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-type/-/path-type-4.0.0.tgz"
-  integrity sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=
-
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pend/-/pend-1.2.0.tgz"
-  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
-
-picocolors@^1.0.0:
-  version "1.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picocolors/-/picocolors-1.1.1.tgz"
-  integrity sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=
-
-picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=
-
-possible-typed-array-names@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz"
-  integrity sha1-ibtjxvraLD6QrcSmR77us5zHv48=
-
-prebuild-install@^7.0.1:
-  version "7.1.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prebuild-install/-/prebuild-install-7.1.3.tgz"
-  integrity sha1-1jCrrSsUdEPyCiEpF76uaLgJLuw=
-  dependencies:
-    detect-libc "^2.0.0"
-    expand-template "^2.0.3"
-    github-from-package "0.0.0"
-    minimist "^1.2.3"
-    mkdirp-classic "^0.5.3"
-    napi-build-utils "^2.0.0"
-    node-abi "^3.3.0"
-    pump "^3.0.0"
-    rc "^1.2.7"
-    simple-get "^4.0.0"
-    tar-fs "^2.0.0"
-    tunnel-agent "^0.6.0"
-
-prelude-ls@^1.2.1:
-  version "1.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz"
-  integrity sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz"
-  integrity sha1-0j1B/hN1ZG3i0BBNNFSjAIgCz3s=
-  dependencies:
-    fast-diff "^1.1.2"
-
-pump@^3.0.0:
-  version "3.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pump/-/pump-3.0.2.tgz"
-  integrity sha1-g28+3WvC7lmSVskk/+DYhXPdy/g=
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
-
-punycode@^2.1.0:
-  version "2.3.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/punycode/-/punycode-2.3.1.tgz"
-  integrity sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=
-
-qs@^6.9.1:
-  version "6.14.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/qs/-/qs-6.14.0.tgz"
-  integrity sha1-xj+kBoDSxclBQSoOiZyJr2DAqTA=
-  dependencies:
-    side-channel "^1.1.0"
-
-queue-microtask@^1.2.2:
-  version "1.2.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz"
-  integrity sha1-SSkii7xyTfrEPg77BYyve2z7YkM=
-
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rc/-/rc-1.2.8.tgz"
-  integrity sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
-read@^1.0.7:
-  version "1.0.7"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/read/-/read-1.0.7.tgz"
-  integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
-  dependencies:
-    mute-stream "~0.0.4"
-
-readable-stream@^3.1.1, readable-stream@^3.4.0:
-  version "3.6.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz"
-  integrity sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
-reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
-  version "1.0.10"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz"
-  integrity sha1-xikhnnijMW2LYEx2XvaJlpZOe/k=
-  dependencies:
-    call-bind "^1.0.8"
-    define-properties "^1.2.1"
-    es-abstract "^1.23.9"
-    es-errors "^1.3.0"
-    es-object-atoms "^1.0.0"
-    get-intrinsic "^1.2.7"
-    get-proto "^1.0.1"
-    which-builtin-type "^1.2.1"
-
-regexp.prototype.flags@^1.5.3:
-  version "1.5.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz"
-  integrity sha1-GtbGLUSiWQB+VbOXDgD3Ru+8qhk=
-  dependencies:
-    call-bind "^1.0.8"
-    define-properties "^1.2.1"
-    es-errors "^1.3.0"
-    get-proto "^1.0.1"
-    gopd "^1.2.0"
-    set-function-name "^2.0.2"
-
-resolve-from@^4.0.0:
-  version "4.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-from/-/resolve-from-4.0.0.tgz"
-  integrity sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=
-
-resolve-pkg-maps@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz"
-  integrity sha1-YWs9wsVwVrVYjDHN9LPWTbEzcg8=
-
-resolve@^1.22.4, resolve@^1.3.2:
-  version "1.22.10"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve/-/resolve-1.22.10.tgz"
-  integrity sha1-tmPoP/sJu/I4aURza6roAwKbizk=
-  dependencies:
-    is-core-module "^2.16.0"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
-
-reusify@^1.0.4:
-  version "1.0.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/reusify/-/reusify-1.0.4.tgz"
-  integrity sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=
-
-rimraf@3.0.2, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz"
-  integrity sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=
-  dependencies:
-    glob "^7.1.3"
-
-run-parallel@^1.1.9:
-  version "1.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz"
-  integrity sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=
-  dependencies:
-    queue-microtask "^1.2.2"
-
-safe-array-concat@^1.1.3:
-  version "1.1.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-array-concat/-/safe-array-concat-1.1.3.tgz"
-  integrity sha1-yeVOxPYDsLu45+UAel7nrs0VOMM=
-  dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.2"
-    get-intrinsic "^1.2.6"
-    has-symbols "^1.1.0"
-    isarray "^2.0.5"
-
-safe-buffer@^5.0.1, safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz"
-  integrity sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=
-
-safe-push-apply@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-push-apply/-/safe-push-apply-1.0.0.tgz"
-  integrity sha1-AYUOmBwWAtOYyFCB82Dk5tA9J/U=
-  dependencies:
-    es-errors "^1.3.0"
-    isarray "^2.0.5"
-
-safe-regex-test@^1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-regex-test/-/safe-regex-test-1.1.0.tgz"
-  integrity sha1-f4fftnoxUHguqvGFg/9dFxGsEME=
-  dependencies:
-    call-bound "^1.0.2"
-    es-errors "^1.3.0"
-    is-regex "^1.2.1"
+    "glob-parent" "^5.1.2"
+    "merge2" "^1.3.0"
+    "micromatch" "^4.0.8"
+
+"fast-json-stable-stringify@^2.0.0":
+  "integrity" "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
+  "version" "2.1.0"
+
+"fast-levenshtein@^2.0.6":
+  "integrity" "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
+  "version" "2.0.6"
+
+"fastq@^1.6.0":
+  "integrity" "sha1-1Q6rqAPIhGqIPBZJKCHrzSzaVfU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fastq/-/fastq-1.19.1.tgz"
+  "version" "1.19.1"
+  dependencies:
+    "reusify" "^1.0.4"
+
+"fd-slicer@~1.1.0":
+  "integrity" "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fd-slicer/-/fd-slicer-1.1.0.tgz"
+  "version" "1.1.0"
+  dependencies:
+    "pend" "~1.2.0"
+
+"fdir@^6.4.3":
+  "integrity" "sha1-ARzaz4N+ypuBHInbuQLfcUJz23I="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fdir/-/fdir-6.4.3.tgz"
+  "version" "6.4.3"
+
+"file-entry-cache@^6.0.1":
+  "integrity" "sha1-IRst2WWcsDlLBz5zI6w8kz1SICc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
+  "version" "6.0.1"
+  dependencies:
+    "flat-cache" "^3.0.4"
+
+"fill-range@^7.1.1":
+  "integrity" "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fill-range/-/fill-range-7.1.1.tgz"
+  "version" "7.1.1"
+  dependencies:
+    "to-regex-range" "^5.0.1"
+
+"find-up@^5.0.0":
+  "integrity" "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz"
+  "version" "5.0.0"
+  dependencies:
+    "locate-path" "^6.0.0"
+    "path-exists" "^4.0.0"
+
+"flat-cache@^3.0.4":
+  "integrity" "sha1-LAwtUEDJmxYydxqdEFclwBFTY+4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat-cache/-/flat-cache-3.2.0.tgz"
+  "version" "3.2.0"
+  dependencies:
+    "flatted" "^3.2.9"
+    "keyv" "^4.5.3"
+    "rimraf" "^3.0.2"
+
+"flatted@^3.2.9":
+  "integrity" "sha1-Z8j62VRUp8er6/dLt47nSkQCM1g="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flatted/-/flatted-3.3.3.tgz"
+  "version" "3.3.3"
+
+"for-each@^0.3.3", "for-each@^0.3.5":
+  "integrity" "sha1-1lBogCeCaSD+6wr3R+57lCGkHUc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/for-each/-/for-each-0.3.5.tgz"
+  "version" "0.3.5"
+  dependencies:
+    "is-callable" "^1.2.7"
+
+"form-data@^4.0.0":
+  "integrity" "sha1-Ncq73TDDznPessQtPI0+2cpReUw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/form-data/-/form-data-4.0.2.tgz"
+  "version" "4.0.2"
+  dependencies:
+    "asynckit" "^0.4.0"
+    "combined-stream" "^1.0.8"
+    "es-set-tostringtag" "^2.1.0"
+    "mime-types" "^2.1.12"
+
+"fs-constants@^1.0.0":
+  "integrity" "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz"
+  "version" "1.0.0"
+
+"fs.realpath@^1.0.0":
+  "integrity" "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz"
+  "version" "1.0.0"
+
+"function-bind@^1.1.2":
+  "integrity" "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.2.tgz"
+  "version" "1.1.2"
+
+"function.prototype.name@^1.1.6", "function.prototype.name@^1.1.8":
+  "integrity" "sha1-5o4d97JZpclJ7u+Vzb3lPt/6u3g="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function.prototype.name/-/function.prototype.name-1.1.8.tgz"
+  "version" "1.1.8"
+  dependencies:
+    "call-bind" "^1.0.8"
+    "call-bound" "^1.0.3"
+    "define-properties" "^1.2.1"
+    "functions-have-names" "^1.2.3"
+    "hasown" "^2.0.2"
+    "is-callable" "^1.2.7"
+
+"functions-have-names@^1.2.3":
+  "integrity" "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/functions-have-names/-/functions-have-names-1.2.3.tgz"
+  "version" "1.2.3"
+
+"get-intrinsic@^1.2.4", "get-intrinsic@^1.2.5", "get-intrinsic@^1.2.6", "get-intrinsic@^1.2.7", "get-intrinsic@^1.3.0":
+  "integrity" "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz"
+  "version" "1.3.0"
+  dependencies:
+    "call-bind-apply-helpers" "^1.0.2"
+    "es-define-property" "^1.0.1"
+    "es-errors" "^1.3.0"
+    "es-object-atoms" "^1.1.1"
+    "function-bind" "^1.1.2"
+    "get-proto" "^1.0.1"
+    "gopd" "^1.2.0"
+    "has-symbols" "^1.1.0"
+    "hasown" "^2.0.2"
+    "math-intrinsics" "^1.1.0"
+
+"get-proto@^1.0.0", "get-proto@^1.0.1":
+  "integrity" "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-proto/-/get-proto-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "dunder-proto" "^1.0.1"
+    "es-object-atoms" "^1.0.0"
+
+"get-symbol-description@^1.1.0":
+  "integrity" "sha1-e91U4L7+j/yfO04gMiDZ8eiBtu4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-symbol-description/-/get-symbol-description-1.1.0.tgz"
+  "version" "1.1.0"
+  dependencies:
+    "call-bound" "^1.0.3"
+    "es-errors" "^1.3.0"
+    "get-intrinsic" "^1.2.6"
+
+"get-tsconfig@^4.10.0":
+  "integrity" "sha1-QDpoKzc6gjYSR1pMKSjHMm/A9rs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/get-tsconfig/-/get-tsconfig-4.10.0.tgz"
+  "version" "4.10.0"
+  dependencies:
+    "resolve-pkg-maps" "^1.0.0"
+
+"github-from-package@0.0.0":
+  "integrity" "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/github-from-package/-/github-from-package-0.0.0.tgz"
+  "version" "0.0.0"
+
+"glob-parent@^5.1.2":
+  "integrity" "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz"
+  "version" "5.1.2"
+  dependencies:
+    "is-glob" "^4.0.1"
+
+"glob-parent@^6.0.2":
+  "integrity" "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz"
+  "version" "6.0.2"
+  dependencies:
+    "is-glob" "^4.0.3"
+
+"glob@^7.0.6", "glob@^7.1.1", "glob@^7.1.3":
+  "integrity" "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-7.2.3.tgz"
+  "version" "7.2.3"
+  dependencies:
+    "fs.realpath" "^1.0.0"
+    "inflight" "^1.0.4"
+    "inherits" "2"
+    "minimatch" "^3.1.1"
+    "once" "^1.3.0"
+    "path-is-absolute" "^1.0.0"
+
+"globals@^13.19.0":
+  "integrity" "sha1-hDKhnXjODB6DOUnDats0VAC7EXE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globals/-/globals-13.24.0.tgz"
+  "version" "13.24.0"
+  dependencies:
+    "type-fest" "^0.20.2"
+
+"globalthis@^1.0.4":
+  "integrity" "sha1-dDDtOpddl7+1m8zkH1yruvplEjY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globalthis/-/globalthis-1.0.4.tgz"
+  "version" "1.0.4"
+  dependencies:
+    "define-properties" "^1.2.1"
+    "gopd" "^1.0.1"
+
+"globby@^11.1.0":
+  "integrity" "sha1-vUvpi7BC+D15b344EZkfvoKg00s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globby/-/globby-11.1.0.tgz"
+  "version" "11.1.0"
+  dependencies:
+    "array-union" "^2.1.0"
+    "dir-glob" "^3.0.1"
+    "fast-glob" "^3.2.9"
+    "ignore" "^5.2.0"
+    "merge2" "^1.4.1"
+    "slash" "^3.0.0"
+
+"gopd@^1.0.1", "gopd@^1.2.0":
+  "integrity" "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/gopd/-/gopd-1.2.0.tgz"
+  "version" "1.2.0"
+
+"graphemer@^1.4.0":
+  "integrity" "sha1-+y8dVeDjoYSa7/yQxPoN1ToOZsY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/graphemer/-/graphemer-1.4.0.tgz"
+  "version" "1.4.0"
+
+"has-bigints@^1.0.2":
+  "integrity" "sha1-KGB+llrJZ+A80qLHCiY2oe2tSf4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-bigints/-/has-bigints-1.1.0.tgz"
+  "version" "1.1.0"
+
+"has-flag@^3.0.0":
+  "integrity" "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz"
+  "version" "3.0.0"
+
+"has-flag@^4.0.0":
+  "integrity" "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz"
+  "version" "4.0.0"
+
+"has-property-descriptors@^1.0.0", "has-property-descriptors@^1.0.2":
+  "integrity" "sha1-lj7X0HHce/XwhMW/vg0bYiJYaFQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz"
+  "version" "1.0.2"
+  dependencies:
+    "es-define-property" "^1.0.0"
+
+"has-proto@^1.2.0":
+  "integrity" "sha1-XeWm6r2V/f/ZgYtDBV6AZeOf6dU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-proto/-/has-proto-1.2.0.tgz"
+  "version" "1.2.0"
+  dependencies:
+    "dunder-proto" "^1.0.0"
+
+"has-symbols@^1.0.3", "has-symbols@^1.1.0":
+  "integrity" "sha1-/JxqeDoISVHQuXH+EBjegTcHozg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz"
+  "version" "1.1.0"
+
+"has-tostringtag@^1.0.2":
+  "integrity" "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz"
+  "version" "1.0.2"
+  dependencies:
+    "has-symbols" "^1.0.3"
+
+"hasown@^2.0.2":
+  "integrity" "sha1-AD6vkb563DcuhOxZ3DclLO24AAM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hasown/-/hasown-2.0.2.tgz"
+  "version" "2.0.2"
+  dependencies:
+    "function-bind" "^1.1.2"
+
+"hosted-git-info@^4.0.2":
+  "integrity" "sha1-gnuChn6f8cjQxNnVOIA5fSyG0iQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hosted-git-info/-/hosted-git-info-4.1.0.tgz"
+  "version" "4.1.0"
+  dependencies:
+    "lru-cache" "^6.0.0"
+
+"htmlparser2@^9.1.0":
+  "integrity" "sha1-zbSY2KdaUfc5th0/cYE2w2m8jCM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/htmlparser2/-/htmlparser2-9.1.0.tgz"
+  "version" "9.1.0"
+  dependencies:
+    "domelementtype" "^2.3.0"
+    "domhandler" "^5.0.3"
+    "domutils" "^3.1.0"
+    "entities" "^4.5.0"
+
+"http-proxy-agent@^7.0.0":
+  "integrity" "sha1-mosfJGhmwChQlIZYX2K48sGMJw4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz"
+  "version" "7.0.2"
+  dependencies:
+    "agent-base" "^7.1.0"
+    "debug" "^4.3.4"
+
+"https-proxy-agent@^7.0.0":
+  "integrity" "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz"
+  "version" "7.0.6"
+  dependencies:
+    "agent-base" "^7.1.2"
+    "debug" "4"
+
+"iconv-lite@^0.6.3", "iconv-lite@0.6.3":
+  "integrity" "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz"
+  "version" "0.6.3"
+  dependencies:
+    "safer-buffer" ">= 2.1.2 < 3.0.0"
+
+"ieee754@^1.1.13":
+  "integrity" "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ieee754/-/ieee754-1.2.1.tgz"
+  "version" "1.2.1"
+
+"ignore@^5.2.0", "ignore@^5.3.1":
+  "integrity" "sha1-PNQOcp82Q/2HywTlC/DrcivFlvU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ignore/-/ignore-5.3.2.tgz"
+  "version" "5.3.2"
+
+"import-fresh@^3.2.1":
+  "integrity" "sha1-nOy1ZQPAraHydB271lRuSxO1fM8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/import-fresh/-/import-fresh-3.3.1.tgz"
+  "version" "3.3.1"
+  dependencies:
+    "parent-module" "^1.0.0"
+    "resolve-from" "^4.0.0"
+
+"imurmurhash@^0.1.4":
+  "integrity" "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz"
+  "version" "0.1.4"
+
+"inflight@^1.0.4":
+  "integrity" "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inflight/-/inflight-1.0.6.tgz"
+  "version" "1.0.6"
+  dependencies:
+    "once" "^1.3.0"
+    "wrappy" "1"
+
+"inherits@^2.0.3", "inherits@^2.0.4", "inherits@2":
+  "integrity" "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/inherits/-/inherits-2.0.4.tgz"
+  "version" "2.0.4"
+
+"ini@~1.3.0":
+  "integrity" "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ini/-/ini-1.3.8.tgz"
+  "version" "1.3.8"
+
+"internal-slot@^1.1.0":
+  "integrity" "sha1-HqyRdilH0vcFa8g42T4TsulgSWE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/internal-slot/-/internal-slot-1.1.0.tgz"
+  "version" "1.1.0"
+  dependencies:
+    "es-errors" "^1.3.0"
+    "hasown" "^2.0.2"
+    "side-channel" "^1.1.0"
+
+"is-array-buffer@^3.0.4", "is-array-buffer@^3.0.5":
+  "integrity" "sha1-ZXQuHmh70sxmYlMGj9hwf+TUQoA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-array-buffer/-/is-array-buffer-3.0.5.tgz"
+  "version" "3.0.5"
+  dependencies:
+    "call-bind" "^1.0.8"
+    "call-bound" "^1.0.3"
+    "get-intrinsic" "^1.2.6"
+
+"is-async-function@^2.0.0":
+  "integrity" "sha1-PmkBjI4E5ztzh5PQIL/ohLn9NSM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-async-function/-/is-async-function-2.1.1.tgz"
+  "version" "2.1.1"
+  dependencies:
+    "async-function" "^1.0.0"
+    "call-bound" "^1.0.3"
+    "get-proto" "^1.0.1"
+    "has-tostringtag" "^1.0.2"
+    "safe-regex-test" "^1.1.0"
+
+"is-bigint@^1.1.0":
+  "integrity" "sha1-3aejRF31ekJYPbQihoLrp8QXBnI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-bigint/-/is-bigint-1.1.0.tgz"
+  "version" "1.1.0"
+  dependencies:
+    "has-bigints" "^1.0.2"
+
+"is-boolean-object@^1.2.1":
+  "integrity" "sha1-cGf0dwmAmjk8cf9bs+E12KkhXZ4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-boolean-object/-/is-boolean-object-1.2.2.tgz"
+  "version" "1.2.2"
+  dependencies:
+    "call-bound" "^1.0.3"
+    "has-tostringtag" "^1.0.2"
+
+"is-bun-module@^2.0.0":
+  "integrity" "sha1-TXhZqHwPyslQyV5mZzDnRerovd0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-bun-module/-/is-bun-module-2.0.0.tgz"
+  "version" "2.0.0"
+  dependencies:
+    "semver" "^7.7.1"
+
+"is-callable@^1.2.7":
+  "integrity" "sha1-O8KoXqdC2eNiBdys3XLKH9xRsFU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-callable/-/is-callable-1.2.7.tgz"
+  "version" "1.2.7"
+
+"is-core-module@^2.13.0", "is-core-module@^2.15.1", "is-core-module@^2.16.0":
+  "integrity" "sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-core-module/-/is-core-module-2.16.1.tgz"
+  "version" "2.16.1"
+  dependencies:
+    "hasown" "^2.0.2"
+
+"is-data-view@^1.0.1", "is-data-view@^1.0.2":
+  "integrity" "sha1-uuCkG5aImGwhiN2mZX5WuPnmO44="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-data-view/-/is-data-view-1.0.2.tgz"
+  "version" "1.0.2"
+  dependencies:
+    "call-bound" "^1.0.2"
+    "get-intrinsic" "^1.2.6"
+    "is-typed-array" "^1.1.13"
+
+"is-date-object@^1.0.5", "is-date-object@^1.1.0":
+  "integrity" "sha1-rYVUGZb8eqiycpcB0ntzGfldgvc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-date-object/-/is-date-object-1.1.0.tgz"
+  "version" "1.1.0"
+  dependencies:
+    "call-bound" "^1.0.2"
+    "has-tostringtag" "^1.0.2"
+
+"is-docker@^3.0.0":
+  "integrity" "sha1-kAk6oxBid9inelkQ265xdH4VogA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-3.0.0.tgz"
+  "version" "3.0.0"
+
+"is-extglob@^2.1.1":
+  "integrity" "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz"
+  "version" "2.1.1"
+
+"is-finalizationregistry@^1.1.0":
+  "integrity" "sha1-7v3NxslN3QZ02chYh7+T+USpfJA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz"
+  "version" "1.1.1"
+  dependencies:
+    "call-bound" "^1.0.3"
+
+"is-generator-function@^1.0.10":
+  "integrity" "sha1-vz7tqTEgE5T1e126KAD5GiODCco="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-generator-function/-/is-generator-function-1.1.0.tgz"
+  "version" "1.1.0"
+  dependencies:
+    "call-bound" "^1.0.3"
+    "get-proto" "^1.0.0"
+    "has-tostringtag" "^1.0.2"
+    "safe-regex-test" "^1.1.0"
+
+"is-glob@^4.0.0", "is-glob@^4.0.1", "is-glob@^4.0.3":
+  "integrity" "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz"
+  "version" "4.0.3"
+  dependencies:
+    "is-extglob" "^2.1.1"
+
+"is-inside-container@^1.0.0":
+  "integrity" "sha1-6B+6aZZi6zHb2vJnZqYdSBRxfqQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-inside-container/-/is-inside-container-1.0.0.tgz"
+  "version" "1.0.0"
+  dependencies:
+    "is-docker" "^3.0.0"
+
+"is-map@^2.0.3":
+  "integrity" "sha1-7elrf+HicLPERl46RlZYdkkm1i4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-map/-/is-map-2.0.3.tgz"
+  "version" "2.0.3"
+
+"is-number-object@^1.1.1":
+  "integrity" "sha1-FEsh6VobwUggXcwoFKkTTsQbJUE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number-object/-/is-number-object-1.1.1.tgz"
+  "version" "1.1.1"
+  dependencies:
+    "call-bound" "^1.0.3"
+    "has-tostringtag" "^1.0.2"
+
+"is-number@^7.0.0":
+  "integrity" "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz"
+  "version" "7.0.0"
+
+"is-path-inside@^3.0.3":
+  "integrity" "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-path-inside/-/is-path-inside-3.0.3.tgz"
+  "version" "3.0.3"
+
+"is-regex@^1.2.1":
+  "integrity" "sha1-dtcKPtEO+b5I61d4h9dCBb8MrSI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-regex/-/is-regex-1.2.1.tgz"
+  "version" "1.2.1"
+  dependencies:
+    "call-bound" "^1.0.2"
+    "gopd" "^1.2.0"
+    "has-tostringtag" "^1.0.2"
+    "hasown" "^2.0.2"
+
+"is-set@^2.0.3":
+  "integrity" "sha1-irIJ6kJGCBQTct7W4MsgDvHZ0B0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-set/-/is-set-2.0.3.tgz"
+  "version" "2.0.3"
+
+"is-shared-array-buffer@^1.0.4":
+  "integrity" "sha1-m2eES9m38ka6BwjDqT40Jpx3T28="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz"
+  "version" "1.0.4"
+  dependencies:
+    "call-bound" "^1.0.3"
+
+"is-string@^1.0.7", "is-string@^1.1.1":
+  "integrity" "sha1-kuo/PVxbbgOcqGd+WsjQfqdzy7k="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-string/-/is-string-1.1.1.tgz"
+  "version" "1.1.1"
+  dependencies:
+    "call-bound" "^1.0.3"
+    "has-tostringtag" "^1.0.2"
+
+"is-symbol@^1.0.4", "is-symbol@^1.1.1":
+  "integrity" "sha1-9HdhJ59TLisFpwJKdQbbvtrNBjQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-symbol/-/is-symbol-1.1.1.tgz"
+  "version" "1.1.1"
+  dependencies:
+    "call-bound" "^1.0.2"
+    "has-symbols" "^1.1.0"
+    "safe-regex-test" "^1.1.0"
+
+"is-typed-array@^1.1.13", "is-typed-array@^1.1.14", "is-typed-array@^1.1.15":
+  "integrity" "sha1-S/tKRbYc7oOlpG+6d45OjVnAzgs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-typed-array/-/is-typed-array-1.1.15.tgz"
+  "version" "1.1.15"
+  dependencies:
+    "which-typed-array" "^1.1.16"
+
+"is-weakmap@^2.0.2":
+  "integrity" "sha1-v3JhXWSd/l9pkHnFS4PkfRrhnP0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-weakmap/-/is-weakmap-2.0.2.tgz"
+  "version" "2.0.2"
+
+"is-weakref@^1.0.2", "is-weakref@^1.1.0":
+  "integrity" "sha1-7qQwGCvo1kF0vZa/+8RvIb8/kpM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-weakref/-/is-weakref-1.1.1.tgz"
+  "version" "1.1.1"
+  dependencies:
+    "call-bound" "^1.0.3"
+
+"is-weakset@^2.0.3":
+  "integrity" "sha1-yfXesLwZBsbW8QJ/KE3fRZJJ2so="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-weakset/-/is-weakset-2.0.4.tgz"
+  "version" "2.0.4"
+  dependencies:
+    "call-bound" "^1.0.3"
+    "get-intrinsic" "^1.2.6"
+
+"is-wsl@^3.1.0":
+  "integrity" "sha1-4cZX45wQCQr8vt7GFyD2uSTDy9I="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-3.1.0.tgz"
+  "version" "3.1.0"
+  dependencies:
+    "is-inside-container" "^1.0.0"
+
+"isarray@^2.0.5":
+  "integrity" "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isarray/-/isarray-2.0.5.tgz"
+  "version" "2.0.5"
+
+"isexe@^2.0.0":
+  "integrity" "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz"
+  "version" "2.0.0"
+
+"js-tokens@^4.0.0":
+  "integrity" "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz"
+  "version" "4.0.0"
+
+"js-yaml@^3.13.1":
+  "integrity" "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz"
+  "version" "3.14.1"
+  dependencies:
+    "argparse" "^1.0.7"
+    "esprima" "^4.0.0"
+
+"js-yaml@^4.1.0":
+  "integrity" "sha1-wftl+PUBeQHN0slRhkuhhFihBgI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz"
+  "version" "4.1.0"
+  dependencies:
+    "argparse" "^2.0.1"
+
+"jsdoc-type-pratt-parser@~4.1.0":
+  "integrity" "sha1-/2tKPzOcNKbBiMv1ChYIeFjSIRM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz"
+  "version" "4.1.0"
+
+"json-buffer@3.0.1":
+  "integrity" "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz"
+  "version" "3.0.1"
+
+"json-schema-traverse@^0.4.1":
+  "integrity" "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
+  "version" "0.4.1"
+
+"json-stable-stringify-without-jsonify@^1.0.1":
+  "integrity" "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
+  "version" "1.0.1"
+
+"json5@^1.0.2":
+  "integrity" "sha1-Y9mNYPIbMTt3xNbaGL+mnYDh1ZM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json5/-/json5-1.0.2.tgz"
+  "version" "1.0.2"
+  dependencies:
+    "minimist" "^1.2.0"
+
+"jsonc-parser@^3.2.0":
+  "integrity" "sha1-8qUktPf9EePXkeVZl3rWC5i3mLQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsonc-parser/-/jsonc-parser-3.3.1.tgz"
+  "version" "3.3.1"
+
+"jsonwebtoken@^9.0.0":
+  "integrity" "sha1-Zf+R9KvvF4RpfUCVK7GZjFBMqvM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz"
+  "version" "9.0.2"
+  dependencies:
+    "jws" "^3.2.2"
+    "lodash.includes" "^4.3.0"
+    "lodash.isboolean" "^3.0.3"
+    "lodash.isinteger" "^4.0.4"
+    "lodash.isnumber" "^3.0.3"
+    "lodash.isplainobject" "^4.0.6"
+    "lodash.isstring" "^4.0.1"
+    "lodash.once" "^4.0.0"
+    "ms" "^2.1.1"
+    "semver" "^7.5.4"
+
+"jwa@^1.4.1":
+  "integrity" "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jwa/-/jwa-1.4.1.tgz"
+  "version" "1.4.1"
+  dependencies:
+    "buffer-equal-constant-time" "1.0.1"
+    "ecdsa-sig-formatter" "1.0.11"
+    "safe-buffer" "^5.0.1"
+
+"jwa@^2.0.0":
+  "integrity" "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jwa/-/jwa-2.0.0.tgz"
+  "version" "2.0.0"
+  dependencies:
+    "buffer-equal-constant-time" "1.0.1"
+    "ecdsa-sig-formatter" "1.0.11"
+    "safe-buffer" "^5.0.1"
+
+"jws@^3.2.2":
+  "integrity" "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jws/-/jws-3.2.2.tgz"
+  "version" "3.2.2"
+  dependencies:
+    "jwa" "^1.4.1"
+    "safe-buffer" "^5.0.1"
+
+"jws@^4.0.0":
+  "integrity" "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jws/-/jws-4.0.0.tgz"
+  "version" "4.0.0"
+  dependencies:
+    "jwa" "^2.0.0"
+    "safe-buffer" "^5.0.1"
+
+"keytar@^7.7.0":
+  "integrity" "sha1-TGIlcI9RtQy/d8Wq6BchlkwpGMs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keytar/-/keytar-7.9.0.tgz"
+  "version" "7.9.0"
+  dependencies:
+    "node-addon-api" "^4.3.0"
+    "prebuild-install" "^7.0.1"
+
+"keyv@^4.5.3":
+  "integrity" "sha1-qHmpnilFL5QkOfKkBeOvizHU3pM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.5.4.tgz"
+  "version" "4.5.4"
+  dependencies:
+    "json-buffer" "3.0.1"
+
+"leven@^3.1.0":
+  "integrity" "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/leven/-/leven-3.1.0.tgz"
+  "version" "3.1.0"
+
+"levn@^0.4.1":
+  "integrity" "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/levn/-/levn-0.4.1.tgz"
+  "version" "0.4.1"
+  dependencies:
+    "prelude-ls" "^1.2.1"
+    "type-check" "~0.4.0"
+
+"linkify-it@^3.0.1":
+  "integrity" "sha1-qYuvRM5FpVDvtNScdp0HUkzC+i4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/linkify-it/-/linkify-it-3.0.3.tgz"
+  "version" "3.0.3"
+  dependencies:
+    "uc.micro" "^1.0.1"
+
+"locate-path@^6.0.0":
+  "integrity" "sha1-VTIeswn+u8WcSAHZMackUqaB0oY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz"
+  "version" "6.0.0"
+  dependencies:
+    "p-locate" "^5.0.0"
+
+"lodash.includes@^4.3.0":
+  "integrity" "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz"
+  "version" "4.3.0"
+
+"lodash.isboolean@^3.0.3":
+  "integrity" "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz"
+  "version" "3.0.3"
+
+"lodash.isinteger@^4.0.4":
+  "integrity" "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz"
+  "version" "4.0.4"
+
+"lodash.isnumber@^3.0.3":
+  "integrity" "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz"
+  "version" "3.0.3"
+
+"lodash.isplainobject@^4.0.6":
+  "integrity" "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz"
+  "version" "4.0.6"
+
+"lodash.isstring@^4.0.1":
+  "integrity" "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz"
+  "version" "4.0.1"
+
+"lodash.merge@^4.6.2":
+  "integrity" "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.merge/-/lodash.merge-4.6.2.tgz"
+  "version" "4.6.2"
+
+"lodash.once@^4.0.0":
+  "integrity" "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz"
+  "version" "4.1.1"
+
+"lru-cache@^6.0.0":
+  "integrity" "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz"
+  "version" "6.0.0"
+  dependencies:
+    "yallist" "^4.0.0"
+
+"markdown-it@^12.3.2":
+  "integrity" "sha1-v5Kskig/6YP+Tej/ir+1rXLNDJA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/markdown-it/-/markdown-it-12.3.2.tgz"
+  "version" "12.3.2"
+  dependencies:
+    "argparse" "^2.0.1"
+    "entities" "~2.1.0"
+    "linkify-it" "^3.0.1"
+    "mdurl" "^1.0.1"
+    "uc.micro" "^1.0.5"
+
+"math-intrinsics@^1.1.0":
+  "integrity" "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz"
+  "version" "1.1.0"
+
+"mdurl@^1.0.1":
+  "integrity" "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mdurl/-/mdurl-1.0.1.tgz"
+  "version" "1.0.1"
+
+"merge2@^1.3.0", "merge2@^1.4.1":
+  "integrity" "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/merge2/-/merge2-1.4.1.tgz"
+  "version" "1.4.1"
+
+"micromatch@^4.0.8":
+  "integrity" "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/micromatch/-/micromatch-4.0.8.tgz"
+  "version" "4.0.8"
+  dependencies:
+    "braces" "^3.0.3"
+    "picomatch" "^2.3.1"
+
+"mime-db@1.52.0":
+  "integrity" "sha1-u6vNwChZ9JhzAchW4zh85exDv3A="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-db/-/mime-db-1.52.0.tgz"
+  "version" "1.52.0"
+
+"mime-types@^2.1.12":
+  "integrity" "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime-types/-/mime-types-2.1.35.tgz"
+  "version" "2.1.35"
+  dependencies:
+    "mime-db" "1.52.0"
+
+"mime@^1.3.4":
+  "integrity" "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mime/-/mime-1.6.0.tgz"
+  "version" "1.6.0"
+
+"mimic-response@^3.1.0":
+  "integrity" "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz"
+  "version" "3.1.0"
+
+"minimatch@^3.0.3":
+  "integrity" "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz"
+  "version" "3.1.2"
+  dependencies:
+    "brace-expansion" "^1.1.7"
+
+"minimatch@^3.0.4":
+  "integrity" "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz"
+  "version" "3.1.2"
+  dependencies:
+    "brace-expansion" "^1.1.7"
+
+"minimatch@^3.0.5":
+  "integrity" "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz"
+  "version" "3.1.2"
+  dependencies:
+    "brace-expansion" "^1.1.7"
+
+"minimatch@^3.1.1":
+  "integrity" "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz"
+  "version" "3.1.2"
+  dependencies:
+    "brace-expansion" "^1.1.7"
+
+"minimatch@^3.1.2":
+  "integrity" "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.1.2.tgz"
+  "version" "3.1.2"
+  dependencies:
+    "brace-expansion" "^1.1.7"
+
+"minimatch@^9.0.4":
+  "integrity" "sha1-10+d1rV9g9jpjPuCEzsDl4vJKeU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-9.0.5.tgz"
+  "version" "9.0.5"
+  dependencies:
+    "brace-expansion" "^2.0.1"
+
+"minimatch@9.0.3":
+  "integrity" "sha1-puAMPeRMOlQr+q5wq/wiQgptqCU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-9.0.3.tgz"
+  "version" "9.0.3"
+  dependencies:
+    "brace-expansion" "^2.0.1"
+
+"minimist@^1.2.0", "minimist@^1.2.3", "minimist@^1.2.6":
+  "integrity" "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimist/-/minimist-1.2.8.tgz"
+  "version" "1.2.8"
+
+"mkdirp-classic@^0.5.2", "mkdirp-classic@^0.5.3":
+  "integrity" "sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz"
+  "version" "0.5.3"
+
+"mkdirp@^0.5.3":
+  "integrity" "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz"
+  "version" "0.5.6"
+  dependencies:
+    "minimist" "^1.2.6"
+
+"ms@^2.1.1", "ms@^2.1.3":
+  "integrity" "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz"
+  "version" "2.1.3"
+
+"mute-stream@~0.0.4":
+  "integrity" "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mute-stream/-/mute-stream-0.0.8.tgz"
+  "version" "0.0.8"
+
+"napi-build-utils@^2.0.0":
+  "integrity" "sha1-E8IsAYf8/MzhRhhEE2NypH3cAn4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/napi-build-utils/-/napi-build-utils-2.0.0.tgz"
+  "version" "2.0.0"
+
+"natural-compare@^1.4.0":
+  "integrity" "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz"
+  "version" "1.4.0"
+
+"node-abi@^3.3.0":
+  "integrity" "sha1-W/tEJCZOrrkUMtKtudojxjowHtA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abi/-/node-abi-3.74.0.tgz"
+  "version" "3.74.0"
+  dependencies:
+    "semver" "^7.3.5"
+
+"node-addon-api@^4.3.0":
+  "integrity" "sha1-UqGgtHUZPgko6Y4EJqDRJUeCt38="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-addon-api/-/node-addon-api-4.3.0.tgz"
+  "version" "4.3.0"
+
+"nth-check@^2.0.1":
+  "integrity" "sha1-yeq0KO/842zWuSySS9sADvHx7R0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nth-check/-/nth-check-2.1.1.tgz"
+  "version" "2.1.1"
+  dependencies:
+    "boolbase" "^1.0.0"
+
+"object-inspect@^1.13.3":
+  "integrity" "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz"
+  "version" "1.13.4"
+
+"object-keys@^1.1.1":
+  "integrity" "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object-keys/-/object-keys-1.1.1.tgz"
+  "version" "1.1.1"
+
+"object.assign@^4.1.7":
+  "integrity" "sha1-jBTKGkJMalYbC7KiL2b1BJqUXT0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object.assign/-/object.assign-4.1.7.tgz"
+  "version" "4.1.7"
+  dependencies:
+    "call-bind" "^1.0.8"
+    "call-bound" "^1.0.3"
+    "define-properties" "^1.2.1"
+    "es-object-atoms" "^1.0.0"
+    "has-symbols" "^1.1.0"
+    "object-keys" "^1.1.1"
+
+"object.fromentries@^2.0.8":
+  "integrity" "sha1-9xldipuXvZXLwZmeqTns0aKwDGU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object.fromentries/-/object.fromentries-2.0.8.tgz"
+  "version" "2.0.8"
+  dependencies:
+    "call-bind" "^1.0.7"
+    "define-properties" "^1.2.1"
+    "es-abstract" "^1.23.2"
+    "es-object-atoms" "^1.0.0"
+
+"object.groupby@^1.0.3":
+  "integrity" "sha1-mxJcNiOBKfb3thlUoecXYUjVAC4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object.groupby/-/object.groupby-1.0.3.tgz"
+  "version" "1.0.3"
+  dependencies:
+    "call-bind" "^1.0.7"
+    "define-properties" "^1.2.1"
+    "es-abstract" "^1.23.2"
+
+"object.values@^1.2.0":
+  "integrity" "sha1-3u1SClCAn/f3Wnz9S8ZMegOMYhY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/object.values/-/object.values-1.2.1.tgz"
+  "version" "1.2.1"
+  dependencies:
+    "call-bind" "^1.0.8"
+    "call-bound" "^1.0.3"
+    "define-properties" "^1.2.1"
+    "es-object-atoms" "^1.0.0"
+
+"once@^1.3.0", "once@^1.3.1", "once@^1.4.0":
+  "integrity" "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/once/-/once-1.4.0.tgz"
+  "version" "1.4.0"
+  dependencies:
+    "wrappy" "1"
+
+"open@^10.1.0":
+  "integrity" "sha1-p3lebl1Rmr5ChtmTe7JLURIlmOE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-10.1.0.tgz"
+  "version" "10.1.0"
+  dependencies:
+    "default-browser" "^5.2.1"
+    "define-lazy-prop" "^3.0.0"
+    "is-inside-container" "^1.0.0"
+    "is-wsl" "^3.1.0"
+
+"optionator@^0.9.3":
+  "integrity" "sha1-fqHBpdkddk+yghOciP4R4YKjpzQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/optionator/-/optionator-0.9.4.tgz"
+  "version" "0.9.4"
+  dependencies:
+    "deep-is" "^0.1.3"
+    "fast-levenshtein" "^2.0.6"
+    "levn" "^0.4.1"
+    "prelude-ls" "^1.2.1"
+    "type-check" "^0.4.0"
+    "word-wrap" "^1.2.5"
+
+"own-keys@^1.0.1":
+  "integrity" "sha1-5ABpEKK/kTWFKJZ27r1vOQz1E1g="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/own-keys/-/own-keys-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "get-intrinsic" "^1.2.6"
+    "object-keys" "^1.1.1"
+    "safe-push-apply" "^1.0.0"
+
+"p-limit@^3.0.2":
+  "integrity" "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz"
+  "version" "3.1.0"
+  dependencies:
+    "yocto-queue" "^0.1.0"
+
+"p-locate@^5.0.0":
+  "integrity" "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz"
+  "version" "5.0.0"
+  dependencies:
+    "p-limit" "^3.0.2"
+
+"parent-module@^1.0.0":
+  "integrity" "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parent-module/-/parent-module-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "callsites" "^3.0.0"
+
+"parse-imports@^2.1.1":
+  "integrity" "sha1-Cm6LUxa+tcmQX1DrK7uMZKSAVkI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse-imports/-/parse-imports-2.2.1.tgz"
+  "version" "2.2.1"
+  dependencies:
+    "es-module-lexer" "^1.5.3"
+    "slashes" "^3.0.12"
+
+"parse-semver@^1.1.1":
+  "integrity" "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse-semver/-/parse-semver-1.1.1.tgz"
+  "version" "1.1.1"
+  dependencies:
+    "semver" "^5.1.0"
+
+"parse5-htmlparser2-tree-adapter@^7.0.0":
+  "integrity" "sha1-tagGVI7Yk6Q+JMy0L7t4BpMR6Bs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz"
+  "version" "7.1.0"
+  dependencies:
+    "domhandler" "^5.0.3"
+    "parse5" "^7.0.0"
+
+"parse5-parser-stream@^7.1.2":
+  "integrity" "sha1-18IOrcN5aNJy4sAmYP/5LdJ+YOE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz"
+  "version" "7.1.2"
+  dependencies:
+    "parse5" "^7.0.0"
+
+"parse5@^7.0.0", "parse5@^7.1.2":
+  "integrity" "sha1-iSj1WRXmEl9DDMRDCXZb8XVWozo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/parse5/-/parse5-7.2.1.tgz"
+  "version" "7.2.1"
+  dependencies:
+    "entities" "^4.5.0"
+
+"path-exists@^4.0.0":
+  "integrity" "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz"
+  "version" "4.0.0"
+
+"path-is-absolute@^1.0.0":
+  "integrity" "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+  "version" "1.0.1"
+
+"path-key@^3.1.0":
+  "integrity" "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz"
+  "version" "3.1.1"
+
+"path-parse@^1.0.7":
+  "integrity" "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz"
+  "version" "1.0.7"
+
+"path-type@^4.0.0":
+  "integrity" "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-type/-/path-type-4.0.0.tgz"
+  "version" "4.0.0"
+
+"pend@~1.2.0":
+  "integrity" "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pend/-/pend-1.2.0.tgz"
+  "version" "1.2.0"
+
+"picocolors@^1.0.0":
+  "integrity" "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picocolors/-/picocolors-1.1.1.tgz"
+  "version" "1.1.1"
+
+"picomatch@^2.3.1":
+  "integrity" "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-2.3.1.tgz"
+  "version" "2.3.1"
+
+"picomatch@^3 || ^4", "picomatch@^4.0.2":
+  "integrity" "sha1-d8dCkx6PO4gglGx2zQwfE3MNHas="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-4.0.2.tgz"
+  "version" "4.0.2"
+
+"possible-typed-array-names@^1.0.0":
+  "integrity" "sha1-k+NYK8DlQmWG2dB7ee5A/IQd5K4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz"
+  "version" "1.1.0"
+
+"prebuild-install@^7.0.1":
+  "integrity" "sha1-1jCrrSsUdEPyCiEpF76uaLgJLuw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prebuild-install/-/prebuild-install-7.1.3.tgz"
+  "version" "7.1.3"
+  dependencies:
+    "detect-libc" "^2.0.0"
+    "expand-template" "^2.0.3"
+    "github-from-package" "0.0.0"
+    "minimist" "^1.2.3"
+    "mkdirp-classic" "^0.5.3"
+    "napi-build-utils" "^2.0.0"
+    "node-abi" "^3.3.0"
+    "pump" "^3.0.0"
+    "rc" "^1.2.7"
+    "simple-get" "^4.0.0"
+    "tar-fs" "^2.0.0"
+    "tunnel-agent" "^0.6.0"
+
+"prelude-ls@^1.2.1":
+  "integrity" "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz"
+  "version" "1.2.1"
+
+"prettier-linter-helpers@^1.0.0":
+  "integrity" "sha1-0j1B/hN1ZG3i0BBNNFSjAIgCz3s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz"
+  "version" "1.0.0"
+  dependencies:
+    "fast-diff" "^1.1.2"
+
+"prettier@>=3.0.0":
+  "integrity" "sha1-T8LODWV+egLmAlSfBTsjnLff4bU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prettier/-/prettier-3.5.3.tgz"
+  "version" "3.5.3"
+
+"pump@^3.0.0":
+  "integrity" "sha1-g28+3WvC7lmSVskk/+DYhXPdy/g="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pump/-/pump-3.0.2.tgz"
+  "version" "3.0.2"
+  dependencies:
+    "end-of-stream" "^1.1.0"
+    "once" "^1.3.1"
+
+"punycode@^2.1.0":
+  "integrity" "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/punycode/-/punycode-2.3.1.tgz"
+  "version" "2.3.1"
+
+"qs@^6.9.1":
+  "integrity" "sha1-xj+kBoDSxclBQSoOiZyJr2DAqTA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/qs/-/qs-6.14.0.tgz"
+  "version" "6.14.0"
+  dependencies:
+    "side-channel" "^1.1.0"
+
+"queue-microtask@^1.2.2":
+  "integrity" "sha1-SSkii7xyTfrEPg77BYyve2z7YkM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz"
+  "version" "1.2.3"
+
+"rc@^1.2.7":
+  "integrity" "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rc/-/rc-1.2.8.tgz"
+  "version" "1.2.8"
+  dependencies:
+    "deep-extend" "^0.6.0"
+    "ini" "~1.3.0"
+    "minimist" "^1.2.0"
+    "strip-json-comments" "~2.0.1"
+
+"read@^1.0.7":
+  "integrity" "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/read/-/read-1.0.7.tgz"
+  "version" "1.0.7"
+  dependencies:
+    "mute-stream" "~0.0.4"
+
+"readable-stream@^3.1.1", "readable-stream@^3.4.0":
+  "integrity" "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz"
+  "version" "3.6.2"
+  dependencies:
+    "inherits" "^2.0.3"
+    "string_decoder" "^1.1.1"
+    "util-deprecate" "^1.0.1"
+
+"reflect.getprototypeof@^1.0.6", "reflect.getprototypeof@^1.0.9":
+  "integrity" "sha1-xikhnnijMW2LYEx2XvaJlpZOe/k="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz"
+  "version" "1.0.10"
+  dependencies:
+    "call-bind" "^1.0.8"
+    "define-properties" "^1.2.1"
+    "es-abstract" "^1.23.9"
+    "es-errors" "^1.3.0"
+    "es-object-atoms" "^1.0.0"
+    "get-intrinsic" "^1.2.7"
+    "get-proto" "^1.0.1"
+    "which-builtin-type" "^1.2.1"
+
+"regexp.prototype.flags@^1.5.3":
+  "integrity" "sha1-GtbGLUSiWQB+VbOXDgD3Ru+8qhk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz"
+  "version" "1.5.4"
+  dependencies:
+    "call-bind" "^1.0.8"
+    "define-properties" "^1.2.1"
+    "es-errors" "^1.3.0"
+    "get-proto" "^1.0.1"
+    "gopd" "^1.2.0"
+    "set-function-name" "^2.0.2"
+
+"resolve-from@^4.0.0":
+  "integrity" "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-from/-/resolve-from-4.0.0.tgz"
+  "version" "4.0.0"
+
+"resolve-pkg-maps@^1.0.0":
+  "integrity" "sha1-YWs9wsVwVrVYjDHN9LPWTbEzcg8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz"
+  "version" "1.0.0"
+
+"resolve@^1.22.4", "resolve@^1.3.2":
+  "integrity" "sha1-tmPoP/sJu/I4aURza6roAwKbizk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/resolve/-/resolve-1.22.10.tgz"
+  "version" "1.22.10"
+  dependencies:
+    "is-core-module" "^2.16.0"
+    "path-parse" "^1.0.7"
+    "supports-preserve-symlinks-flag" "^1.0.0"
+
+"reusify@^1.0.4":
+  "integrity" "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/reusify/-/reusify-1.1.0.tgz"
+  "version" "1.1.0"
+
+"rimraf@^3.0.2", "rimraf@3.0.2":
+  "integrity" "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz"
+  "version" "3.0.2"
+  dependencies:
+    "glob" "^7.1.3"
+
+"run-applescript@^7.0.0":
+  "integrity" "sha1-5aVTwr/9Yg4WnSdsHNjxtkd4++s="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/run-applescript/-/run-applescript-7.0.0.tgz"
+  "version" "7.0.0"
+
+"run-parallel@^1.1.9":
+  "integrity" "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz"
+  "version" "1.2.0"
+  dependencies:
+    "queue-microtask" "^1.2.2"
+
+"safe-array-concat@^1.1.3":
+  "integrity" "sha1-yeVOxPYDsLu45+UAel7nrs0VOMM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-array-concat/-/safe-array-concat-1.1.3.tgz"
+  "version" "1.1.3"
+  dependencies:
+    "call-bind" "^1.0.8"
+    "call-bound" "^1.0.2"
+    "get-intrinsic" "^1.2.6"
+    "has-symbols" "^1.1.0"
+    "isarray" "^2.0.5"
+
+"safe-buffer@^5.0.1", "safe-buffer@~5.2.0":
+  "integrity" "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz"
+  "version" "5.2.1"
+
+"safe-push-apply@^1.0.0":
+  "integrity" "sha1-AYUOmBwWAtOYyFCB82Dk5tA9J/U="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-push-apply/-/safe-push-apply-1.0.0.tgz"
+  "version" "1.0.0"
+  dependencies:
+    "es-errors" "^1.3.0"
+    "isarray" "^2.0.5"
+
+"safe-regex-test@^1.1.0":
+  "integrity" "sha1-f4fftnoxUHguqvGFg/9dFxGsEME="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safe-regex-test/-/safe-regex-test-1.1.0.tgz"
+  "version" "1.1.0"
+  dependencies:
+    "call-bound" "^1.0.2"
+    "es-errors" "^1.3.0"
+    "is-regex" "^1.2.1"
 
 "safer-buffer@>= 2.1.2 < 3.0.0":
-  version "2.1.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz"
-  integrity sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=
+  "integrity" "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz"
+  "version" "2.1.2"
 
-sax@>=0.6.0:
-  version "1.4.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sax/-/sax-1.4.1.tgz"
-  integrity sha1-RMyJiDd/EmME07P8EBDHM7kp7w8=
+"sax@>=0.6.0":
+  "integrity" "sha1-RMyJiDd/EmME07P8EBDHM7kp7w8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sax/-/sax-1.4.1.tgz"
+  "version" "1.4.1"
 
-semver@^5.1.0, semver@^5.3.0:
-  version "5.7.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.2.tgz"
-  integrity sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=
+"semver@^5.1.0":
+  "integrity" "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.2.tgz"
+  "version" "5.7.2"
 
-semver@^6.3.1:
-  version "6.3.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-6.3.1.tgz"
-  integrity sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=
+"semver@^5.3.0":
+  "integrity" "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-5.7.2.tgz"
+  "version" "5.7.2"
 
-semver@^7.3.5, semver@^7.5.2, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3:
-  version "7.7.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.7.0.tgz"
-  integrity sha1-nG/mHQxvn6niZXUWLuWpGANhsJw=
+"semver@^6.3.1":
+  "integrity" "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-6.3.1.tgz"
+  "version" "6.3.1"
 
-set-function-length@^1.2.2:
-  version "1.2.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/set-function-length/-/set-function-length-1.2.2.tgz"
-  integrity sha1-qscjFBmOrtl1z3eyw7a4gGleVEk=
+"semver@^7.3.5", "semver@^7.5.2", "semver@^7.5.4", "semver@^7.6.0", "semver@^7.6.3", "semver@^7.7.1":
+  "integrity" "sha1-q9UJjYKxjGyB9gdP8mR/0+ciDJ8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.7.1.tgz"
+  "version" "7.7.1"
+
+"set-function-length@^1.2.2":
+  "integrity" "sha1-qscjFBmOrtl1z3eyw7a4gGleVEk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/set-function-length/-/set-function-length-1.2.2.tgz"
+  "version" "1.2.2"
   dependencies:
-    define-data-property "^1.1.4"
-    es-errors "^1.3.0"
-    function-bind "^1.1.2"
-    get-intrinsic "^1.2.4"
-    gopd "^1.0.1"
-    has-property-descriptors "^1.0.2"
+    "define-data-property" "^1.1.4"
+    "es-errors" "^1.3.0"
+    "function-bind" "^1.1.2"
+    "get-intrinsic" "^1.2.4"
+    "gopd" "^1.0.1"
+    "has-property-descriptors" "^1.0.2"
 
-set-function-name@^2.0.2:
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/set-function-name/-/set-function-name-2.0.2.tgz"
-  integrity sha1-FqcFxaDcL15jjKltiozU4cK5CYU=
+"set-function-name@^2.0.2":
+  "integrity" "sha1-FqcFxaDcL15jjKltiozU4cK5CYU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/set-function-name/-/set-function-name-2.0.2.tgz"
+  "version" "2.0.2"
   dependencies:
-    define-data-property "^1.1.4"
-    es-errors "^1.3.0"
-    functions-have-names "^1.2.3"
-    has-property-descriptors "^1.0.2"
+    "define-data-property" "^1.1.4"
+    "es-errors" "^1.3.0"
+    "functions-have-names" "^1.2.3"
+    "has-property-descriptors" "^1.0.2"
 
-set-proto@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/set-proto/-/set-proto-1.0.0.tgz"
-  integrity sha1-B2Dbz/MLLX6AH9bhmYPlbaM3Vl4=
+"set-proto@^1.0.0":
+  "integrity" "sha1-B2Dbz/MLLX6AH9bhmYPlbaM3Vl4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/set-proto/-/set-proto-1.0.0.tgz"
+  "version" "1.0.0"
   dependencies:
-    dunder-proto "^1.0.1"
-    es-errors "^1.3.0"
-    es-object-atoms "^1.0.0"
+    "dunder-proto" "^1.0.1"
+    "es-errors" "^1.3.0"
+    "es-object-atoms" "^1.0.0"
 
-shebang-command@^2.0.0:
-  version "2.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz"
-  integrity sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=
+"shebang-command@^2.0.0":
+  "integrity" "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz"
+  "version" "2.0.0"
   dependencies:
-    shebang-regex "^3.0.0"
+    "shebang-regex" "^3.0.0"
 
-shebang-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz"
-  integrity sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=
+"shebang-regex@^3.0.0":
+  "integrity" "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz"
+  "version" "3.0.0"
 
-side-channel-list@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz"
-  integrity sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=
+"side-channel-list@^1.0.0":
+  "integrity" "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz"
+  "version" "1.0.0"
   dependencies:
-    es-errors "^1.3.0"
-    object-inspect "^1.13.3"
+    "es-errors" "^1.3.0"
+    "object-inspect" "^1.13.3"
 
-side-channel-map@^1.0.1:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz"
-  integrity sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I=
+"side-channel-map@^1.0.1":
+  "integrity" "sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz"
+  "version" "1.0.1"
   dependencies:
-    call-bound "^1.0.2"
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.5"
-    object-inspect "^1.13.3"
+    "call-bound" "^1.0.2"
+    "es-errors" "^1.3.0"
+    "get-intrinsic" "^1.2.5"
+    "object-inspect" "^1.13.3"
 
-side-channel-weakmap@^1.0.2:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz"
-  integrity sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo=
+"side-channel-weakmap@^1.0.2":
+  "integrity" "sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz"
+  "version" "1.0.2"
   dependencies:
-    call-bound "^1.0.2"
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.5"
-    object-inspect "^1.13.3"
-    side-channel-map "^1.0.1"
+    "call-bound" "^1.0.2"
+    "es-errors" "^1.3.0"
+    "get-intrinsic" "^1.2.5"
+    "object-inspect" "^1.13.3"
+    "side-channel-map" "^1.0.1"
 
-side-channel@^1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/side-channel/-/side-channel-1.1.0.tgz"
-  integrity sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=
+"side-channel@^1.1.0":
+  "integrity" "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/side-channel/-/side-channel-1.1.0.tgz"
+  "version" "1.1.0"
   dependencies:
-    es-errors "^1.3.0"
-    object-inspect "^1.13.3"
-    side-channel-list "^1.0.0"
-    side-channel-map "^1.0.1"
-    side-channel-weakmap "^1.0.2"
+    "es-errors" "^1.3.0"
+    "object-inspect" "^1.13.3"
+    "side-channel-list" "^1.0.0"
+    "side-channel-map" "^1.0.1"
+    "side-channel-weakmap" "^1.0.2"
 
-simple-concat@^1.0.0:
-  version "1.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/simple-concat/-/simple-concat-1.0.1.tgz"
-  integrity sha1-9Gl2CCujXCJj8cirXt/ibEHJVS8=
+"simple-concat@^1.0.0":
+  "integrity" "sha1-9Gl2CCujXCJj8cirXt/ibEHJVS8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/simple-concat/-/simple-concat-1.0.1.tgz"
+  "version" "1.0.1"
 
-simple-get@^4.0.0:
-  version "4.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/simple-get/-/simple-get-4.0.1.tgz"
-  integrity sha1-SjnbVJKHyXnTUhEvoD/Zn9a8NUM=
+"simple-get@^4.0.0":
+  "integrity" "sha1-SjnbVJKHyXnTUhEvoD/Zn9a8NUM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/simple-get/-/simple-get-4.0.1.tgz"
+  "version" "4.0.1"
   dependencies:
-    decompress-response "^6.0.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
+    "decompress-response" "^6.0.0"
+    "once" "^1.3.1"
+    "simple-concat" "^1.0.0"
 
-slash@^3.0.0:
-  version "3.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/slash/-/slash-3.0.0.tgz"
-  integrity sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=
+"slash@^3.0.0":
+  "integrity" "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/slash/-/slash-3.0.0.tgz"
+  "version" "3.0.0"
 
-slashes@^3.0.12:
-  version "3.0.12"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/slashes/-/slashes-3.0.12.tgz"
-  integrity sha1-PWZMh3rVQtwVCeryxQ841IOmQ1o=
+"slashes@^3.0.12":
+  "integrity" "sha1-PWZMh3rVQtwVCeryxQ841IOmQ1o="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/slashes/-/slashes-3.0.12.tgz"
+  "version" "3.0.12"
 
-source-map@^0.6.0:
-  version "0.6.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map/-/source-map-0.6.1.tgz"
-  integrity sha1-dHIq8y6WFOnCh6jQu95IteLxomM=
+"source-map@^0.6.0":
+  "integrity" "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map/-/source-map-0.6.1.tgz"
+  "version" "0.6.1"
 
-spdx-exceptions@^2.1.0:
-  version "2.5.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz"
-  integrity sha1-XWB9J/yAb2bXtkp2ZlD6iQ8E7WY=
+"spdx-exceptions@^2.1.0":
+  "integrity" "sha1-XWB9J/yAb2bXtkp2ZlD6iQ8E7WY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz"
+  "version" "2.5.0"
 
-spdx-expression-parse@^4.0.0:
-  version "4.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz"
-  integrity sha1-ojr58xMhFUZdrCFcCZMD5M6sV5Q=
+"spdx-expression-parse@^4.0.0":
+  "integrity" "sha1-ojr58xMhFUZdrCFcCZMD5M6sV5Q="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz"
+  "version" "4.0.0"
   dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
+    "spdx-exceptions" "^2.1.0"
+    "spdx-license-ids" "^3.0.0"
 
-spdx-license-ids@^3.0.0:
-  version "3.0.21"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz"
-  integrity sha1-bW6YDJ3ytvyQU0OjstcCpiOVNsM=
+"spdx-license-ids@^3.0.0":
+  "integrity" "sha1-bW6YDJ3ytvyQU0OjstcCpiOVNsM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz"
+  "version" "3.0.21"
 
-sprintf-js@~1.0.2:
-  version "1.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz"
-  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+"sprintf-js@~1.0.2":
+  "integrity" "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz"
+  "version" "1.0.3"
 
-stable-hash@^0.0.4:
-  version "0.0.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stable-hash/-/stable-hash-0.0.4.tgz"
-  integrity sha1-Va59rcE+Sz+u0TYBWHzsQYWbQvc=
+"stable-hash@^0.0.5":
+  "integrity" "sha1-lOiDeq6sW00PYx0pcq3vKSS0Amk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stable-hash/-/stable-hash-0.0.5.tgz"
+  "version" "0.0.5"
 
-stoppable@^1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stoppable/-/stoppable-1.1.0.tgz"
-  integrity sha1-MtpWjoPqSIsI5NfqLDvMnXUBXVs=
+"stoppable@^1.1.0":
+  "integrity" "sha1-MtpWjoPqSIsI5NfqLDvMnXUBXVs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stoppable/-/stoppable-1.1.0.tgz"
+  "version" "1.1.0"
 
-string.prototype.trim@^1.2.10:
-  version "1.2.10"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz"
-  integrity sha1-QLLdXulMlZtNz7HWXOcukNpIDIE=
+"string_decoder@^1.1.1":
+  "integrity" "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz"
+  "version" "1.3.0"
   dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.2"
-    define-data-property "^1.1.4"
-    define-properties "^1.2.1"
-    es-abstract "^1.23.5"
-    es-object-atoms "^1.0.0"
-    has-property-descriptors "^1.0.2"
+    "safe-buffer" "~5.2.0"
 
-string.prototype.trimend@^1.0.8, string.prototype.trimend@^1.0.9:
-  version "1.0.9"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz"
-  integrity sha1-YuJzEnLNKFBBs2WWBU6fZlabaUI=
+"string.prototype.trim@^1.2.10":
+  "integrity" "sha1-QLLdXulMlZtNz7HWXOcukNpIDIE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz"
+  "version" "1.2.10"
   dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.2"
-    define-properties "^1.2.1"
-    es-object-atoms "^1.0.0"
+    "call-bind" "^1.0.8"
+    "call-bound" "^1.0.2"
+    "define-data-property" "^1.1.4"
+    "define-properties" "^1.2.1"
+    "es-abstract" "^1.23.5"
+    "es-object-atoms" "^1.0.0"
+    "has-property-descriptors" "^1.0.2"
 
-string.prototype.trimstart@^1.0.8:
-  version "1.0.8"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz"
-  integrity sha1-fug03ajHwX7/MRhHK7Nb/tqjTd4=
+"string.prototype.trimend@^1.0.8", "string.prototype.trimend@^1.0.9":
+  "integrity" "sha1-YuJzEnLNKFBBs2WWBU6fZlabaUI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz"
+  "version" "1.0.9"
   dependencies:
-    call-bind "^1.0.7"
-    define-properties "^1.2.1"
-    es-object-atoms "^1.0.0"
+    "call-bind" "^1.0.8"
+    "call-bound" "^1.0.2"
+    "define-properties" "^1.2.1"
+    "es-object-atoms" "^1.0.0"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=
+"string.prototype.trimstart@^1.0.8":
+  "integrity" "sha1-fug03ajHwX7/MRhHK7Nb/tqjTd4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz"
+  "version" "1.0.8"
   dependencies:
-    safe-buffer "~5.2.0"
+    "call-bind" "^1.0.7"
+    "define-properties" "^1.2.1"
+    "es-object-atoms" "^1.0.0"
 
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=
+"strip-ansi@^6.0.1":
+  "integrity" "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  "version" "6.0.1"
   dependencies:
-    ansi-regex "^5.0.1"
+    "ansi-regex" "^5.0.1"
 
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-bom/-/strip-bom-3.0.0.tgz"
-  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+"strip-bom@^3.0.0":
+  "integrity" "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-bom/-/strip-bom-3.0.0.tgz"
+  "version" "3.0.0"
 
-strip-json-comments@^3.1.1:
-  version "3.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
-  integrity sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=
+"strip-json-comments@^3.1.1":
+  "integrity" "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
+  "version" "3.1.1"
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+"strip-json-comments@~2.0.1":
+  "integrity" "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+  "version" "2.0.1"
 
-supports-color@^5.3.0:
-  version "5.5.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz"
-  integrity sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=
+"supports-color@^5.3.0":
+  "integrity" "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz"
+  "version" "5.5.0"
   dependencies:
-    has-flag "^3.0.0"
+    "has-flag" "^3.0.0"
 
-supports-color@^7.1.0:
-  version "7.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-7.2.0.tgz"
-  integrity sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=
+"supports-color@^7.1.0":
+  "integrity" "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-color/-/supports-color-7.2.0.tgz"
+  "version" "7.2.0"
   dependencies:
-    has-flag "^4.0.0"
+    "has-flag" "^4.0.0"
 
-supports-preserve-symlinks-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
-  integrity sha1-btpL00SjyUrqN21MwxvHcxEDngk=
+"supports-preserve-symlinks-flag@^1.0.0":
+  "integrity" "sha1-btpL00SjyUrqN21MwxvHcxEDngk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
+  "version" "1.0.0"
 
-synckit@^0.9.1:
-  version "0.9.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/synckit/-/synckit-0.9.2.tgz"
-  integrity sha1-o6k17KeSLUi559bGGCLubDrk7GI=
+"synckit@^0.10.2":
+  "integrity" "sha1-lArqLHttFBpPdNvevIHglYwzGks="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/synckit/-/synckit-0.10.3.tgz"
+  "version" "0.10.3"
+  dependencies:
+    "@pkgr/core" "^0.2.0"
+    "tslib" "^2.8.1"
+
+"synckit@^0.9.1":
+  "integrity" "sha1-o6k17KeSLUi559bGGCLubDrk7GI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/synckit/-/synckit-0.9.2.tgz"
+  "version" "0.9.2"
   dependencies:
     "@pkgr/core" "^0.1.0"
-    tslib "^2.6.2"
+    "tslib" "^2.6.2"
 
-tapable@^2.2.0:
-  version "2.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tapable/-/tapable-2.2.1.tgz"
-  integrity sha1-GWenPvQGCoLxKrlq+G1S/bdu7KA=
-
-tar-fs@^2.0.0:
-  version "2.1.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar-fs/-/tar-fs-2.1.2.tgz"
-  integrity sha1-Ql8VTzQEyxbLj/bmcdRasu2VlsU=
+"tar-fs@^2.0.0":
+  "integrity" "sha1-Ql8VTzQEyxbLj/bmcdRasu2VlsU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar-fs/-/tar-fs-2.1.2.tgz"
+  "version" "2.1.2"
   dependencies:
-    chownr "^1.1.1"
-    mkdirp-classic "^0.5.2"
-    pump "^3.0.0"
-    tar-stream "^2.1.4"
+    "chownr" "^1.1.1"
+    "mkdirp-classic" "^0.5.2"
+    "pump" "^3.0.0"
+    "tar-stream" "^2.1.4"
 
-tar-stream@^2.1.4:
-  version "2.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar-stream/-/tar-stream-2.2.0.tgz"
-  integrity sha1-rK2EwoQTawYNw/qmRHSqmuvXcoc=
+"tar-stream@^2.1.4":
+  "integrity" "sha1-rK2EwoQTawYNw/qmRHSqmuvXcoc="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar-stream/-/tar-stream-2.2.0.tgz"
+  "version" "2.2.0"
   dependencies:
-    bl "^4.0.3"
-    end-of-stream "^1.4.1"
-    fs-constants "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^3.1.1"
+    "bl" "^4.0.3"
+    "end-of-stream" "^1.4.1"
+    "fs-constants" "^1.0.0"
+    "inherits" "^2.0.3"
+    "readable-stream" "^3.1.1"
 
-text-table@^0.2.0:
-  version "0.2.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/text-table/-/text-table-0.2.0.tgz"
-  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+"text-table@^0.2.0":
+  "integrity" "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/text-table/-/text-table-0.2.0.tgz"
+  "version" "0.2.0"
 
-tmp@^0.2.1:
-  version "0.2.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tmp/-/tmp-0.2.3.tgz"
-  integrity sha1-63g8wivB6L69BnFHbUbqTrMqea4=
-
-to-regex-range@^5.0.1:
-  version "5.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz"
-  integrity sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=
+"tinyglobby@^0.2.12":
+  "integrity" "sha1-rJQaQuDFdzvQtdCPMt6C50oaYbU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tinyglobby/-/tinyglobby-0.2.12.tgz"
+  "version" "0.2.12"
   dependencies:
-    is-number "^7.0.0"
+    "fdir" "^6.4.3"
+    "picomatch" "^4.0.2"
 
-ts-api-utils@^1.0.1:
-  version "1.4.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ts-api-utils/-/ts-api-utils-1.4.3.tgz"
-  integrity sha1-v8IhX+ZSj+yrKw+6VwouikJjsGQ=
+"tmp@^0.2.1":
+  "integrity" "sha1-63g8wivB6L69BnFHbUbqTrMqea4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tmp/-/tmp-0.2.3.tgz"
+  "version" "0.2.3"
 
-ts-api-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ts-api-utils/-/ts-api-utils-2.0.0.tgz"
-  integrity sha1-udfV9+yfc29NDwl1i4YHl5BEqQA=
+"to-regex-range@^5.0.1":
+  "integrity" "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz"
+  "version" "5.0.1"
+  dependencies:
+    "is-number" "^7.0.0"
 
-tsconfig-paths@^3.15.0:
-  version "3.15.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz"
-  integrity sha1-UpnsYF5VsauyPsk57xXtr0gwcNQ=
+"ts-api-utils@^1.0.1":
+  "integrity" "sha1-v8IhX+ZSj+yrKw+6VwouikJjsGQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ts-api-utils/-/ts-api-utils-1.4.3.tgz"
+  "version" "1.4.3"
+
+"ts-api-utils@^2.0.1":
+  "integrity" "sha1-WV9wlORu7TZME/0j51+VE9Kbr5E="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ts-api-utils/-/ts-api-utils-2.1.0.tgz"
+  "version" "2.1.0"
+
+"tsconfig-paths@^3.15.0":
+  "integrity" "sha1-UpnsYF5VsauyPsk57xXtr0gwcNQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz"
+  "version" "3.15.0"
   dependencies:
     "@types/json5" "^0.0.29"
-    json5 "^1.0.2"
-    minimist "^1.2.6"
-    strip-bom "^3.0.0"
+    "json5" "^1.0.2"
+    "minimist" "^1.2.6"
+    "strip-bom" "^3.0.0"
 
-tslib@^1.13.0, tslib@^1.8.1:
-  version "1.14.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-1.14.1.tgz"
-  integrity sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=
+"tslib@^1.13.0":
+  "integrity" "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-1.14.1.tgz"
+  "version" "1.14.1"
 
-tslib@^2.2.0, tslib@^2.6.2:
-  version "2.8.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.8.1.tgz"
-  integrity sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=
+"tslib@^1.8.1":
+  "integrity" "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-1.14.1.tgz"
+  "version" "1.14.1"
 
-tslint@^6.1.3:
-  version "6.1.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslint/-/tslint-6.1.3.tgz"
-  integrity sha1-XCOy7MwySH1VI706Rw6aoxeJ2QQ=
+"tslib@^2.2.0", "tslib@^2.6.2", "tslib@^2.8.1":
+  "integrity" "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.8.1.tgz"
+  "version" "2.8.1"
+
+"tslint@^5.0.0 || ^6.0.0", "tslint@^6.1.3":
+  "integrity" "sha1-XCOy7MwySH1VI706Rw6aoxeJ2QQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslint/-/tslint-6.1.3.tgz"
+  "version" "6.1.3"
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    builtin-modules "^1.1.1"
-    chalk "^2.3.0"
-    commander "^2.12.1"
-    diff "^4.0.1"
-    glob "^7.1.1"
-    js-yaml "^3.13.1"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.3"
-    resolve "^1.3.2"
-    semver "^5.3.0"
-    tslib "^1.13.0"
-    tsutils "^2.29.0"
+    "builtin-modules" "^1.1.1"
+    "chalk" "^2.3.0"
+    "commander" "^2.12.1"
+    "diff" "^4.0.1"
+    "glob" "^7.1.1"
+    "js-yaml" "^3.13.1"
+    "minimatch" "^3.0.4"
+    "mkdirp" "^0.5.3"
+    "resolve" "^1.3.2"
+    "semver" "^5.3.0"
+    "tslib" "^1.13.0"
+    "tsutils" "^2.29.0"
 
-tsutils@^2.29.0:
-  version "2.29.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tsutils/-/tsutils-2.29.0.tgz"
-  integrity sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=
+"tsutils@^2.29.0":
+  "integrity" "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tsutils/-/tsutils-2.29.0.tgz"
+  "version" "2.29.0"
   dependencies:
-    tslib "^1.8.1"
+    "tslib" "^1.8.1"
 
-tunnel-agent@^0.6.0:
-  version "0.6.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-  integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
+"tunnel-agent@^0.6.0":
+  "integrity" "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+  "version" "0.6.0"
   dependencies:
-    safe-buffer "^5.0.1"
+    "safe-buffer" "^5.0.1"
 
-tunnel@0.0.6:
-  version "0.0.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel/-/tunnel-0.0.6.tgz"
-  integrity sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=
+"tunnel@0.0.6":
+  "integrity" "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel/-/tunnel-0.0.6.tgz"
+  "version" "0.0.6"
 
-type-check@^0.4.0, type-check@~0.4.0:
-  version "0.4.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-check/-/type-check-0.4.0.tgz"
-  integrity sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=
+"type-check@^0.4.0", "type-check@~0.4.0":
+  "integrity" "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-check/-/type-check-0.4.0.tgz"
+  "version" "0.4.0"
   dependencies:
-    prelude-ls "^1.2.1"
+    "prelude-ls" "^1.2.1"
 
-type-fest@^0.20.2:
-  version "0.20.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-fest/-/type-fest-0.20.2.tgz"
-  integrity sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=
+"type-fest@^0.20.2":
+  "integrity" "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-fest/-/type-fest-0.20.2.tgz"
+  "version" "0.20.2"
 
-typed-array-buffer@^1.0.3:
-  version "1.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz"
-  integrity sha1-pyOVRQpIaewDP9VJNxtHrzou5TY=
+"typed-array-buffer@^1.0.3":
+  "integrity" "sha1-pyOVRQpIaewDP9VJNxtHrzou5TY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz"
+  "version" "1.0.3"
   dependencies:
-    call-bound "^1.0.3"
-    es-errors "^1.3.0"
-    is-typed-array "^1.1.14"
+    "call-bound" "^1.0.3"
+    "es-errors" "^1.3.0"
+    "is-typed-array" "^1.1.14"
 
-typed-array-byte-length@^1.0.3:
-  version "1.0.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz"
-  integrity sha1-hAegT314aE89JSqhoUPSt3tBYM4=
+"typed-array-byte-length@^1.0.3":
+  "integrity" "sha1-hAegT314aE89JSqhoUPSt3tBYM4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz"
+  "version" "1.0.3"
   dependencies:
-    call-bind "^1.0.8"
-    for-each "^0.3.3"
-    gopd "^1.2.0"
-    has-proto "^1.2.0"
-    is-typed-array "^1.1.14"
+    "call-bind" "^1.0.8"
+    "for-each" "^0.3.3"
+    "gopd" "^1.2.0"
+    "has-proto" "^1.2.0"
+    "is-typed-array" "^1.1.14"
 
-typed-array-byte-offset@^1.0.4:
-  version "1.0.4"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz"
-  integrity sha1-rjaYuOyRqKuUUBYQiu8A1b/xI1U=
+"typed-array-byte-offset@^1.0.4":
+  "integrity" "sha1-rjaYuOyRqKuUUBYQiu8A1b/xI1U="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz"
+  "version" "1.0.4"
   dependencies:
-    available-typed-arrays "^1.0.7"
-    call-bind "^1.0.8"
-    for-each "^0.3.3"
-    gopd "^1.2.0"
-    has-proto "^1.2.0"
-    is-typed-array "^1.1.15"
-    reflect.getprototypeof "^1.0.9"
+    "available-typed-arrays" "^1.0.7"
+    "call-bind" "^1.0.8"
+    "for-each" "^0.3.3"
+    "gopd" "^1.2.0"
+    "has-proto" "^1.2.0"
+    "is-typed-array" "^1.1.15"
+    "reflect.getprototypeof" "^1.0.9"
 
-typed-array-length@^1.0.7:
-  version "1.0.7"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-array-length/-/typed-array-length-1.0.7.tgz"
-  integrity sha1-7k3v+YS2S+HhGLDejJyHfVznPT0=
+"typed-array-length@^1.0.7":
+  "integrity" "sha1-7k3v+YS2S+HhGLDejJyHfVznPT0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-array-length/-/typed-array-length-1.0.7.tgz"
+  "version" "1.0.7"
   dependencies:
-    call-bind "^1.0.7"
-    for-each "^0.3.3"
-    gopd "^1.0.1"
-    is-typed-array "^1.1.13"
-    possible-typed-array-names "^1.0.0"
-    reflect.getprototypeof "^1.0.6"
+    "call-bind" "^1.0.7"
+    "for-each" "^0.3.3"
+    "gopd" "^1.0.1"
+    "is-typed-array" "^1.1.13"
+    "possible-typed-array-names" "^1.0.0"
+    "reflect.getprototypeof" "^1.0.6"
 
-typed-rest-client@^1.8.4:
-  version "1.8.11"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz"
-  integrity sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=
+"typed-rest-client@^1.8.4":
+  "integrity" "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz"
+  "version" "1.8.11"
   dependencies:
-    qs "^6.9.1"
-    tunnel "0.0.6"
-    underscore "^1.12.1"
+    "qs" "^6.9.1"
+    "tunnel" "0.0.6"
+    "underscore" "^1.12.1"
 
-typescript@^5.5.4:
-  version "5.7.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-5.7.3.tgz"
-  integrity sha1-kZtEp9u4WDqbhW0WK+JKVL+ABz4=
+"typescript@*", "typescript@^5.5.4", "typescript@>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev", "typescript@>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev", "typescript@>=4.2.0", "typescript@>=4.8.4", "typescript@>=4.8.4 <5.9.0":
+  "integrity" "sha1-gXCzcC90t52y5aliB8FeZYB5meQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-5.8.2.tgz"
+  "version" "5.8.2"
 
-uc.micro@^1.0.1, uc.micro@^1.0.5:
-  version "1.0.6"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uc.micro/-/uc.micro-1.0.6.tgz"
-  integrity sha1-nEEagCpAmpH8bPdAgbq6NLJEmaw=
+"uc.micro@^1.0.1", "uc.micro@^1.0.5":
+  "integrity" "sha1-nEEagCpAmpH8bPdAgbq6NLJEmaw="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uc.micro/-/uc.micro-1.0.6.tgz"
+  "version" "1.0.6"
 
-unbox-primitive@^1.1.0:
-  version "1.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unbox-primitive/-/unbox-primitive-1.1.0.tgz"
-  integrity sha1-jZ0snt7qhGDH81AzqIhnlEk00eI=
+"unbox-primitive@^1.1.0":
+  "integrity" "sha1-jZ0snt7qhGDH81AzqIhnlEk00eI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unbox-primitive/-/unbox-primitive-1.1.0.tgz"
+  "version" "1.1.0"
   dependencies:
-    call-bound "^1.0.3"
-    has-bigints "^1.0.2"
-    has-symbols "^1.1.0"
-    which-boxed-primitive "^1.1.1"
+    "call-bound" "^1.0.3"
+    "has-bigints" "^1.0.2"
+    "has-symbols" "^1.1.0"
+    "which-boxed-primitive" "^1.1.1"
 
-underscore@^1.12.1:
-  version "1.13.7"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/underscore/-/underscore-1.13.7.tgz"
-  integrity sha1-lw4zljr5p92iKPF+voOZ5fvmOhA=
+"underscore@^1.12.1":
+  "integrity" "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/underscore/-/underscore-1.13.7.tgz"
+  "version" "1.13.7"
 
-undici@^6.19.5:
-  version "6.21.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici/-/undici-6.21.1.tgz"
-  integrity sha1-M2AloUFi5oN+RK17gZs1tsavDgU=
+"undici-types@~6.21.0":
+  "integrity" "sha1-aR0ArzkJvpOn+qE75hs6W1DvEss="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici-types/-/undici-types-6.21.0.tgz"
+  "version" "6.21.0"
 
-uri-js@^4.2.2:
-  version "4.4.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uri-js/-/uri-js-4.4.1.tgz"
-  integrity sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=
+"undici@^6.19.5":
+  "integrity" "sha1-ScWITo+QOcZaie6QGO88ji8fSSg="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici/-/undici-6.21.2.tgz"
+  "version" "6.21.2"
+
+"unrs-resolver@^1.3.2":
+  "integrity" "sha1-fB3Arauxw5ccjFy92MHC90Iobm0="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/unrs-resolver/-/unrs-resolver-1.3.2.tgz"
+  "version" "1.3.2"
+  optionalDependencies:
+    "@unrs/resolver-binding-darwin-arm64" "1.3.2"
+    "@unrs/resolver-binding-darwin-x64" "1.3.2"
+    "@unrs/resolver-binding-freebsd-x64" "1.3.2"
+    "@unrs/resolver-binding-linux-arm-gnueabihf" "1.3.2"
+    "@unrs/resolver-binding-linux-arm-musleabihf" "1.3.2"
+    "@unrs/resolver-binding-linux-arm64-gnu" "1.3.2"
+    "@unrs/resolver-binding-linux-arm64-musl" "1.3.2"
+    "@unrs/resolver-binding-linux-ppc64-gnu" "1.3.2"
+    "@unrs/resolver-binding-linux-s390x-gnu" "1.3.2"
+    "@unrs/resolver-binding-linux-x64-gnu" "1.3.2"
+    "@unrs/resolver-binding-linux-x64-musl" "1.3.2"
+    "@unrs/resolver-binding-wasm32-wasi" "1.3.2"
+    "@unrs/resolver-binding-win32-arm64-msvc" "1.3.2"
+    "@unrs/resolver-binding-win32-ia32-msvc" "1.3.2"
+    "@unrs/resolver-binding-win32-x64-msvc" "1.3.2"
+
+"uri-js@^4.2.2":
+  "integrity" "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uri-js/-/uri-js-4.4.1.tgz"
+  "version" "4.4.1"
   dependencies:
-    punycode "^2.1.0"
+    "punycode" "^2.1.0"
 
-url-join@^4.0.1:
-  version "4.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-join/-/url-join-4.0.1.tgz"
-  integrity sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec=
+"url-join@^4.0.1":
+  "integrity" "sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/url-join/-/url-join-4.0.1.tgz"
+  "version" "4.0.1"
 
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz"
-  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+"util-deprecate@^1.0.1":
+  "integrity" "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz"
+  "version" "1.0.2"
 
-uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uuid/-/uuid-8.3.2.tgz"
-  integrity sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=
+"uuid@^8.3.0":
+  "integrity" "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uuid/-/uuid-8.3.2.tgz"
+  "version" "8.3.2"
 
-whatwg-encoding@^3.1.1:
-  version "3.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz"
-  integrity sha1-0PTvdpkF1CbhaI8+NDgambYLduU=
+"whatwg-encoding@^3.1.1":
+  "integrity" "sha1-0PTvdpkF1CbhaI8+NDgambYLduU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz"
+  "version" "3.1.1"
   dependencies:
-    iconv-lite "0.6.3"
+    "iconv-lite" "0.6.3"
 
-whatwg-mimetype@^4.0.0:
-  version "4.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz"
-  integrity sha1-vBv5SphdxQOI1UqSWKxAXDyi/Ao=
+"whatwg-mimetype@^4.0.0":
+  "integrity" "sha1-vBv5SphdxQOI1UqSWKxAXDyi/Ao="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz"
+  "version" "4.0.0"
 
-which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
-  version "1.1.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz"
-  integrity sha1-127Cfff6Fl8Y1YCDdKX+I8KbF24=
+"which-boxed-primitive@^1.1.0", "which-boxed-primitive@^1.1.1":
+  "integrity" "sha1-127Cfff6Fl8Y1YCDdKX+I8KbF24="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz"
+  "version" "1.1.1"
   dependencies:
-    is-bigint "^1.1.0"
-    is-boolean-object "^1.2.1"
-    is-number-object "^1.1.1"
-    is-string "^1.1.1"
-    is-symbol "^1.1.1"
+    "is-bigint" "^1.1.0"
+    "is-boolean-object" "^1.2.1"
+    "is-number-object" "^1.1.1"
+    "is-string" "^1.1.1"
+    "is-symbol" "^1.1.1"
 
-which-builtin-type@^1.2.1:
-  version "1.2.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which-builtin-type/-/which-builtin-type-1.2.1.tgz"
-  integrity sha1-iRg9obSQerCJprAgKcxdjWV0Jw4=
+"which-builtin-type@^1.2.1":
+  "integrity" "sha1-iRg9obSQerCJprAgKcxdjWV0Jw4="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which-builtin-type/-/which-builtin-type-1.2.1.tgz"
+  "version" "1.2.1"
   dependencies:
-    call-bound "^1.0.2"
-    function.prototype.name "^1.1.6"
-    has-tostringtag "^1.0.2"
-    is-async-function "^2.0.0"
-    is-date-object "^1.1.0"
-    is-finalizationregistry "^1.1.0"
-    is-generator-function "^1.0.10"
-    is-regex "^1.2.1"
-    is-weakref "^1.0.2"
-    isarray "^2.0.5"
-    which-boxed-primitive "^1.1.0"
-    which-collection "^1.0.2"
-    which-typed-array "^1.1.16"
+    "call-bound" "^1.0.2"
+    "function.prototype.name" "^1.1.6"
+    "has-tostringtag" "^1.0.2"
+    "is-async-function" "^2.0.0"
+    "is-date-object" "^1.1.0"
+    "is-finalizationregistry" "^1.1.0"
+    "is-generator-function" "^1.0.10"
+    "is-regex" "^1.2.1"
+    "is-weakref" "^1.0.2"
+    "isarray" "^2.0.5"
+    "which-boxed-primitive" "^1.1.0"
+    "which-collection" "^1.0.2"
+    "which-typed-array" "^1.1.16"
 
-which-collection@^1.0.2:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which-collection/-/which-collection-1.0.2.tgz"
-  integrity sha1-Yn73YkOSChB+fOjpYZHevksWwqA=
+"which-collection@^1.0.2":
+  "integrity" "sha1-Yn73YkOSChB+fOjpYZHevksWwqA="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which-collection/-/which-collection-1.0.2.tgz"
+  "version" "1.0.2"
   dependencies:
-    is-map "^2.0.3"
-    is-set "^2.0.3"
-    is-weakmap "^2.0.2"
-    is-weakset "^2.0.3"
+    "is-map" "^2.0.3"
+    "is-set" "^2.0.3"
+    "is-weakmap" "^2.0.2"
+    "is-weakset" "^2.0.3"
 
-which-typed-array@^1.1.16, which-typed-array@^1.1.18:
-  version "1.1.18"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which-typed-array/-/which-typed-array-1.1.18.tgz"
-  integrity sha1-3yOJ6/P7skanE5DpBzCp7bbOF60=
+"which-typed-array@^1.1.16", "which-typed-array@^1.1.18":
+  "integrity" "sha1-3wOELocLa4jhF1JKSzZLb8aJ+VY="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which-typed-array/-/which-typed-array-1.1.19.tgz"
+  "version" "1.1.19"
   dependencies:
-    available-typed-arrays "^1.0.7"
-    call-bind "^1.0.8"
-    call-bound "^1.0.3"
-    for-each "^0.3.3"
-    gopd "^1.2.0"
-    has-tostringtag "^1.0.2"
+    "available-typed-arrays" "^1.0.7"
+    "call-bind" "^1.0.8"
+    "call-bound" "^1.0.4"
+    "for-each" "^0.3.5"
+    "get-proto" "^1.0.1"
+    "gopd" "^1.2.0"
+    "has-tostringtag" "^1.0.2"
 
-which@^2.0.1:
-  version "2.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz"
-  integrity sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=
+"which@^2.0.1":
+  "integrity" "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz"
+  "version" "2.0.2"
   dependencies:
-    isexe "^2.0.0"
+    "isexe" "^2.0.0"
 
-word-wrap@^1.2.5:
-  version "1.2.5"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz"
-  integrity sha1-0sRcbdT7zmIaZvE2y+Mor9BBCzQ=
+"word-wrap@^1.2.5":
+  "integrity" "sha1-0sRcbdT7zmIaZvE2y+Mor9BBCzQ="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz"
+  "version" "1.2.5"
 
-wrappy@1:
-  version "1.0.2"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+"wrappy@1":
+  "integrity" "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz"
+  "version" "1.0.2"
 
-xml2js@^0.5.0:
-  version "0.5.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xml2js/-/xml2js-0.5.0.tgz"
-  integrity sha1-2UQGMfuy7YACA/rRBvJyT2LEk7c=
+"xml2js@^0.5.0":
+  "integrity" "sha1-2UQGMfuy7YACA/rRBvJyT2LEk7c="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xml2js/-/xml2js-0.5.0.tgz"
+  "version" "0.5.0"
   dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
+    "sax" ">=0.6.0"
+    "xmlbuilder" "~11.0.0"
 
-xmlbuilder@~11.0.0:
-  version "11.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xmlbuilder/-/xmlbuilder-11.0.1.tgz"
-  integrity sha1-vpuuHIoEbnazESdyY0fQrXACvrM=
+"xmlbuilder@~11.0.0":
+  "integrity" "sha1-vpuuHIoEbnazESdyY0fQrXACvrM="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/xmlbuilder/-/xmlbuilder-11.0.1.tgz"
+  "version" "11.0.1"
 
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yallist/-/yallist-4.0.0.tgz"
-  integrity sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=
+"yallist@^4.0.0":
+  "integrity" "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yallist/-/yallist-4.0.0.tgz"
+  "version" "4.0.0"
 
-yauzl@^2.3.1:
-  version "2.10.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yauzl/-/yauzl-2.10.0.tgz"
-  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+"yauzl@^2.3.1":
+  "integrity" "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yauzl/-/yauzl-2.10.0.tgz"
+  "version" "2.10.0"
   dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"
+    "buffer-crc32" "~0.2.3"
+    "fd-slicer" "~1.1.0"
 
-yazl@^2.2.2:
-  version "2.5.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yazl/-/yazl-2.5.1.tgz"
-  integrity sha1-o9ZdPdZZpbCTeFDoYJ8i//orXDU=
+"yazl@^2.2.2":
+  "integrity" "sha1-o9ZdPdZZpbCTeFDoYJ8i//orXDU="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yazl/-/yazl-2.5.1.tgz"
+  "version" "2.5.1"
   dependencies:
-    buffer-crc32 "~0.2.3"
+    "buffer-crc32" "~0.2.3"
 
-yocto-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz"
-  integrity sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=
+"yocto-queue@^0.1.0":
+  "integrity" "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs="
+  "resolved" "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz"
+  "version" "0.1.0"


### PR DESCRIPTION
We have been running on node 20. https://github.com/ewanharris/vscode-versions
We have also been permitting versions of vscode that run our logic under node 18. 

This can cause a lot of issues because our compiler and tests will never run the logic with this version.
This bumps the version up to the latest release.

C# and C#DK generally focus on supporting 'latest' versions of code, so I think we are ok with what we have here for versioning.