### PR TITLE
Add setting to disable messages in the output window

### DIFF
--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -120,8 +120,8 @@
                 },
                 "dotnetAcquisitionExtension.suppressOutput": {
                     "type": "boolean",
-                    "description": "Enable this to show more detailed output from our extension.",
-                    "default": "false"
+                    "default": false,
+                    "description": "Hide all messages in the output window from our extension. Error pop-ups from APIs that other extensions request we display will still appear.",
                 }
             }
         }

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -117,6 +117,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Show the command to reset extension data in the command palette. Restart VS Code and remove dependent extensions first."
+                },
+                "dotnetAcquisitionExtension.suppressOutput": {
+                    "type": "boolean",
+                    "description": "Enable this to show more detailed output from our extension.",
+                    "default": "false"
                 }
             }
         }

--- a/vscode-dotnet-runtime-extension/package.json
+++ b/vscode-dotnet-runtime-extension/package.json
@@ -121,7 +121,7 @@
                 "dotnetAcquisitionExtension.suppressOutput": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Hide all messages in the output window from our extension. Error pop-ups from APIs that other extensions request we display will still appear.",
+                    "description": "Hide all messages in the output window from our extension. Error pop-ups from APIs that other extensions request we display will still appear."
                 }
             }
         }

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -97,6 +97,7 @@ namespace configKeys
     export const allowInvalidPaths = 'allowInvalidPaths';
     export const cacheTimeToLiveMultiplier = 'cacheTimeToLiveMultiplier';
     export const showResetDataCommand = 'showResetDataCommand';
+    export const suppressOutput = 'suppressOutput';
 }
 
 namespace commandKeys
@@ -153,6 +154,7 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
 
 
     const allowInvalidPathSetting = extensionConfiguration.get<boolean>(configKeys.allowInvalidPaths);
+    const suppressOutput = extensionConfiguration.get<boolean>(configKeys.suppressOutput) ?? false;
     const isExtensionTelemetryEnabled = enableExtensionTelemetry(extensionConfiguration, configKeys.enableTelemetry);
     const displayWorker = extensionContext ? extensionContext.displayWorker : new WindowDisplayWorker();
 
@@ -173,7 +175,7 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
         packageJson
     } as IEventStreamContext;
     const [globalEventStream, outputChannel, loggingObserver,
-        eventStreamObservers, telemetryObserver, _] = registerEventStream(eventStreamContext, vsCodeExtensionContext, utilContext);
+        eventStreamObservers, telemetryObserver, _] = registerEventStream(eventStreamContext, vsCodeExtensionContext, utilContext, suppressOutput);
 
 
     // Setting up command-shared classes for Runtime & SDK Acquisition

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamRegistration.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamRegistration.ts
@@ -36,7 +36,7 @@ export interface IEventStreamContext
 }
 
 export function registerEventStream(context: IEventStreamContext, extensionContext: IVSCodeExtensionContext,
-    utilityContext: IUtilityContext): [EventStream, vscode.OutputChannel, LoggingObserver, IEventStreamObserver[], TelemetryObserver | null, ModalEventRepublisher]
+    utilityContext: IUtilityContext, suppressOutput = false): [EventStream, vscode.OutputChannel, LoggingObserver, IEventStreamObserver[], TelemetryObserver | null, ModalEventRepublisher]
 {
     const outputChannel = vscode.window.createOutputChannel(context.displayChannelName);
     if (!fs.existsSync(context.logPath))
@@ -49,7 +49,7 @@ export function registerEventStream(context: IEventStreamContext, extensionConte
     const eventStreamObservers: IEventStreamObserver[] =
         [
             new StatusBarObserver(vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, Number.MIN_VALUE), context.showLogCommand),
-            new OutputChannelObserver(outputChannel),
+            new OutputChannelObserver(outputChannel, suppressOutput),
             loggingObserver
         ];
 

--- a/vscode-dotnet-runtime-library/src/EventStream/IOutputChannel.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/IOutputChannel.ts
@@ -1,0 +1,124 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+
+/**
+ * Represents an output channel for displaying text information.
+ * This interface is compatible with VS Code's OutputChannel but doesn't depend on the vscode module.
+ */
+export interface IOutputChannel
+{
+    /**
+     * The human-readable name of this output channel.
+     */
+    readonly name: string;
+
+    /**
+     * Append the given value to the channel.
+     *
+     * @param value A string, falsy values will not be printed.
+     */
+    append(value: string): void;
+
+    /**
+     * Append the given value and a line feed character
+     * to the channel.
+     *
+     * @param value A string, falsy values will be printed.
+     */
+    appendLine(value: string): void;
+
+    /**
+     * Replaces all output from the channel with the given value.
+     *
+     * @param value A string, falsy values will not be printed.
+     */
+    replace(value: string): void;
+
+    /**
+     * Removes all output from the channel.
+     */
+    clear(): void;
+
+    /**
+     * Reveal this channel in the UI.
+     *
+     * @param preserveFocus When `true` the channel will not take focus.
+     */
+    show(preserveFocus?: boolean): void;
+
+    /**
+     * Reveal this channel in the UI.
+     *
+     * @param column This argument is **deprecated** and will be ignored.
+     * @param preserveFocus When `true` the channel will not take focus.
+     */
+    show(column?: ViewColumn, preserveFocus?: boolean): void;
+
+    /**
+     * Hide this channel from the UI.
+     */
+    hide(): void;
+
+    /**
+     * Dispose and free associated resources.
+     */
+    dispose(): void;
+}
+
+/**
+ * Denotes a column in the editor layout. Columns are used to show editors side by side.
+ * This enum is compatible with VS Code's ViewColumn but doesn't depend on the vscode module.
+ */
+export enum ViewColumn
+{
+    /**
+     * A *symbolic* editor column representing the currently active column. This value
+     * can be used when opening editors, but the *resolved* {@link TextEditor.viewColumn viewColumn}-value
+     * of editors will always be `One`, `Two`, `Three`,... or `undefined` but never `Active`.
+     */
+    Active = -1,
+    /**
+     * A *symbolic* editor column representing the column to the side of the active one. This value
+     * can be used when opening editors, but the *resolved* {@link TextEditor.viewColumn viewColumn}-value
+     * of editors will always be `One`, `Two`, `Three`,... or `undefined` but never `Beside`.
+     */
+    Beside = -2,
+    /**
+     * The first editor column.
+     */
+    One = 1,
+    /**
+     * The second editor column.
+     */
+    Two = 2,
+    /**
+     * The third editor column.
+     */
+    Three = 3,
+    /**
+     * The fourth editor column.
+     */
+    Four = 4,
+    /**
+     * The fifth editor column.
+     */
+    Five = 5,
+    /**
+     * The sixth editor column.
+     */
+    Six = 6,
+    /**
+     * The seventh editor column.
+     */
+    Seven = 7,
+    /**
+     * The eighth editor column.
+     */
+    Eight = 8,
+    /**
+     * The ninth editor column.
+     */
+    Nine = 9
+}

--- a/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
@@ -186,7 +186,7 @@ export class OutputChannelObserver implements IEventStreamObserver
 
     private startDownloadIndicator()
     {
-        this.downloadProgressInterval = setInterval(() => this.outputChannel.append('.'), 1000);
+        this.downloadProgressInterval = setInterval(() => this.outputChannel.append('.'), 3000);
     }
 
     private stopDownloadIndicator()

--- a/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
@@ -28,13 +28,18 @@ export class OutputChannelObserver implements IEventStreamObserver
     private readonly inProgressDownloads: string[] = [];
     private downloadProgressInterval: NodeJS.Timeout | undefined;
 
-    // private inProgressDownloads:
-    constructor(private readonly outputChannel: vscode.OutputChannel)
+    constructor(private readonly outputChannel: vscode.OutputChannel, private readonly suppressOutput: boolean = false)
     {
     }
 
+
     public post(event: IEvent): void
     {
+        if (this.suppressOutput)
+        {
+            return;
+        }
+
         switch (event.type)
         {
             case EventType.DotnetAcquisitionStart:

--- a/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/OutputChannelObserver.ts
@@ -2,7 +2,6 @@
 *  Licensed to the .NET Foundation under one or more agreements.
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
-import * as vscode from 'vscode';
 import
 {
     DotnetAcquisitionAlreadyInstalled,
@@ -22,13 +21,14 @@ import
 import { EventType } from './EventType';
 import { IEvent } from './IEvent';
 import { IEventStreamObserver } from './IEventStreamObserver';
+import { IOutputChannel } from './IOutputChannel';
 
 export class OutputChannelObserver implements IEventStreamObserver
 {
     private readonly inProgressDownloads: string[] = [];
     private downloadProgressInterval: NodeJS.Timeout | undefined;
 
-    constructor(private readonly outputChannel: vscode.OutputChannel, private readonly suppressOutput: boolean = false)
+    constructor(private readonly outputChannel: IOutputChannel, private readonly suppressOutput: boolean = false)
     {
     }
 

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -458,7 +458,6 @@ export class MockCommandExecutor extends ICommandExecutor
         return this.trueExecutor.setEnvironmentVariable(variable, value, vscodeContext, failureWarningMessage, nonWinFailureMessage);
     }
 }
-
 export class MockFileUtilities extends IFileUtilities
 {
     private trueUtilities = new FileUtilities();

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockOutputChannel.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockOutputChannel.ts
@@ -3,9 +3,9 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
+import { IOutputChannel, ViewColumn } from '../../EventStream/IOutputChannel';
 
-export class MockOutputChannel implements vscode.OutputChannel
+export class MockOutputChannel implements IOutputChannel
 {
     name: string = 'Test';
     appendedText: string[] = [];
@@ -23,7 +23,7 @@ export class MockOutputChannel implements vscode.OutputChannel
 
     replace(value: string): void
     {
-        // Not needed for this test
+        // Not needed
     }
 
     clear(): void
@@ -33,7 +33,7 @@ export class MockOutputChannel implements vscode.OutputChannel
     }
 
     show(preserveFocus?: boolean): void;
-    show(column?: vscode.ViewColumn, preserveFocus?: boolean): void;
+    show(column?: ViewColumn, preserveFocus?: boolean): void;
     show(column?: any, preserveFocus?: any): void
     {
         // Not needed
@@ -46,6 +46,6 @@ export class MockOutputChannel implements vscode.OutputChannel
 
     dispose(): void
     {
-        // Not needed for this test
+        // Not needed
     }
 }

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockOutputChannel.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockOutputChannel.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export class MockOutputChannel implements vscode.OutputChannel
+{
+    name: string = 'Test';
+    appendedText: string[] = [];
+    appendedLines: string[] = [];
+
+    append(value: string): void
+    {
+        this.appendedText.push(value);
+    }
+
+    appendLine(value: string): void
+    {
+        this.appendedLines.push(value);
+    }
+
+    replace(value: string): void
+    {
+        // Not needed for this test
+    }
+
+    clear(): void
+    {
+        this.appendedText = [];
+        this.appendedLines = [];
+    }
+
+    show(preserveFocus?: boolean): void;
+    show(column?: vscode.ViewColumn, preserveFocus?: boolean): void;
+    show(column?: any, preserveFocus?: any): void
+    {
+        // Not needed
+    }
+
+    hide(): void
+    {
+        // Not needed
+    }
+
+    dispose(): void
+    {
+        // Not needed for this test
+    }
+}

--- a/vscode-dotnet-runtime-library/src/test/unit/OutputChannelObserver.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/OutputChannelObserver.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import * as chai from 'chai';
 import { DotnetInstall } from '../../Acquisition/DotnetInstall';
-import { DotnetAcquisitionCompleted, DotnetAcquisitionStarted, DotnetFileIntegrityFailureEvent } from '../../EventStream/EventStreamEvents';
+import { DotnetAcquisitionCompleted, DotnetAcquisitionStarted, DotnetExistingPathResolutionCompleted, DotnetFileIntegrityFailureEvent } from '../../EventStream/EventStreamEvents';
 import { OutputChannelObserver } from '../../EventStream/OutputChannelObserver';
 import { MockOutputChannel } from '../mocks/MockOutputChannel';
 
@@ -47,7 +47,7 @@ suite('OutputChannelObserver Unit Tests', function ()
         const observer = new OutputChannelObserver(mockOutputChannel, false);
 
         // Test with an event that produces output
-        const acquisitionStartedEvent = new DotnetAcquisitionStarted(mockInstall, 'test-extension');
+        const acquisitionStartedEvent = new DotnetExistingPathResolutionCompleted(mockInstall.installId);
         observer.post(acquisitionStartedEvent);
 
         // Verify output was written when suppressOutput is false

--- a/vscode-dotnet-runtime-library/src/test/unit/OutputChannelObserver.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/OutputChannelObserver.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+import * as chai from 'chai';
+import { DotnetInstall } from '../../Acquisition/DotnetInstall';
+import { DotnetAcquisitionCompleted, DotnetAcquisitionStarted, DotnetFileIntegrityFailureEvent } from '../../EventStream/EventStreamEvents';
+import { OutputChannelObserver } from '../../EventStream/OutputChannelObserver';
+import { MockOutputChannel } from '../mocks/MockOutputChannel';
+
+const assert = chai.assert;
+const defaultTimeoutTime = 5000;
+
+suite('OutputChannelObserver Unit Tests', function ()
+{
+    const mockInstall: DotnetInstall = {
+        version: '8.0',
+        isGlobal: false,
+        architecture: 'x64',
+        installId: '8.0~x64',
+        installMode: 'runtime'
+    };
+
+    test('It suppresses output when suppressOutput is true', async () =>
+    {
+        const mockOutputChannel = new MockOutputChannel();
+        const observer = new OutputChannelObserver(mockOutputChannel, true);
+
+        // Test various event types that normally produce output
+        const acquisitionStartedEvent = new DotnetAcquisitionStarted(mockInstall, 'test-extension');
+        const acquisitionCompletedEvent = new DotnetAcquisitionCompleted(mockInstall, '/path/to/dotnet', 'test-extension');
+        const warningEvent = new DotnetFileIntegrityFailureEvent('Test warning message');
+
+        // Post events to the observer
+        observer.post(acquisitionStartedEvent);
+        observer.post(acquisitionCompletedEvent);
+        observer.post(warningEvent);
+
+        // Verify no output was written when suppressOutput is true
+        assert.isEmpty(mockOutputChannel.appendedText, 'No output should be written when suppressOutput is true');
+        assert.isEmpty(mockOutputChannel.appendedLines, 'No lines should be written when suppressOutput is true');
+    }).timeout(defaultTimeoutTime);
+
+    test('It produces output when suppressOutput is false', async () =>
+    {
+        const mockOutputChannel = new MockOutputChannel();
+        const observer = new OutputChannelObserver(mockOutputChannel, false);
+
+        // Test with an event that produces output
+        const acquisitionStartedEvent = new DotnetAcquisitionStarted(mockInstall, 'test-extension');
+        observer.post(acquisitionStartedEvent);
+
+        // Verify output was written when suppressOutput is false
+        assert.isNotEmpty(mockOutputChannel.appendedText, 'Output should be written when suppressOutput is false');
+    }).timeout(defaultTimeoutTime);
+
+    test('It produces output when suppressOutput is not specified (default behavior)', async () =>
+    {
+        const mockOutputChannel = new MockOutputChannel();
+        const observer = new OutputChannelObserver(mockOutputChannel); // No suppressOutput parameter
+
+        // Test with an event that produces output
+        const warningEvent = new DotnetFileIntegrityFailureEvent('Test warning message');
+        observer.post(warningEvent);
+
+        // Verify output was written with default behavior
+        assert.isNotEmpty(mockOutputChannel.appendedLines, 'Output should be written with default behavior');
+        assert.include(mockOutputChannel.appendedLines.join(''), 'Test warning message', 'The warning message should be in the output');
+    }).timeout(defaultTimeoutTime);
+});


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/2027

The output window in vscode, under the '.NET Install Tool' tab may be annoying/unnecessary to the user. This adds a setting to disable that output. We will want to do that for the automatic update, so this prepares for that as well.