### PR TITLE
RHEL: Prefer DNF Over Yum

### DIFF
--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -799,7 +799,7 @@
         "searchCommand": [
             {
                 "runUnderSudo": false,
-                "commandRoot": "yum",
+                "commandRoot": "dnf",
                 "commandParts": [
                     "search",
                     "{packageName}",
@@ -822,7 +822,7 @@
         "packageLookupCommand": [
             {
                 "runUnderSudo": false,
-                "commandRoot": "yum",
+                "commandRoot": "dnf",
                 "commandParts": [
                     "list",
                     "install",

--- a/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/RedHatDistroTests.test.ts
@@ -52,7 +52,7 @@ suite('Red Hat For Linux Distro Logic Unit Tests', function ()
         {
             // assert this passes : we don't want the test to be reliant on machine state for whether the package exists or not, so don't check output
             await provider.dotnetPackageExistsOnSystem(mockVersion, installType);
-            assert.equal(mockExecutor.attemptedCommand, 'yum list install dotnet-sdk-9.0 -q');
+            assert.equal(mockExecutor.attemptedCommand, 'dnf list install dotnet-sdk-9.0 -q');
         }
     }).timeout(standardTimeoutTime);
 


### PR DESCRIPTION
Please see: https://github.com/dotnet/vscode-dotnet-runtime/issues/2175
Resolves: https://devdiv.visualstudio.com/DevDiv/_queries/query/?tempQueryId=b79dee94-a770-46a2-9d77-6beba92ee01a

https://cyberpanel.net/blog/dnf-vs-yum#:~:text=DNF%20is%20the%20next%2Dgeneration,of%20Red%20Hat%2Dbased%20systems.

We mainly want to support RHEL 8, 9 and both already use DNF. We dont support RHEL 7 or below.
Note: I noticed RHEL does not support dotnet until it is registered. But that is not related to this issue.
Confirmed working on RHEL 9.5 VM:
![image](https://github.com/user-attachments/assets/70f3be18-f0fc-4fe0-b908-45d34e1f9aa3)
