### PR TITLE
Issue 2208 - README links to wrong CMake extension

### DIFF
--- a/vscode-dotnet-runtime-extension/README.md
+++ b/vscode-dotnet-runtime-extension/README.md
@@ -154,5 +154,5 @@ This project may contain trademarks or logos for projects, products, or services
 [changing the installation timeout]: https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md#install-script-timeouts
 [Unity]: https://marketplace.visualstudio.com/items?itemName=VisualStudioToolsForUnity.vstuc
 [.NET MAUI]: https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui
-[CMake]: https://marketplace.visualstudio.com/items?itemName=twxs.cmake
+[CMake]: https://marketplace.visualstudio.com/items?itemName=josetr.cmake-language-support-vscode
 [Bicep]: https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-bicep


### PR DESCRIPTION
The currently listed extension 'CMake' does not require the dotnet runtime. 
Updated to the 'CMake Language Support' extension which does require the runtime.

Related: Issue https://github.com/dotnet/vscode-dotnet-runtime/issues/2208