### PR TITLE
Handle Corrupt Install Script Installs

### DIFF
--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -326,6 +326,23 @@ suite('DotnetCoreAcquisitionExtension End to End', function ()
         await installMultipleVersions(['2.2', '3.0', '3.1'], 'aspnetcore');
     }).timeout(standardTimeoutTime * 2);
 
+    test('Works With Prior Incomplete or Corrupted Install', async () =>
+    {
+        const installPath = await installRuntime('9.0', 'runtime');
+        assert.isTrue(fs.existsSync(installPath), 'The path exists after install');
+        // remove the install executable but not the folder to simulate a corrupt install
+        rimraf.sync(installPath);
+        assert.isFalse(fs.existsSync(installPath), 'The path does not exist after uninstall');
+        // try to acquire again, and it should succeed
+        const _ = await installRuntime('9.0', 'runtime');
+    }).timeout(standardTimeoutTime);
+
+    test('It works if the install exists', async () =>
+    {
+        const installPath = await installRuntime('9.0', 'runtime');
+        const samePath = await installRuntime('9.0', 'runtime');
+    }).timeout(standardTimeoutTime);
+
     test('Find dotnet PATH Command Met Condition', async () =>
     {
         // install 5.0 then look for 5.0 path

--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -81,7 +81,7 @@ export class FileUtilities extends IFileUtilities
             try
             {
                 eventStream?.post(new FileToWipe(`The file ${f} may be deleted.`))
-                if (!fileExtensionsToDelete || fileExtensionsToDelete?.includes(path.extname(f).toLocaleLowerCase()) && !(f?.includes('lock')))
+                if (!fileExtensionsToDelete || fileExtensionsToDelete?.includes(path.extname(f).toLocaleLowerCase()))
                 {
                     eventStream?.post(new FileToWipe(`The file ${f} is being deleted -- if no error is reported, it should be wiped.`))
                     await fs.promises.rm(path.join(directoryToWipe, f));


### PR DESCRIPTION
The dotnet install script has a bug where it wont do the install if the folder is not empty. Sometimes it will leave a partially done install, like if killed, in which case we get to a bad state.

This fixes that by cleaning up the directory, and or checking if dotnet.exe exists, whether it works. dotnet --list-runtimes is a fast way to do this since it should only invoke the host and not need to invoke the SDK. doing just 'dotnet' will not work as that does not return 0.

Also, gets rid of the 'lock' exception since thats from the proper-lockfile lib which we don't use anymore.

Resolves: https://github.com/dotnet/vscode-dotnet-runtime/issues/2059
First scrapped attempt: https://github.com/dotnet/vscode-dotnet-runtime/pull/2106