### PR TITLE
Dont use entire env as cache key

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -263,7 +263,7 @@ This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/is
             if (os.platform() === 'win32') // Windows does not have chmod +x ability with nodejs.
             {
                 const permissionsCommand = CommandExecutor.makeCommand('icacls', [`"${installerPath}"`, '/grant:r', `"%username%":F`, '/t', '/c']);
-                const commandRes = await this.commandRunner.execute(permissionsCommand, { dotnetInstallToolCacheTtlMs: SYSTEM_INFORMATION_CACHE_DURATION_MS }, false);
+                const commandRes = await this.commandRunner.execute(permissionsCommand, {}, false);
                 if (commandRes.stderr !== '')
                 {
                     const error = new EventBasedError('FailedToSetInstallerPermissions', `Failed to set icacls permissions on the installer file ${installerPath}. ${commandRes.stderr}`);

--- a/vscode-dotnet-runtime-library/src/LocalMemoryCacheSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/LocalMemoryCacheSingleton.ts
@@ -114,8 +114,7 @@ export class LocalMemoryCacheSingleton
             }
             else if (k === 'env')
             {
-                return `${minimizeEnvironment(v)}-${TelemetryUtilities.HashData(JSON.stringify(v))}`; // Each command with a unique env must be cached uniquely -- it's helpful to see what the important vars are in the log.
-                // But we don't want to store the entire env/log it.
+                return `${minimizeEnvironment(v)}`;
             }
             return v;
         })}`;


### PR DESCRIPTION
The cache is a local memory cache reset upon vscode loading. It caches commands that we run to avoid running them again. We noticed the environment changes very often but most commands are only impacted by certain environment variables. If there is an env var we did not consider that could change a command's output, then this would make that case incorrect. However, we think the perf gain for this and the lack of opportunity for this is OK. For example, we check PATH, DOTNET_ROOT, etc and would still respond to those changes when we map a command to run to a cache key.

Possible commands are impacted, are dotnet --info, --list-runtimes, and querying the registry, as well as running netstat, checking etc/os-release, etc. I think the reg is the most concerning one as the PATH in vscode may not update there but it is on a 9 second timer and a correct env var already should not exist to make that update properly with the cache.