### PR TITLE
Check dotnet path without which or where first

### DIFF
--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -515,6 +515,17 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
         const validator = new DotnetConditionValidator(workerContext, utilContext);
         const finder = new DotnetPathFinder(workerContext, utilContext);
 
+        const dotnetOnShellSpawn = (await finder.findDotnetFastFromListOnly())?.[0] ?? '';
+        if (dotnetOnShellSpawn)
+        {
+            const validatedShellSpawn = await getPathIfValid(dotnetOnShellSpawn, validator, commandContext);
+            if (validatedShellSpawn)
+            {
+                loggingObserver.dispose();
+                return { dotnetPath: validatedShellSpawn };
+            }
+        }
+
         const dotnetsOnPATH = await finder.findRawPathEnvironmentSetting();
         for (const dotnetPath of dotnetsOnPATH ?? [])
         {

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -100,9 +100,13 @@ export class DotnetPathFinder implements IDotnetPathFinder
     public async findDotnetFastFromListOnly(): Promise<string[] | undefined>
     {
         const oldLookup = process.env.DOTNET_MULTILEVEL_LOOKUP;
-        process.env.DOTNET_MULTILEVEL_LOOKUP = '0'; // make it so --list-runtimes only finds the runtimes on that path: https://learn.microsoft.com/en-us/dotnet/core/compatibility/deployment/7.0/multilevel-lookup#reason-for-change
-        const finalPath = await this.getTruePath(['dotnet']);
-        return this.returnWithRestoringEnvironment(finalPath, 'DOTNET_MULTILEVEL_LOOKUP', oldLookup);
+        try {
+            process.env.DOTNET_MULTILEVEL_LOOKUP = '0'; // make it so --list-runtimes only finds the runtimes on that path: https://learn.microsoft.com/en-us/dotnet/core/compatibility/deployment/7.0/multilevel-lookup#reason-for-change
+            const finalPath = await this.getTruePath(['dotnet']);
+            return this.returnWithRestoringEnvironment(finalPath, 'DOTNET_MULTILEVEL_LOOKUP', oldLookup);
+        } finally {
+            process.env.DOTNET_MULTILEVEL_LOOKUP = oldLookup; // Ensure the environment variable is always restored
+        }
     }
 
     /**


### PR DESCRIPTION
Which and where can be slow to find. For the common case which we want to make fast, we can just check 'dotnet' first and see if that works.

Note: Ideally, this function would only return a string, but that would require writing a wrapper around this return type just for this function and does not follow the other existing patterns.

With respect to tests: This should be covered by the existing 'find path' tests.

cc @lifengl