### PR TITLE
Skip CHCP Calls and Utilize DOTNET_CLI_UI_LANGUAGE

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -118,8 +118,7 @@ Please set the PATH to a dotnet host that matches the architecture ${requirement
             return [];
         }
 
-        const findSDKsCommand = await this.setCodePage() ? CommandExecutor.makeCommand(`chcp`, [`65001`, `|`, `"${existingPath}"`, '--list-sdks']) :
-            CommandExecutor.makeCommand(`"${existingPath}"`, ['--list-sdks']);
+        const findSDKsCommand = CommandExecutor.makeCommand(`"${existingPath}"`, ['--list-sdks']);
 
         const sdkInfo = await (this.executor!).execute(findSDKsCommand, { dotnetInstallToolCacheTtlMs: DOTNET_INFORMATION_CACHE_DURATION_MS }, false).then((result) =>
         {
@@ -142,13 +141,6 @@ Please set the PATH to a dotnet host that matches the architecture ${requirement
         });
 
         return sdkInfo;
-    }
-
-    private async setCodePage(): Promise<boolean>
-    {
-        // For Windows, we need to change the code page to UTF-8 to handle the output of the command. https://github.com/nodejs/node-v0.x-archive/issues/2190
-        // Only certain builds of windows support UTF 8 so we need to check that we can use it.
-        return os.platform() === 'win32' ? (await this.executor!.tryFindWorkingCommand([CommandExecutor.makeCommand('chcp', ['65001'])], { dotnetInstallToolCacheTtlMs: SYS_CMD_SEARCH_CACHE_DURATION_MS })) !== null : false;
     }
 
     public stringVersionMeetsRequirement(availableVersion: string, requestedVersion: string, requirement: IDotnetFindPathContext): boolean
@@ -275,8 +267,7 @@ Please set the PATH to a dotnet host that matches the architecture ${requirement
             return [];
         }
 
-        const findRuntimesCommand = await this.setCodePage() ? CommandExecutor.makeCommand(`chcp`, [`65001`, `|`, `"${existingPath}"`, '--list-runtimes']) :
-            CommandExecutor.makeCommand(`"${existingPath}"`, ['--list-runtimes']);
+        const findRuntimesCommand = CommandExecutor.makeCommand(`"${existingPath}"`, ['--list-runtimes']);
 
         const windowsDesktopString = 'Microsoft.WindowsDesktop.App';
         const aspnetCoreString = 'Microsoft.AspNetCore.App';

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -248,7 +248,7 @@ Please set the PATH to a dotnet host that matches the architecture ${requirement
 
     private stringArchitectureMeetsRequirement(outputArchitecture: string, requiredArchitecture: string | null | undefined): boolean
     {
-        return !requiredArchitecture || outputArchitecture === '' || FileUtilities.dotnetInfoArchToNodeArch(outputArchitecture, this.workerContext.eventStream) === requiredArchitecture;
+        return !requiredArchitecture || !outputArchitecture || FileUtilities.dotnetInfoArchToNodeArch(outputArchitecture, this.workerContext.eventStream) === requiredArchitecture;
     }
 
     private allowPreview(availableVersion: string, requirement: IDotnetFindPathContext): boolean

--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -443,10 +443,20 @@ ${stderr}`));
 
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             options.encoding = 'utf8';
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            options.env ??= { ...process.env };
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            options.env.DOTNET_CLI_UI_LANGUAGE ??= 'en-US';
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            options.env.DOTNET_NOLOGO ??= 'true';
         }
         else
         {
-            options = { cwd: path.resolve(__dirname), shell: true, encoding: 'utf8' };
+            options = {
+                cwd: path.resolve(__dirname), shell: true, encoding: 'utf8', env:
+                    { ...process.env, DOTNET_CLI_UI_LANGUAGE: 'en-US', DOTNET_NOLOGO: 'true' }
+            };
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access


### PR DESCRIPTION
Calling chcp has significant performance impacts. What we need is the line that says 'Architecture' from dotnet --info to be in english.

But, I got some help from @elinor-fung who confirmed the output of the host is not localized, so it will actually _always_ be in english.

DOTNET_CLI_UI_LANGUAGE is only respected by the SDK and related tools. So, this does help ensure the rest of the output is in english going forward. CHCP calls do not matter since we enforce the 'utf8' encoding on the terminal anyways.

This also adds NOLOGO to prevent the issue of first run exp + performance delay from it.

Testing:
- I tested setting the string to other settings such as arabic, which I did not have installed on my machine, to see if it would break if someone did not have english installed. It worked just fine. 
- I set all of my language settings (System, Formatting, VS Code to JP) and tested this change to confirm it worked.
- CDK currently called DOTNET_CLI_UI_LANGUAGE='en-us' without issue: https://devdiv.visualstudio.com/DevDiv/_git/vs-green?path=/src/netRuntimeDiscovery.ts&version=GBmain&_a=contents&line=268&lineStyle=plain&lineEnd=269&lineStartColumn=1&lineEndColumn=1
- I was worried that if we set this, somehow I would break the code for people without english or that the encoding would not be correct. It gives me some relief that this has not caused any issues for DevKit folks. 
- node by default uses process.env is the env option is undefined, so this is not a behavioral change. 

cc @lifengl