### PR TITLE
Improve Command Caching by Aliasing Commands

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -30,41 +30,59 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
     public async dotnetMeetsRequirement(dotnetExecutablePath: string, requirement: IDotnetFindPathContext): Promise<boolean>
     {
         let hostArch = '';
+        const oldLookup = process.env.DOTNET_MULTILEVEL_LOOKUP;
+        // This is deprecated but still needed to scan .NET 6 and below
+        process.env.DOTNET_MULTILEVEL_LOOKUP = '0'; // make it so --list-runtimes only finds the runtimes on that path: https://learn.microsoft.com/en-us/dotnet/core/compatibility/deployment/7.0/multilevel-lookup#reason-for-change
 
-        if (requirement.acquireContext.mode === 'sdk')
+        try
         {
-            const availableSDKs = await this.getSDKs(dotnetExecutablePath, requirement.acquireContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture());
-            hostArch = availableSDKs?.at(0)?.architecture ?? await this.getHostArchitecture(dotnetExecutablePath, requirement);
-            if (availableSDKs.some((sdk) =>
+            if (requirement.acquireContext.mode === 'sdk')
             {
-                return this.stringArchitectureMeetsRequirement(hostArch, requirement.acquireContext.architecture) &&
-                    this.stringVersionMeetsRequirement(sdk.version, requirement.acquireContext.version, requirement) && this.allowPreview(sdk.version, requirement);
-            }))
-            {
-                this.workerContext.eventStream.post(new DotnetConditionsValidated(`${dotnetExecutablePath} satisfies the conditions.`));
-                return true;
+                const availableSDKs = await this.getSDKs(dotnetExecutablePath, requirement.acquireContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture());
+                hostArch = availableSDKs?.at(0)?.architecture ?? await this.getHostArchitecture(dotnetExecutablePath, requirement);
+                if (availableSDKs.some((sdk) =>
+                {
+                    return this.stringArchitectureMeetsRequirement(hostArch, requirement.acquireContext.architecture) &&
+                        this.stringVersionMeetsRequirement(sdk.version, requirement.acquireContext.version, requirement) && this.allowPreview(sdk.version, requirement);
+                }))
+                {
+                    this.workerContext.eventStream.post(new DotnetConditionsValidated(`${dotnetExecutablePath} satisfies the conditions.`));
+                    return true;
+                }
             }
-        }
-        else
-        {
-            // No need to consider SDKs when looking for runtimes as all the runtimes installed with the SDKs will be included in the runtimes list.
-            const availableRuntimes = await this.getRuntimes(dotnetExecutablePath, requirement.acquireContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture());
-            hostArch = availableRuntimes?.at(0)?.architecture ?? await this.getHostArchitecture(dotnetExecutablePath, requirement);
-            if (availableRuntimes.some((runtime) =>
+            else
             {
-                return runtime.mode === requirement.acquireContext.mode && this.stringArchitectureMeetsRequirement(hostArch, requirement.acquireContext.architecture) &&
-                    this.stringVersionMeetsRequirement(runtime.version, requirement.acquireContext.version, requirement) && this.allowPreview(runtime.version, requirement);
-            }))
-            {
-                this.workerContext.eventStream.post(new DotnetConditionsValidated(`${dotnetExecutablePath} satisfies the conditions.`));
-                return true;
+                // No need to consider SDKs when looking for runtimes as all the runtimes installed with the SDKs will be included in the runtimes list.
+                const availableRuntimes = await this.getRuntimes(dotnetExecutablePath, requirement.acquireContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture());
+                hostArch = availableRuntimes?.at(0)?.architecture ?? await this.getHostArchitecture(dotnetExecutablePath, requirement);
+                if (availableRuntimes.some((runtime) =>
+                {
+                    return runtime.mode === requirement.acquireContext.mode && this.stringArchitectureMeetsRequirement(hostArch, requirement.acquireContext.architecture) &&
+                        this.stringVersionMeetsRequirement(runtime.version, requirement.acquireContext.version, requirement) && this.allowPreview(runtime.version, requirement);
+                }))
+                {
+                    this.workerContext.eventStream.post(new DotnetConditionsValidated(`${dotnetExecutablePath} satisfies the conditions.`));
+                    return true;
+                }
             }
-        }
 
-        this.workerContext.eventStream.post(new DotnetFindPathDidNotMeetCondition(`${dotnetExecutablePath} did NOT satisfy the conditions: hostArch: ${hostArch}, requiredArch: ${requirement.acquireContext.architecture},
+            this.workerContext.eventStream.post(new DotnetFindPathDidNotMeetCondition(`${dotnetExecutablePath} did NOT satisfy the conditions: hostArch: ${hostArch}, requiredArch: ${requirement.acquireContext.architecture},
             required version: ${requirement.acquireContext.version}, required mode: ${requirement.acquireContext.mode}`));
 
-        return false;
+            return false;
+        }
+        finally
+        {
+            // Restore the environment variable to its original value
+            if (oldLookup !== undefined)
+            {
+                process.env.DOTNET_MULTILEVEL_LOOKUP = oldLookup;
+            }
+            else
+            {
+                delete process.env.DOTNET_MULTILEVEL_LOOKUP;
+            }
+        }
     }
 
     /**

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -304,10 +304,9 @@ Please set the PATH to a dotnet host that matches the architecture ${requirement
         return true;
     }
 
-    public getRuntimesCommand(existingPath: string, requestedArchitecture: string): CommandExecutorCommand
+    private getRuntimesCommand(existingPath: string, requestedArchitecture: string): CommandExecutorCommand
     {
         return CommandExecutor.makeCommand(`"${existingPath}"`, ['--list-runtimes', '--arch', requestedArchitecture]);
-
     }
 
     public async getRuntimes(existingPath: string, requestedArchitecture: string | null): Promise<IDotnetListInfo[]>

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetPathFinder.ts
@@ -411,7 +411,7 @@ export class DotnetPathFinder implements IDotnetPathFinder
                 // /usr/local/bin/dotnet becomes /snap/dotnet-sdk/current/dotnet in reality, may have different behavior in shells.
                 if (os.platform() === 'win32')
                 {
-                    LocalMemoryCacheSingleton.getInstance().aliasCommandAsAnotherCommandRoot(truePath, tentativePath, this.workerContext.eventStream);
+                    LocalMemoryCacheSingleton.getInstance().aliasCommandAsAnotherCommandRoot(`"${truePath}"`, `"${tentativePath}"`, this.workerContext.eventStream);
                 }
             }
             else

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -1195,6 +1195,15 @@ export class DotnetFindPathLookupSetting extends DotnetCustomMessageEvent
     public readonly eventName = 'DotnetFindPathLookupSetting';
 }
 
+export class CacheAliasCreated extends DotnetCustomMessageEvent
+{
+    public readonly eventName = 'CacheAliasCreated';
+    public getProperties()
+    {
+        return { Message: this.eventMessage, ...getDisabledTelemetryOnChance(1) };
+    };
+}
+
 export class DotnetFindPathSettingFound extends DotnetCustomMessageEvent
 {
     public readonly eventName = 'DotnetFindPathSettingFound';

--- a/vscode-dotnet-runtime-library/src/LocalMemoryCacheSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/LocalMemoryCacheSingleton.ts
@@ -130,6 +130,7 @@ export class LocalMemoryCacheSingleton
     private cacheableCommandToKey(key: CacheableCommand): string
     {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        Object.keys(key.options).sort();
         return `${CommandExecutor.prettifyCommandExecutorCommand(key.command)}${JSON.stringify(key.options, function replacer(k, v)
         {
             // Replace the dotnetInstallToolCacheTtlMs key with undefined so that it doesn't affect the cache key.

--- a/vscode-dotnet-runtime-library/src/LocalMemoryCacheSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/LocalMemoryCacheSingleton.ts
@@ -6,8 +6,8 @@
 
 import * as nodeCache from 'node-cache';
 import { IAcquisitionWorkerContext } from "./Acquisition/IAcquisitionWorkerContext";
-import { CacheClearEvent, CacheGetEvent, CachePutEvent } from "./EventStream/EventStreamEvents";
-import { TelemetryUtilities } from './EventStream/TelemetryUtilities';
+import { IEventStream } from './EventStream/EventStream';
+import { CacheAliasCreated, CacheClearEvent, CacheGetEvent, CachePutEvent } from "./EventStream/EventStreamEvents";
 import { CommandExecutor } from "./Utils/CommandExecutor";
 import { CommandExecutorCommand } from "./Utils/CommandExecutorCommand";
 import { CommandExecutorResult } from "./Utils/CommandExecutorResult";
@@ -30,6 +30,8 @@ export class LocalMemoryCacheSingleton
     protected static instance: LocalMemoryCacheSingleton;
 
     protected cache: nodeCache = new nodeCache();
+
+    private commandRootAliases: Map<string, string> = new Map<string, string>();
 
     protected constructor(public readonly timeToLiveMultiplier = 1)
     {
@@ -67,6 +69,10 @@ export class LocalMemoryCacheSingleton
 
     public getCommand(key: CacheableCommand, context: IAcquisitionWorkerContext): CommandExecutorResult | undefined
     {
+        if (this.commandRootAliases.has(key.command.commandRoot))
+        {
+            key.command.commandRoot = this.commandRootAliases.get(key.command.commandRoot) ?? key.command.commandRoot;
+        }
         return this.get(this.cacheableCommandToKey(key), context);
     }
 
@@ -93,30 +99,26 @@ export class LocalMemoryCacheSingleton
     {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         const ttl = key.options?.dotnetInstallToolCacheTtlMs ?? 5000;
+        if (this.commandRootAliases.has(key.command.commandRoot))
+        {
+            key.command.commandRoot = this.commandRootAliases.get(key.command.commandRoot) ?? key.command.commandRoot;
+        }
+
         return this.put(this.cacheableCommandToKey(key), obj, { ttlMs: ttl } as LocalMemoryCacheMetadata, context);
     }
 
     /**
      *
-     * @param newCommandRoot The root of the command that will result in the same output. Example: if we know "dotnet" is "C:\\Program Files\\dotnet\\dotnet.exe"
-     * @param originalCommand The identical command that had likely already been cached. Won't make it so if that's not already the case.
-     * @param populateDefaultOptions If true, will populate the default options for the command. This is useful if the command is not already populated with the default options.
-     * @param context
+     * @param commandRootAlias The root of the command that will result in the same output. Example: if we know "dotnet" is "C:\\Program Files\\dotnet\\dotnet.exe"
+     * @param aliasedCommandRoot The identical command that had likely already been cached.
+     * @remarks This does not work in the opposite direction. If you alias "dotnet" to "dotnet2", it will not alias "dotnet2" to "dotnet".
+     * Trying that will result in neither command being cache aliased to one another.
+     * Basically, this will replace all command checks in the cache that have the commandRoot of `commandRootAlias` with the `aliasedCommandRoot`.
      */
-    public cacheIdenticalCommandWithUniqueRoot(newCommandRoot: string, originalCommand: CacheableCommand, populateDefaultOptions = true, context: IAcquisitionWorkerContext): void
+    public aliasCommandAsAnotherCommandRoot(commandRootAlias: string, aliasedCommandRoot: string, eventStream: IEventStream): void
     {
-        if (populateDefaultOptions)
-        {
-            originalCommand.options = { ...originalCommand.options, CommandExecutor.getDefaultOptions() };
-        }
-        const cachedRes = this.getCommand(originalCommand, context);
-
-        if (cachedRes)
-        {
-            const cloneCommand = originalCommand;
-            cloneCommand.command.commandRoot = newCommandRoot;
-            this.putCommand(cloneCommand, cachedRes, context);
-        }
+        eventStream.post(new CacheAliasCreated(`Aliasing command root ${commandRootAlias} to ${aliasedCommandRoot}`));
+        this.commandRootAliases.set(commandRootAlias, aliasedCommandRoot);
     }
 
     public invalidate(context?: IAcquisitionWorkerContext): void

--- a/vscode-dotnet-runtime-library/src/LocalMemoryCacheSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/LocalMemoryCacheSingleton.ts
@@ -107,6 +107,19 @@ export class LocalMemoryCacheSingleton
         return this.put(this.cacheableCommandToKey(key), obj, { ttlMs: ttl } as LocalMemoryCacheMetadata, context);
     }
 
+    private sortObjectKeys(unordered: any): any
+    {
+        const ordered = Object.keys(unordered).sort().reduce(
+            (obj, key) =>
+            {
+                (obj as any)[key] = unordered[key];
+                return obj;
+            },
+            {}
+        );
+    }
+
+
     /**
      *
      * @param commandRootAlias The root of the command that will result in the same output. Example: if we know "dotnet" is "C:\\Program Files\\dotnet\\dotnet.exe"
@@ -130,8 +143,7 @@ export class LocalMemoryCacheSingleton
     private cacheableCommandToKey(key: CacheableCommand): string
     {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        Object.keys(key.options).sort();
-        return `${CommandExecutor.prettifyCommandExecutorCommand(key.command)}${JSON.stringify(key.options, function replacer(k, v)
+        return `${CommandExecutor.prettifyCommandExecutorCommand(key.command)}${JSON.stringify(this.sortObjectKeys(key.options), function replacer(k, v)
         {
             // Replace the dotnetInstallToolCacheTtlMs key with undefined so that it doesn't affect the cache key.
             if (k === 'dotnetInstallToolCacheTtlMs')

--- a/vscode-dotnet-runtime-library/src/test/unit/LocalMemoryCacheSingleton.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LocalMemoryCacheSingleton.test.ts
@@ -3,14 +3,17 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
 import * as chai from 'chai';
+import * as lodash from 'lodash';
+
 import { DOTNET_INFORMATION_CACHE_DURATION_MS } from '../../Acquisition/CacheTimeConstants';
 import { DotnetPathFinder } from '../../Acquisition/DotnetPathFinder';
-import { CacheGetEvent, CachePutEvent } from '../../EventStream/EventStreamEvents';
+import { CacheAliasCreated, CacheGetEvent, CachePutEvent } from '../../EventStream/EventStreamEvents';
 import { LocalMemoryCacheMetadata, LocalMemoryCacheSingleton } from '../../LocalMemoryCacheSingleton';
 import { WebRequestWorkerSingleton } from '../../Utils/WebRequestWorkerSingleton';
 import { MockCommandExecutor, MockEventStream, MockFileUtilities } from '../mocks/MockObjects';
 import { getMockAcquisitionContext, getMockUtilityContext } from './TestUtility';
 const assert = chai.assert;
+const cacheTime = 90000;
 
 suite('LocalMemoryCacheSingleton Unit Tests', function ()
 {
@@ -55,65 +58,91 @@ suite('LocalMemoryCacheSingleton Unit Tests', function ()
         const resultShouldNotExist = LocalMemoryCacheSingleton.getInstance().get('foo', mockContext);
         assert.equal(resultShouldNotExist, undefined, 'The cache does not cache with ttl as 0');
 
-        LocalMemoryCacheSingleton.getInstance().put('foo', 'bar', { ttlMs: 90000 } as LocalMemoryCacheMetadata, mockContext);
+        LocalMemoryCacheSingleton.getInstance().put('foo', 'bar', { ttlMs: cacheTime } as LocalMemoryCacheMetadata, mockContext);
         const resultShouldExist = LocalMemoryCacheSingleton.getInstance().get('foo', mockContext);
         assert.equal(resultShouldExist, 'bar', 'The cache caches after 0 but renewed ttl.');
     });
 
-    test('It correctly uses cache with command aliases', async () => {
+    test('It correctly uses cache with command aliases', async () =>
+    {
         const originalPath = 'dotnet';
         const aliasPath = 'C:\\Program Files\\dotnet\\dotnet.exe';
-        const cacheKey = `${originalPath} --list-sdks`;
-        const cacheValue = '10.0.100 [C:\\Program Files\\dotnet\\sdk]`;
-        
-        // Cache with original path
-        LocalMemoryCacheSingleton.getInstance().put(cacheKey, cacheValue, { ttlMs: 90000 } as LocalMemoryCacheMetadata, mockContext);
-        
-        // Before alias registration
-        assert.equal(LocalMemoryCacheSingleton.getInstance().get(cacheKey, mockContext), cacheValue);
-        assert.isUndefined(LocalMemoryCacheSingleton.getInstance().get(`${aliasPath} --list-sdks`, mockContext));
-        
-        // Register alias and test
+
+        const commandArgs = ['--list-sdks'];
+        const cacheValue = {
+            stdout: '10.0.100 [C:\\Program Files\\dotnet\\sdk]',
+            stderr: '',
+            status: '0'
+        };
+
+        const cacheCommand = {
+            command: {
+                commandRoot: originalPath,
+                commandParts: commandArgs,
+                runUnderSudo: false
+            },
+            options: { dotnetInstallToolCacheTtlMs: cacheTime }
+        };
+
+        const aliasCommand = lodash.cloneDeep(cacheCommand);
+        aliasCommand.command.commandRoot = aliasPath;
+
+        LocalMemoryCacheSingleton.getInstance().putCommand(cacheCommand, cacheValue, mockContext);
+
+        assert.deepEqual(LocalMemoryCacheSingleton.getInstance().getCommand(cacheCommand, mockContext), cacheValue);
+        assert.isUndefined(LocalMemoryCacheSingleton.getInstance().getCommand(aliasCommand, mockContext));
+
         LocalMemoryCacheSingleton.getInstance().aliasCommandAsAnotherCommandRoot(aliasPath, originalPath, eventStream);
-        assert.equal(LocalMemoryCacheSingleton.getInstance().get(`${aliasPath} --list-sdks`, mockContext), cacheValue);
-        
-        // Verify event
-        const aliasEvent = eventStream.events.find(event => 
-            event instanceof CacheAliasCreated && 
+        assert.deepEqual(LocalMemoryCacheSingleton.getInstance().getCommand(aliasCommand, mockContext), cacheValue);
+
+        const aliasEvent = eventStream.events.find(event =>
+            event instanceof CacheAliasCreated &&
             (event as CacheAliasCreated).eventMessage.includes(aliasPath)
         );
         assert.exists(aliasEvent);
     });
 
-    test('It handles command options with different properties correctly', async () => {
+    test('It handles command options with different properties correctly', async () =>
+    {
         const commandRoot = 'dotnet';
         const commandArgs = ['--list-runtimes'];
-        const outputValue = 'Microsoft.NETCore.App 10.0.1';
-        
-        // Command with original options order
+        const outputValue = {
+            stdout: 'Microsoft.NETCore.App 10.0.1',
+            stderr: '',
+            status: '0'
+        };
+
         const originalCommand = {
-            command: { commandRoot, args: commandArgs },
-            options: { ttl: 90000, env: { 'LANG': 'en-US' } }
+            command: {
+                commandRoot: commandRoot,
+                commandParts: commandArgs,
+                runUnderSudo: false
+            },
+            options: { ttl: cacheTime, env: { 'LANG': 'en-US' }, dotnetInstallToolCacheTtlMs: cacheTime }
         };
-        
-        // Same options but different order
+
         const reorderedCommand = {
-            command: { commandRoot, args: commandArgs },
-            options: { env: { 'LANG': 'en-US' }, ttl: 90000 }
+            command: {
+                commandRoot: commandRoot,
+                commandParts: commandArgs,
+                runUnderSudo: false
+            },
+            options: { env: { 'LANG': 'en-US' }, ttl: cacheTime, dotnetInstallToolCacheTtlMs: cacheTime }
         };
-        
-        // Different properties
+
         const differentCommand = {
-            command: { commandRoot, args: commandArgs },
-            options: { ttl: 90000, verbose: true }
+            command: {
+                commandRoot: commandRoot,
+                commandParts: commandArgs,
+                runUnderSudo: false
+            },
+            options: { ttl: cacheTime, verbose: true, dotnetInstallToolCacheTtlMs: cacheTime }
         };
-        
-        // Cache original command
+
         LocalMemoryCacheSingleton.getInstance().putCommand(originalCommand, outputValue, mockContext);
-        
-        // Test results
-        assert.equal(LocalMemoryCacheSingleton.getInstance().getCommand(originalCommand, mockContext), outputValue);
-        assert.equal(LocalMemoryCacheSingleton.getInstance().getCommand(reorderedCommand, mockContext), outputValue);
-        assert.notEqual(LocalMemoryCacheSingleton.getInstance().getCommand(differentCommand, mockContext), outputValue);
+
+        assert.deepEqual(LocalMemoryCacheSingleton.getInstance().getCommand(originalCommand, mockContext), outputValue, 'The original command should return the cached value.');
+        assert.deepEqual(LocalMemoryCacheSingleton.getInstance().getCommand(reorderedCommand, mockContext), outputValue, 'The reordered command should return the same cached value.');
+        assert.equal(LocalMemoryCacheSingleton.getInstance().getCommand(differentCommand, mockContext), undefined, 'A command with different options values should not be cached');
     });
 });


### PR DESCRIPTION
2 Things.

1. We resolve the full PATH of 'dotnet'. Then when we know the full path, we call `--list-runtimes` again on the full path. 
We know the full path is the same as 'dotnet'. So we should alias that in the cache and not redo the work again.

2. The options object was unsorted by json.stringify and nondeterministic in the JS spec. That would prevent things from being cached correctly. Not so good. 

This fixes those things.