### PR TITLE
Add .lock to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -50,3 +50,4 @@
 *.sln text=auto eol=crlf
 
 *.sh eol=lf
+*.lock linguist-generated=true


### PR DESCRIPTION
## Summary

When reviewing PRs, they often have `yarn.lock` files for tracking the package versions used by yarn. To make these files not reveal themselves by default in PRs, you set this `linguist-generated=true` attribute to them.

They'll now show up like this in PRs:

![image](https://github.com/user-attachments/assets/a8336628-67ab-4b83-84ff-dccd8204daa3)
