### PR TITLE
Handle Existing Installs with Other Request Orderings Correctly

### DIFF
--- a/vscode-dotnet-runtime-extension/package-lock.json
+++ b/vscode-dotnet-runtime-extension/package-lock.json
@@ -80,7 +80,7 @@
                 "glob": "^7.2.0"
             },
             "engines": {
-                "vscode": "^1.74.0"
+                "vscode": "^1.99.0"
             },
             "optionalDependencies": {
                 "fsevents": "^2.3.3"

--- a/vscode-dotnet-runtime-library/package-lock.json
+++ b/vscode-dotnet-runtime-library/package-lock.json
@@ -44,7 +44,7 @@
 				"glob": "^7.2.0"
 			},
 			"engines": {
-				"vscode": "^1.74.0"
+				"vscode": "^1.99.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "^2.3.3"

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -68,8 +68,8 @@ You will need to restart VS Code after these changes. If PowerShell is still not
         {
             try
             {
-                let windowsFullCommand = `powershell.exe -NoProfile -NonInteractive -NoLogo -ExecutionPolicy bypass -Command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; & ${installCommand} }"`;
                 let powershellReference = 'powershell.exe';
+                let windowsFullCommand = `${powershellReference} -NoProfile -NonInteractive -NoLogo -ExecutionPolicy bypass -Command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; & ${installCommand} }"`;
                 if (winOS)
                 {
                     powershellReference = await this.verifyPowershellCanRun(install);

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -31,15 +31,14 @@ import { FileUtilities } from '../Utils/FileUtilities';
 import { InstallScriptAcquisitionWorker } from './InstallScriptAcquisitionWorker';
 
 import { IUtilityContext } from '../Utils/IUtilityContext';
-import { executeWithLock, getDotnetExecutable } from '../Utils/TypescriptUtilities';
+import { getDotnetExecutable } from '../Utils/TypescriptUtilities';
 import { WebRequestWorkerSingleton } from '../Utils/WebRequestWorkerSingleton';
-import { LOCAL_LOCK_PING_DURATION_MS } from './CacheTimeConstants';
 import { DotnetConditionValidator } from './DotnetConditionValidator';
+import { DotnetCoreAcquisitionWorker } from './DotnetCoreAcquisitionWorker';
 import { DotnetInstall } from './DotnetInstall';
 import { DotnetInstallMode } from './DotnetInstallMode';
 import { IAcquisitionInvoker } from './IAcquisitionInvoker';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
-import { IDotnetInstallationContext } from './IDotnetInstallationContext';
 import { IInstallScriptAcquisitionWorker } from './IInstallScriptAcquisitionWorker';
 
 export class AcquisitionInvoker extends IAcquisitionInvoker
@@ -58,122 +57,118 @@ You will need to restart VS Code after these changes. If PowerShell is still not
         this.fileUtilities = new FileUtilities();
     }
 
-    public async installDotnet(installationContext: IDotnetInstallationContext, installObj: DotnetInstall): Promise<void>
+    public async installDotnet(install: DotnetInstall): Promise<void>
     {
-        return executeWithLock(this.eventStream, false, installObj.installId,
-            LOCAL_LOCK_PING_DURATION_MS, installationContext.timeoutSeconds * 1000,
-            async (installContext: IDotnetInstallationContext, install: DotnetInstall) =>
-            {
-                const winOS = os.platform() === 'win32';
-                const installCommand = await this.getInstallCommand(installContext.version, installContext.installDir, installContext.installMode, installContext.architecture);
+        const installDir = this.workerContext.installDirectoryProvider.getInstallDir(install.installId);
+        const winOS = os.platform() === 'win32';
+        const installCommand = await this.getInstallCommand(this.workerContext.acquisitionContext.version, installDir, this.workerContext.acquisitionContext.mode, this.workerContext.acquisitionContext.architecture);
+        const dotnetPath = path.join(installDir, getDotnetExecutable());
 
-                return new Promise<void>(async (resolve, reject) =>
+        return new Promise<void>(async (resolve, reject) =>
+        {
+            try
+            {
+                let windowsFullCommand = `powershell.exe -NoProfile -NonInteractive -NoLogo -ExecutionPolicy bypass -Command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; & ${installCommand} }"`;
+                let powershellReference = 'powershell.exe';
+                if (winOS)
                 {
+                    powershellReference = await this.verifyPowershellCanRun(install);
+                    windowsFullCommand = windowsFullCommand.replace('powershell.exe', powershellReference);
+                }
+
+                // The install script can leave behind a directory in an invalid install state. Make sure the executable is present at the very least.
+                if (await this.fileUtilities.exists(installDir))
+                {
+                    if (await this.fileUtilities.exists(dotnetPath))
+                    {
+                        const validator = new DotnetConditionValidator(this.workerContext, this.utilityContext);
+                        const meetsRequirement = await validator.dotnetMeetsRequirement(dotnetPath, { acquireContext: this.workerContext.acquisitionContext, versionSpecRequirement: 'equal' });
+                        if (meetsRequirement)
+                        {
+                            return resolve();
+                        }
+                    }
+
                     try
                     {
-                        let windowsFullCommand = `powershell.exe -NoProfile -NonInteractive -NoLogo -ExecutionPolicy bypass -Command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; & ${installCommand} }"`;
-                        let powershellReference = 'powershell.exe';
-                        if (winOS)
-                        {
-                            powershellReference = await this.verifyPowershellCanRun(installContext, install);
-                            windowsFullCommand = windowsFullCommand.replace('powershell.exe', powershellReference);
-                        }
-
-                        // The install script can leave behind a directory in an invalid install state. Make sure the executable is present at the very least.
-                        if (await this.fileUtilities.exists(installContext.installDir))
-                        {
-                            const dotnetPath = path.join(installContext.installDir, getDotnetExecutable());
-                            if (await this.fileUtilities.exists(dotnetPath))
-                            {
-                                const validator = new DotnetConditionValidator(this.workerContext, this.utilityContext);
-                                const meetsRequirement = await validator.dotnetMeetsRequirement(dotnetPath, { acquireContext: installContext, versionSpecRequirement: 'equal' });
-                                if (meetsRequirement)
-                                {
-                                    return resolve();
-                                }
-                            }
-
-                            try
-                            {
-                                await fs.promises.rm(installContext.installDir, { recursive: true, force: true });
-                            }
-                            catch (err: any)
-                            {
-                                this.eventStream.post(new SuppressedAcquisitionError(err, `${installContext.installDir} could not be not removed, and it has a corrupted install. Please remove it manually.`));
-                            }
-                        }
-
-                        cp.exec(winOS ? windowsFullCommand : installCommand,
-                            { cwd: process.cwd(), maxBuffer: 500 * 1024, timeout: 1000 * installContext.timeoutSeconds, killSignal: 'SIGKILL' },
-                            async (error, stdout, stderr) =>
-                            {
-                                if (stdout)
-                                {
-                                    this.eventStream.post(new DotnetAcquisitionScriptOutput(install, TelemetryUtilities.HashAllPaths(stdout)));
-                                }
-                                if (stderr)
-                                {
-                                    this.eventStream.post(new DotnetAcquisitionScriptOutput(install, `STDERR: ${TelemetryUtilities.HashAllPaths(stderr)}`));
-                                }
-                                if (this.looksLikeBadExecutionPolicyError(stderr))
-                                {
-                                    const badPolicyError = new EventBasedError('PowershellBadExecutionPolicy', `Your powershell execution policy does not allow script execution, so we can't automate the installation.
-Please read more at https://go.microsoft.com/fwlink/?LinkID=135170`);
-                                    this.eventStream.post(new PowershellBadExecutionPolicy(badPolicyError, install));
-                                    reject(badPolicyError);
-                                }
-                                if ((this.looksLikeBadLanguageModeError(stderr) || error?.code === 1) && await this.badLanguageModeSet(powershellReference))
-                                {
-                                    const badModeError = new EventBasedError('PowershellBadLanguageMode', `Your Language Mode disables PowerShell language features needed to install .NET. Read more at: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes.
-If you cannot change this flag, try setting a custom existingDotnetPath via the instructions here: https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md.`);
-                                    this.eventStream.post(new PowershellBadLanguageMode(badModeError, install));
-                                    reject(badModeError);
-                                }
-                                if (error)
-                                {
-                                    if (!(await WebRequestWorkerSingleton.getInstance().isOnline(installContext.timeoutSeconds, this.eventStream)))
-                                    {
-                                        const offlineError = new EventBasedError('DotnetOfflineFailure', 'No internet connection detected: Cannot install .NET');
-                                        this.eventStream.post(new DotnetOfflineFailure(offlineError, install));
-                                        reject(offlineError);
-                                    }
-                                    else if (error.signal === 'SIGKILL')
-                                    {
-                                        const newError = new EventBasedError('DotnetAcquisitionTimeoutError',
-                                            `${timeoutConstants.timeoutMessage}, MESSAGE: ${error.message}, CODE: ${error.code}, KILLED: ${error.killed}`, error.stack);
-                                        this.eventStream.post(new DotnetAcquisitionTimeoutError(error, install, installContext.timeoutSeconds));
-                                        reject(newError);
-                                    }
-                                    else
-                                    {
-                                        const newError = new EventBasedError('DotnetAcquisitionInstallError',
-                                            `${timeoutConstants.timeoutMessage}, MESSAGE: ${error.message}, CODE: ${error.code}, SIGNAL: ${error.signal}`, error.stack);
-                                        this.eventStream.post(new DotnetAcquisitionInstallError(newError, install));
-                                        reject(newError);
-                                    }
-                                }
-                                else if ((stderr?.length ?? 0) > 0)
-                                {
-                                    this.eventStream.post(new DotnetAcquisitionCompleted(install, installContext.dotnetPath, installContext.version));
-                                    resolve();
-                                }
-                                else
-                                {
-                                    this.eventStream.post(new DotnetAcquisitionCompleted(install, installContext.dotnetPath, installContext.version));
-                                    resolve();
-                                }
-                            });
+                        await fs.promises.rm(installDir, { recursive: true, force: true });
                     }
-                    catch (error: any)
+                    catch (err: any)
                     {
-                        // Remove this when https://github.com/typescript-eslint/typescript-eslint/issues/2728 is done
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                        const newError = new EventBasedError('DotnetAcquisitionUnexpectedError', error?.message, error?.stack);
-                        this.eventStream.post(new DotnetAcquisitionUnexpectedError(newError, install));
-                        reject(newError);
+                        this.eventStream.post(new SuppressedAcquisitionError(err, `${installDir} could not be not removed, and it has a corrupted install. Please remove it manually.`));
                     }
-                });
-            }, installationContext, installObj);
+                }
+
+                cp.exec(winOS ? windowsFullCommand : installCommand,
+                    { cwd: process.cwd(), maxBuffer: 500 * 1024, timeout: 1000 * this.workerContext.timeoutSeconds, killSignal: 'SIGKILL' },
+                    async (error, stdout, stderr) =>
+                    {
+                        if (stdout)
+                        {
+                            this.eventStream.post(new DotnetAcquisitionScriptOutput(install, TelemetryUtilities.HashAllPaths(stdout)));
+                        }
+                        if (stderr)
+                        {
+                            this.eventStream.post(new DotnetAcquisitionScriptOutput(install, `STDERR: ${TelemetryUtilities.HashAllPaths(stderr)}`));
+                        }
+                        if (this.looksLikeBadExecutionPolicyError(stderr))
+                        {
+                            const badPolicyError = new EventBasedError('PowershellBadExecutionPolicy', `Your powershell execution policy does not allow script execution, so we can't automate the installation.
+Please read more at https://go.microsoft.com/fwlink/?LinkID=135170`);
+                            this.eventStream.post(new PowershellBadExecutionPolicy(badPolicyError, install));
+                            reject(badPolicyError);
+                        }
+                        if ((this.looksLikeBadLanguageModeError(stderr) || error?.code === 1) && await this.badLanguageModeSet(powershellReference))
+                        {
+                            const badModeError = new EventBasedError('PowershellBadLanguageMode', `Your Language Mode disables PowerShell language features needed to install .NET. Read more at: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes.
+If you cannot change this flag, try setting a custom existingDotnetPath via the instructions here: https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md.`);
+                            this.eventStream.post(new PowershellBadLanguageMode(badModeError, install));
+                            reject(badModeError);
+                        }
+                        if (error)
+                        {
+                            if (!(await WebRequestWorkerSingleton.getInstance().isOnline(this.workerContext.timeoutSeconds, this.eventStream)))
+                            {
+                                const offlineError = new EventBasedError('DotnetOfflineFailure', 'No internet connection detected: Cannot install .NET');
+                                this.eventStream.post(new DotnetOfflineFailure(offlineError, install));
+                                reject(offlineError);
+                            }
+                            else if (error.signal === 'SIGKILL')
+                            {
+                                const newError = new EventBasedError('DotnetAcquisitionTimeoutError',
+                                    `${timeoutConstants.timeoutMessage}, MESSAGE: ${error.message}, CODE: ${error.code}, KILLED: ${error.killed}`, error.stack);
+                                this.eventStream.post(new DotnetAcquisitionTimeoutError(error, install, this.workerContext.timeoutSeconds));
+                                reject(newError);
+                            }
+                            else
+                            {
+                                const newError = new EventBasedError('DotnetAcquisitionInstallError',
+                                    `${timeoutConstants.timeoutMessage}, MESSAGE: ${error.message}, CODE: ${error.code}, SIGNAL: ${error.signal}`, error.stack);
+                                this.eventStream.post(new DotnetAcquisitionInstallError(newError, install));
+                                reject(newError);
+                            }
+                        }
+                        else if ((stderr?.length ?? 0) > 0)
+                        {
+                            this.eventStream.post(new DotnetAcquisitionCompleted(install, dotnetPath, this.workerContext.acquisitionContext.version));
+                            resolve();
+                        }
+                        else
+                        {
+                            this.eventStream.post(new DotnetAcquisitionCompleted(install, dotnetPath, this.workerContext.acquisitionContext.version));
+                            resolve();
+                        }
+                    });
+            }
+            catch (error: any)
+            {
+                // Remove this when https://github.com/typescript-eslint/typescript-eslint/issues/2728 is done
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                const newError = new EventBasedError('DotnetAcquisitionUnexpectedError', error?.message, error?.stack);
+                this.eventStream.post(new DotnetAcquisitionUnexpectedError(newError, install));
+                reject(newError);
+            }
+        });
     }
 
     private looksLikeBadExecutionPolicyError(stderr: string): boolean
@@ -222,15 +217,15 @@ At dotnet-install.ps1:1189 char:5
         }
     }
 
-    private async getInstallCommand(version: string, dotnetInstallDir: string, installMode: DotnetInstallMode, architecture: string): Promise<string>
+    private async getInstallCommand(version: string, dotnetInstallDir: string, installMode?: DotnetInstallMode, architecture?: string | null): Promise<string>
     {
-        const arch = this.fileUtilities.nodeArchToDotnetArch(architecture, this.eventStream);
+        const arch = this.fileUtilities.nodeArchToDotnetArch(architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture(), this.eventStream);
         let args = [
             '-InstallDir', this.escapeFilePath(dotnetInstallDir),
             '-Version', version,
             '-Verbose'
         ];
-        if (installMode === 'runtime')
+        if (installMode === 'runtime' || !installMode)
         {
             args = args.concat('-Runtime', 'dotnet');
         }
@@ -267,7 +262,7 @@ At dotnet-install.ps1:1189 char:5
      * @remarks Some users have reported not having powershell.exe or having execution policy that fails property evaluation functions in powershell install scripts.
      * We use this function to throw better errors if powershell is not configured correctly.
      */
-    private async verifyPowershellCanRun(installContext: IDotnetInstallationContext, installId: DotnetInstall): Promise<string>
+    private async verifyPowershellCanRun(installId: DotnetInstall): Promise<string>
     {
         let knownError = false;
         let error = null;

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -2,14 +2,13 @@
 *  Licensed to the .NET Foundation under one or more agreements.
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
-import * as os from 'os';
-import { DotnetFindPathDidNotMeetCondition, DotnetUnableToCheckPATHArchitecture } from '../EventStream/EventStreamEvents';
+import { DotnetConditionsValidated, DotnetFindPathDidNotMeetCondition, DotnetUnableToCheckPATHArchitecture } from '../EventStream/EventStreamEvents';
 import { IDotnetFindPathContext } from '../IDotnetFindPathContext';
 import { CommandExecutor } from '../Utils/CommandExecutor';
 import { FileUtilities } from '../Utils/FileUtilities';
 import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { IUtilityContext } from '../Utils/IUtilityContext';
-import { DOTNET_INFORMATION_CACHE_DURATION_MS, SYS_CMD_SEARCH_CACHE_DURATION_MS } from './CacheTimeConstants';
+import { DOTNET_INFORMATION_CACHE_DURATION_MS } from './CacheTimeConstants';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IDotnetConditionValidator } from './IDotnetConditionValidator';
 import { IDotnetListInfo } from './IDotnetListInfo';
@@ -38,6 +37,7 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
                     this.stringVersionMeetsRequirement(sdk.version, requirement.acquireContext.version, requirement) && this.allowPreview(sdk.version, requirement);
             }))
             {
+                this.workerContext.eventStream.post(new DotnetConditionsValidated(`${dotnetExecutablePath} satisfies the conditions.`));
                 return true;
             }
         }
@@ -51,6 +51,7 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
                     this.stringVersionMeetsRequirement(runtime.version, requirement.acquireContext.version, requirement) && this.allowPreview(runtime.version, requirement);
             }))
             {
+                this.workerContext.eventStream.post(new DotnetConditionsValidated(`${dotnetExecutablePath} satisfies the conditions.`));
                 return true;
             }
         }

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -35,7 +35,8 @@ import
     DotnetWSLSecurityError,
     EventBasedError,
     EventCancellationError,
-    SuppressedAcquisitionError
+    SuppressedAcquisitionError,
+    UtilizingExistingInstallPromise
 } from '../EventStream/EventStreamEvents';
 import * as versionUtils from './VersionUtilities';
 
@@ -52,7 +53,7 @@ import { IFileUtilities } from '../Utils/IFileUtilities';
 import { getInstallFromContext, getInstallIdCustomArchitecture } from '../Utils/InstallIdUtilities';
 import { IUtilityContext } from '../Utils/IUtilityContext';
 import { executeWithLock, isRunningUnderWSL } from '../Utils/TypescriptUtilities';
-import { DOTNET_INFORMATION_CACHE_DURATION_MS, GLOBAL_LOCK_PING_DURATION_MS } from './CacheTimeConstants';
+import { DOTNET_INFORMATION_CACHE_DURATION_MS, GLOBAL_LOCK_PING_DURATION_MS, LOCAL_LOCK_PING_DURATION_MS } from './CacheTimeConstants';
 import { directoryProviderFactory } from './DirectoryProviderFactory';
 import
 {
@@ -66,7 +67,6 @@ import { GlobalInstallerResolver } from './GlobalInstallerResolver';
 import { IAcquisitionInvoker } from './IAcquisitionInvoker';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IDotnetCoreAcquisitionWorker } from './IDotnetCoreAcquisitionWorker';
-import { IDotnetInstallationContext } from './IDotnetInstallationContext';
 import { IGlobalInstaller } from './IGlobalInstaller';
 import { InstallationGraveyard } from './InstallationGraveyard';
 import
@@ -275,6 +275,7 @@ To keep your .NET version up to date, please reconnect to the internet at your s
         const existingAcquisitionPromise = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getPromise(install, context.acquisitionContext);
         if (existingAcquisitionPromise)
         {
+            context.eventStream.post(new UtilizingExistingInstallPromise(`The requested version ${JSON.stringify(install)} is already being acquired by another extension. Returning the result of it's request when finished.`));
             return { dotnetPath: existingAcquisitionPromise } as IDotnetAcquireResult;
         }
         else
@@ -322,56 +323,55 @@ To keep your .NET version up to date, please reconnect to the internet at your s
     private async acquireLocalCore(context: IAcquisitionWorkerContext, mode: DotnetInstallMode, install: DotnetInstall, acquisitionInvoker: IAcquisitionInvoker): Promise<string>
     {
         const version = context.acquisitionContext.version!;
-        this.checkForPartialInstalls(context, install).catch(() => {});
+        await this.checkForPartialInstalls(context, install).catch(() => {});
 
-        let installedVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls('installed', context.installDirectoryProvider);
-        const dotnetInstallDir = context.installDirectoryProvider.getInstallDir(install.installId);
-        const dotnetPath = path.join(dotnetInstallDir, this.dotnetExecutable);
-
-        if (mode === 'sdk')
-        {
-            const installExists = await this.file.exists(dotnetPath);
-            const noInstallsInInstalledList = (installedVersions?.length ?? 0) === 0;
-            if (installExists && noInstallsInInstalledList)
+        return executeWithLock(context.eventStream, false, install.installId, LOCAL_LOCK_PING_DURATION_MS, context.timeoutSeconds * 1000,
+            async () =>
             {
-                // The education bundle already laid down a local install, add it to our managed installs
-                installedVersions = await InstallTrackerSingleton.getInstance(context.eventStream,
-                    context.extensionState).checkForUnrecordedLocalSDKSuccessfulInstall(context, dotnetInstallDir, installedVersions);
+                let installedVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls('installed', context.installDirectoryProvider);
+                const dotnetInstallDir = context.installDirectoryProvider.getInstallDir(install.installId);
+                const dotnetPath = path.join(dotnetInstallDir, this.dotnetExecutable);
+
+                if (mode === 'sdk')
+                {
+                    const installExists = await this.file.exists(dotnetPath);
+                    const noInstallsInInstalledList = (installedVersions?.length ?? 0) === 0;
+                    if (installExists && noInstallsInInstalledList)
+                    {
+                        // The education bundle already laid down a local install, add it to our managed installs
+                        installedVersions = await InstallTrackerSingleton.getInstance(context.eventStream,
+                            context.extensionState).checkForUnrecordedLocalSDKSuccessfulInstall(context, dotnetInstallDir, installedVersions);
+                    }
+                }
+
+                context.acquisitionContext.installType ??= 'local'; // Before this API param existed, all calls were for local types.
+                context.acquisitionContext.architecture ??= this.getDefaultInternalArchitecture(context.acquisitionContext.architecture);
+
+                const existingInstall = await this.getExistingInstall(context, installedVersions, install, dotnetPath);
+                if (existingInstall !== null)
+                {
+                    return existingInstall;
+                }
+
+                // We update the extension state to indicate we're starting a .NET Core installation.
+                await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).trackInstallingVersion(context, install);
+                context.eventStream.post(new DotnetAcquisitionStarted(install, version, context.acquisitionContext.requestingExtensionId));
+
+
+                await acquisitionInvoker.installDotnet(install).catch((reason) =>
+                {
+                    throw reason; // This will get handled and cast into an event based error by its caller.
+                });
+
+                context.installationValidator.validateDotnetInstall(install, dotnetPath);
+
+                await this.removeMatchingLegacyInstall(context, installedVersions, version);
+                await this.tryCleanUpInstallGraveyard(context);
+
+                await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).reclassifyInstallingVersionToInstalled(context, install);
+                return dotnetPath;
             }
-        }
-
-        const existingInstall = await this.getExistingInstall(context, installedVersions, install, dotnetPath);
-        if (existingInstall !== null)
-        {
-            return existingInstall;
-        }
-
-        // We update the extension state to indicate we're starting a .NET Core installation.
-        await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).trackInstallingVersion(context, install);
-
-        const installContext = {
-            installDir: dotnetInstallDir,
-            version,
-            dotnetPath,
-            timeoutSeconds: context.timeoutSeconds,
-            installMode: mode,
-            installType: context.acquisitionContext.installType ?? 'local', // Before this API param existed, all calls were for local types.
-            architecture: context.acquisitionContext.architecture ?? this.getDefaultInternalArchitecture(context.acquisitionContext.architecture),
-        } as IDotnetInstallationContext;
-        context.acquisitionContext.architecture = installContext.architecture;
-        context.eventStream.post(new DotnetAcquisitionStarted(install, version, context.acquisitionContext.requestingExtensionId));
-        await acquisitionInvoker.installDotnet(installContext, install).catch((reason) =>
-        {
-            throw reason; // This will get handled and cast into an event based error by its caller.
-        });
-        context.installationValidator.validateDotnetInstall(install, dotnetPath);
-
-        await this.removeMatchingLegacyInstall(context, installedVersions, version);
-        await this.tryCleanUpInstallGraveyard(context);
-
-        await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).reclassifyInstallingVersionToInstalled(context, install);
-
-        return dotnetPath;
+        );
     }
 
     private async getExistingInstall(context: IAcquisitionWorkerContext, installedVersions: InstallRecord[], install: DotnetInstall, dotnetPath: string): Promise<string | null>
@@ -433,19 +433,26 @@ To keep your .NET version up to date, please reconnect to the internet at your s
 
     private async checkForPartialInstalls(context: IAcquisitionWorkerContext, installId: DotnetInstall)
     {
-        const installingVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls('installing', context.installDirectoryProvider);
-        const partialInstall = installingVersions?.some(x => x.dotnetInstall.installId === installId.installId);
+        await executeWithLock(context.eventStream, false, installId.installId,
+            LOCAL_LOCK_PING_DURATION_MS, context.timeoutSeconds * 1000,
+            async () =>
+            {
 
-        // Don't count it as partial if the promise is still being resolved.
-        // The promises get wiped out upon reload, so we can check this.
-        if (partialInstall && await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getPromise(installId, context.acquisitionContext, true) === null)
-        {
-            // Partial install, we never updated our extension to no longer be 'installing'. Maybe someone killed the vscode process or we failed in an unexpected way.
-            context.eventStream.post(new DotnetAcquisitionPartialInstallation(installId));
+                const installingVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls('installing', context.installDirectoryProvider);
+                const partialInstall = installingVersions?.some(x => x.dotnetInstall.installId === installId.installId);
 
-            // Delete the existing local files so we can re-install. For global installs, let the installer handle it.
-            await this.uninstallLocal(context, installId);
-        }
+                // Don't count it as partial if the promise is still being resolved.
+                // The promises get wiped out upon reload, so we can check this.
+                if (partialInstall && await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getPromise(installId, context.acquisitionContext, true) === null)
+                {
+                    // Partial install, we never updated our extension to no longer be 'installing'. Maybe someone killed the vscode process or we failed in an unexpected way.
+                    context.eventStream.post(new DotnetAcquisitionPartialInstallation(installId));
+
+                    // Delete the existing local files so we can re-install. For global installs, let the installer handle it.
+                    await this.uninstallLocal(context, installId);
+                }
+            }
+        );
     }
 
     public async tryCleanUpInstallGraveyard(context: IAcquisitionWorkerContext): Promise<void>
@@ -508,7 +515,7 @@ To keep your .NET version up to date, please reconnect to the internet at your s
 
         const installingVersion = await globalInstallerResolver.getFullySpecifiedVersion();
         context.eventStream.post(new DotnetGlobalVersionResolutionCompletionEvent(`The version we resolved that was requested is: ${installingVersion}.`));
-        this.checkForPartialInstalls(context, install).catch(() => {});
+        await this.checkForPartialInstalls(context, install).catch(() => {});
 
         const installedVersions = await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).getExistingInstalls('installed', context.installDirectoryProvider);
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/IAcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IAcquisitionInvoker.ts
@@ -2,17 +2,18 @@
 *  Licensed to the .NET Foundation under one or more agreements.
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
-import { InstallationValidator } from './InstallationValidator';
 import { IEventStream } from '../EventStream/EventStream';
-import { IDotnetInstallationContext } from './IDotnetInstallationContext';
-import { IInstallationValidator } from './IInstallationValidator';
 import { DotnetInstall } from './DotnetInstall';
+import { IInstallationValidator } from './IInstallationValidator';
+import { InstallationValidator } from './InstallationValidator';
 
-export abstract class IAcquisitionInvoker {
+export abstract class IAcquisitionInvoker
+{
     public readonly installationValidator: IInstallationValidator;
-    constructor(protected readonly eventStream: IEventStream) {
+    constructor(protected readonly eventStream: IEventStream)
+    {
         this.installationValidator = new InstallationValidator(eventStream);
     }
 
-    public abstract installDotnet(installContext: IDotnetInstallationContext, install : DotnetInstall): Promise<void>;
+    public abstract installDotnet(install: DotnetInstall): Promise<void>;
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -903,6 +903,11 @@ export class DotnetUnableToCheckPATHArchitecture extends DotnetVisibleWarningEve
     public readonly eventName = 'DotnetUnableToCheckPATHArchitecture';
 }
 
+export class UtilizingExistingInstallPromise extends DotnetCustomMessageEvent
+{
+    public readonly eventName = 'UtilizingExistingInstallPromise';
+}
+
 export class DotnetVersionCategorizedEvent extends DotnetCustomMessageEvent
 {
     public readonly eventName = 'DotnetVersionCategorizedEvent';
@@ -1151,6 +1156,11 @@ export class DotnetFindPathLookupRealPATH extends DotnetCustomMessageEvent
 export class DotnetFindPathRealPATHFound extends DotnetCustomMessageEvent
 {
     public readonly eventName = 'DotnetFindPathRealPATHFound';
+}
+
+export class DotnetConditionsValidated extends DotnetCustomMessageEvent
+{
+    public readonly eventName = 'DotnetConditionsValidated';
 }
 
 export class DotnetFindPathHostFxrResolutionLookup extends DotnetCustomMessageEvent

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -162,7 +162,7 @@ export class NodeIPCMutex
                 catch (err: any)
                 {
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                    return reject(err?.message && err?.name ? err as Error : new Error(`Action: ${actionId} Failed to acquire lock: ${JSON.stringify(err ?? '')}`));
+                    return reject(err?.message && err?.name ? err as Error : new Error(`Action: ${actionId} Failed During Execution: ${JSON.stringify(err ?? '')}`));
                 }
                 finally
                 {

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -93,7 +93,7 @@ export class NoInstallAcquisitionInvoker extends IAcquisitionInvoker
         const testInstallContext = {
             version: install.version,
             installMode: install.installMode,
-            architecture: install.architecture,
+            architecture: install.architecture ?? 'null',
             dotnetPath: path.join(this.path, getDotnetExecutable()) ?? path.join(this.workerContext.installDirectoryProvider.getInstallDir(install.installId), getDotnetExecutable()),
             installDir: this.path ?? this.workerContext.installDirectoryProvider.getInstallDir(install.installId),
             installType: install.isGlobal ? 'global' : 'local',
@@ -104,7 +104,7 @@ export class NoInstallAcquisitionInvoker extends IAcquisitionInvoker
         {
 
             this.eventStream.post(new TestAcquireCalled(testInstallContext));
-            const install = GetDotnetInstallInfo(testInstallContext.version, testInstallContext.installMode, 'local', testInstallContext.architecture)
+            const install = GetDotnetInstallInfo(testInstallContext.version, testInstallContext.installMode, 'local', testInstallContext.architecture ?? 'null')
             this.eventStream.post(new DotnetAcquisitionCompleted(
                 install, testInstallContext.dotnetPath, testInstallContext.version));
             resolve();

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -108,7 +108,6 @@ export class NoInstallAcquisitionInvoker extends IAcquisitionInvoker
             this.eventStream.post(new DotnetAcquisitionCompleted(
                 install, testInstallContext.dotnetPath, testInstallContext.version));
             resolve();
-
         });
     }
 }

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -36,6 +36,7 @@ import { ICommandExecutor } from '../../Utils/ICommandExecutor';
 import { IFileUtilities } from '../../Utils/IFileUtilities';
 import { IUtilityContext } from '../../Utils/IUtilityContext';
 import { IVSCodeEnvironment } from '../../Utils/IVSCodeEnvironment';
+import { getDotnetExecutable } from '../../Utils/TypescriptUtilities';
 import { WebRequestWorkerSingleton } from '../../Utils/WebRequestWorkerSingleton';
 import { getMockUtilityContext } from '../unit/TestUtility';
 
@@ -81,25 +82,35 @@ export class MockEventStream implements IEventStream
 
 export class NoInstallAcquisitionInvoker extends IAcquisitionInvoker
 {
-    public installDotnet(installContext: IDotnetInstallationContext): Promise<void>
-    {
-        return new Promise<void>((resolve, reject) =>
-        {
-            this.eventStream.post(new TestAcquireCalled(installContext));
-            const install = GetDotnetInstallInfo(installContext.version, installContext.installMode, 'local', installContext.architecture)
-            this.eventStream.post(new DotnetAcquisitionCompleted(
-                install, installContext.dotnetPath, installContext.version));
-            resolve();
-
-        });
-    }
-
-    constructor(eventStream: IEventStream, worker: MockDotnetCoreAcquisitionWorker)
+    constructor(eventStream: IEventStream, worker: MockDotnetCoreAcquisitionWorker, private readonly workerContext: IAcquisitionWorkerContext, private readonly path: string)
     {
         super(eventStream);
         worker.enableNoInstallInvoker();
     }
 
+    public installDotnet(install: DotnetInstall): Promise<void>
+    {
+        const testInstallContext = {
+            version: install.version,
+            installMode: install.installMode,
+            architecture: install.architecture,
+            dotnetPath: path.join(this.path, getDotnetExecutable()) ?? path.join(this.workerContext.installDirectoryProvider.getInstallDir(install.installId), getDotnetExecutable()),
+            installDir: this.path ?? this.workerContext.installDirectoryProvider.getInstallDir(install.installId),
+            installType: install.isGlobal ? 'global' : 'local',
+            timeoutSeconds: testDefaultTimeoutTimeMs,
+        } as IDotnetInstallationContext
+
+        return new Promise<void>((resolve, reject) =>
+        {
+
+            this.eventStream.post(new TestAcquireCalled(testInstallContext));
+            const install = GetDotnetInstallInfo(testInstallContext.version, testInstallContext.installMode, 'local', testInstallContext.architecture)
+            this.eventStream.post(new DotnetAcquisitionCompleted(
+                install, testInstallContext.dotnetPath, testInstallContext.version));
+            resolve();
+
+        });
+    }
 }
 
 export class MockDotnetCoreAcquisitionWorker extends DotnetCoreAcquisitionWorker
@@ -123,7 +134,7 @@ export class MockDotnetCoreAcquisitionWorker extends DotnetCoreAcquisitionWorker
 
 export class RejectingAcquisitionInvoker extends IAcquisitionInvoker
 {
-    public installDotnet(installContext: IDotnetInstallationContext): Promise<void>
+    public installDotnet(install: DotnetInstall): Promise<void>
     {
         return new Promise<void>((resolve, reject) =>
         {
@@ -134,7 +145,7 @@ export class RejectingAcquisitionInvoker extends IAcquisitionInvoker
 
 export class ErrorAcquisitionInvoker extends IAcquisitionInvoker
 {
-    public installDotnet(installContext: IDotnetInstallationContext): Promise<void>
+    public installDotnet(install: DotnetInstall): Promise<void>
     {
         throw new EventBasedError('MockErrorAcquisitionInvokerFailure', 'Command Failed');
     }

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -74,7 +74,8 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function ()
     function setupWorker(workerContext: IAcquisitionWorkerContext, eventStream: IEventStream): [MockDotnetCoreAcquisitionWorker, IAcquisitionInvoker]
     {
         const acquisitionWorker = getMockAcquisitionWorker(workerContext);
-        const invoker = new NoInstallAcquisitionInvoker(eventStream, acquisitionWorker, workerContext, path.dirname(getExpectedPath(getInstallFromContext(workerContext).installId, workerContext.acquisitionContext.mode ?? 'runtime')));
+        const expectedPath = path.dirname(getExpectedPath(getInstallFromContext(workerContext).installId, workerContext.acquisitionContext.mode ?? 'runtime'));
+        const invoker = new NoInstallAcquisitionInvoker(eventStream, acquisitionWorker, workerContext, expectedPath);
 
         return [acquisitionWorker, invoker];
     }

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -74,7 +74,9 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function ()
     function setupWorker(workerContext: IAcquisitionWorkerContext, eventStream: IEventStream): [MockDotnetCoreAcquisitionWorker, IAcquisitionInvoker]
     {
         const acquisitionWorker = getMockAcquisitionWorker(workerContext);
-        const invoker = new NoInstallAcquisitionInvoker(eventStream, acquisitionWorker, workerContext, path.dirname(getExpectedPath(getInstallFromContext(workerContext).installId, workerContext.acquisitionContext.mode ?? 'runtime')));
+        const installId = path.dirname(getExpectedPath(getInstallFromContext(workerContext).installId;
+        const mode = workerContext.acquisitionContext.mode ?? 'runtime';
+        const invoker = new NoInstallAcquisitionInvoker(eventStream, acquisitionWorker, workerContext, installId, mode)));
 
         return [acquisitionWorker, invoker];
     }

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -74,9 +74,7 @@ suite('DotnetCoreAcquisitionWorker Unit Tests', function ()
     function setupWorker(workerContext: IAcquisitionWorkerContext, eventStream: IEventStream): [MockDotnetCoreAcquisitionWorker, IAcquisitionInvoker]
     {
         const acquisitionWorker = getMockAcquisitionWorker(workerContext);
-        const installId = path.dirname(getExpectedPath(getInstallFromContext(workerContext).installId;
-        const mode = workerContext.acquisitionContext.mode ?? 'runtime';
-        const invoker = new NoInstallAcquisitionInvoker(eventStream, acquisitionWorker, workerContext, installId, mode)));
+        const invoker = new NoInstallAcquisitionInvoker(eventStream, acquisitionWorker, workerContext, path.dirname(getExpectedPath(getInstallFromContext(workerContext).installId, workerContext.acquisitionContext.mode ?? 'runtime')));
 
         return [acquisitionWorker, invoker];
     }

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -304,7 +304,7 @@ ${eventStream.events.map(event => event.eventName).join(', ')}`);
 
         for (const version of versions)
         {
-            const ctx = getMockAcquisitionContext('runtime', versions[0], expectedTimeoutTime, eventStream, extContext);
+            const ctx = getMockAcquisitionContext('runtime', version, expectedTimeoutTime, eventStream, extContext);
             const [acquisitionWorker, invoker] = setupWorker(ctx, eventStream);
             migrateContextToNewInstall(ctx, version, os.arch());
             const res = await acquisitionWorker.acquireLocalRuntime(ctx, invoker);

--- a/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -123,7 +123,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function ()
       const _ = new MockInstallTracker(eventStream, mockContext.extensionState);
 
       // Assert preinstalled SDKs are detected
-      const acquisitionInvoker = new NoInstallAcquisitionInvoker(eventStream, acquisitionWorker);
+      const acquisitionInvoker = new NoInstallAcquisitionInvoker(eventStream, acquisitionWorker, mockContext, path.dirname(sdkDirCurrent));
       const result = await acquisitionWorker.acquireLocalSDK(mockContext, acquisitionInvoker);
       assert.equal(path.dirname(result.dotnetPath), dotnetDir, 'preinstalled sdk path is the same as installed sdk path on api call');
       const preinstallEvents = eventStream.events

--- a/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-sdk-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -5,7 +5,6 @@
 
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import * as cp from 'child_process';
 import { warn } from 'console';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -36,7 +35,6 @@ import
 } from 'vscode-dotnet-runtime-library';
 import { InstallTrackerSingleton } from 'vscode-dotnet-runtime-library/dist/Acquisition/InstallTrackerSingleton';
 import * as extension from '../../extension';
-import { uninstallSDKExtension } from '../../ExtensionUninstall';
 import rimraf = require('rimraf');
 
 const standardTimeoutTime = 100000;
@@ -172,24 +170,6 @@ suite('DotnetCoreAcquisitionExtension End to End', function ()
       await promisify(rimraf)(dotnetDir);
     }).timeout(standardTimeoutTime);
 
-    test('Install Command', async () =>
-    {
-      const context: IDotnetAcquireContext = { version: currentSDKVersion, requestingExtensionId: 'ms-dotnettools.sample-extension' };
-      const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet-sdk.acquire', context);
-      assert.exists(result);
-      assert.exists(result!.dotnetPath);
-      assert.include(result!.dotnetPath, '.dotnet');
-      const sdkDir = fs.readdirSync(path.join(path.dirname(result!.dotnetPath), 'sdk'))[0];
-      assert.include(sdkDir, context.version);
-      if (os.platform() === 'win32')
-      {
-        assert.include(result!.dotnetPath, process.env.APPDATA!);
-      }
-      assert.isTrue(fs.existsSync(result!.dotnetPath));
-      // Clean up storage
-      await vscode.commands.executeCommand('dotnet-sdk.uninstallAll');
-    }).timeout(standardTimeoutTime);
-
     test('Install Command with Unknown Extension Id', async () =>
     {
       const context: IDotnetAcquireContext = { version: currentSDKVersion, requestingExtensionId: 'unknown' };
@@ -246,42 +226,6 @@ suite('DotnetCoreAcquisitionExtension End to End', function ()
       assert.strictEqual(await resolver.getFullySpecifiedVersion(), fullVersion);
     }).timeout(standardTimeoutTime);
 
-    test('Install Command Sets the PATH', async () =>
-    {
-      const existingPath = process.env.PATH;
-      const context: IDotnetAcquireContext = { version: currentSDKVersion, requestingExtensionId: 'ms-dotnettools.sample-extension' };
-      const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet-sdk.acquire', context);
-      assert.exists(result, 'The acquisition command did not provide a valid result?');
-      assert.exists(result!.dotnetPath);
-
-      const expectedPath = path.dirname(result!.dotnetPath);
-      const pathVar = environmentVariableCollection.variables.PATH;
-
-      if (existingPath?.includes('dotnet'))
-      {
-        warn('The local SDK test could not run on your machine correctly because it has a GLOBAL SDK installed.');
-        return;
-      }
-
-      assert.include(pathVar, expectedPath);
-
-      let pathResult: string;
-      if (os.platform() === 'win32')
-      {
-        pathResult = cp.execSync(`%SystemRoot%\\System32\\reg.exe query "HKCU\\Environment" /v "Path"`).toString();
-      } else if (os.platform() === 'darwin')
-      {
-        pathResult = fs.readFileSync(path.join(os.homedir(), '.zshrc')).toString();
-      } else
-      {
-        pathResult = fs.readFileSync(path.join(os.homedir(), '.profile')).toString();
-      }
-      assert.include(pathResult, expectedPath);
-
-      // Clean up storage
-      await vscode.commands.executeCommand('dotnet-sdk.uninstallAll');
-    }).timeout(standardTimeoutTime);
-
     test('Install Status Command', async () =>
     {
       const existingPath = process.env.PATH;
@@ -302,16 +246,6 @@ suite('DotnetCoreAcquisitionExtension End to End', function ()
 
       // Clean up storage
       await vscode.commands.executeCommand('dotnet-sdk.uninstallAll');
-    }).timeout(standardTimeoutTime);
-
-    test('Extension Uninstall Removes SDKs', async () =>
-    {
-      const context: IDotnetAcquireContext = { version: currentSDKVersion, requestingExtensionId: 'ms-dotnettools.sample-extension' };
-      const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet-sdk.acquire', context);
-      assert.exists(result);
-      assert.exists(result!.dotnetPath);
-      uninstallSDKExtension();
-      assert.isFalse(fs.existsSync(result!.dotnetPath));
     }).timeout(standardTimeoutTime);
   });
 });


### PR DESCRIPTION
A problem C# has noticed is that there is a small chance for the install script to think it is done installing, and for our extension to think we have installed, even though not all files are there.

Upon closer inspection, I realized some issues and resolved them:

# There is a race condition

We have a check to see if there is an existing 'promise' that is working on doing the same install as another request. However, sometimes that check will run simultaneously. What we did before was only lock during the process of running the install script, locking on the installation id (version+arch+install type+mode), and then locking on the data structure that stores what is done installing vs installed. Now we lock during the process of looking for existing installs, doing the install, and recording the install to prevent such a race condition.

# Incorrect Type Casting

The install script handler used the wrong type (InstallationContext) instead of a AcquisitionContext to validate it, so the mode it was validating was undefined. This means it would consider a valid install to be invalid.