### PR TITLE
Find Locally Managed Runtimes

### DIFF
--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -569,6 +569,21 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
             return { dotnetPath: validatedRoot };
         }
 
+        if (commandContext.acquireContext.mode === 'runtime' || commandContext.acquireContext.mode === 'aspnetcore')
+        {
+            const extensionManagedRuntimeRecordPaths = await finder.findExtensionManagedRuntimes();
+            const filteredExtensionManagedRuntimeRecordPaths = validator.filterValidPaths(extensionManagedRuntimeRecordPaths, commandContext);
+            for (const dotnetPath of filteredExtensionManagedRuntimeRecordPaths ?? [])
+            {
+                const validatedExistingManagedPath = await getPathIfValid(dotnetPath.path, validator, commandContext);
+                if (validatedExistingManagedPath)
+                {
+                    loggingObserver.dispose();
+                    return { dotnetPath: dotnetPath.path };
+                }
+            }
+        }
+
         const dotnetOnHostfxrRecord = await finder.findHostInstallPaths(commandContext.acquireContext.architecture);
         for (const dotnetPath of dotnetOnHostfxrRecord ?? [])
         {

--- a/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/DotnetCoreAcquisitionExtension.test.ts
@@ -447,7 +447,7 @@ suite('DotnetCoreAcquisitionExtension End to End', function ()
         }
     }).timeout(standardTimeoutTime);
 
-    test('Find dotnet PATH Command does not work with extension-managed runtime installations', async () =>
+    test('Find dotnet PATH Command does work with extension-managed runtime installations', async () =>
     {
         // First install a runtime that we'll try to find
         const version = '7.0';
@@ -474,7 +474,9 @@ suite('DotnetCoreAcquisitionExtension End to End', function ()
 
             // Then verify we can find the extension-managed runtime
             const result = await vscode.commands.executeCommand<IDotnetAcquireResult>('dotnet.findPath', findPathContext);
-            assert.notExists(result, 'Should find a runtime');
+            assert.exists(result, 'Should find a runtime');
+            assert.exists(result!.dotnetPath, 'Should find a runtime path');
+            assert.equal(result!.dotnetPath.toLowerCase(), runtimePath.toLowerCase(), 'Should find the correct runtime path');
         }
         finally
         {


### PR DESCRIPTION
This was implemented but then backed out for release in https://github.com/dotnet/vscode-dotnet-runtime/pull/2302.

This includes one fix which is to respect DOTNET_ROOT over the locally installed runtimes. Users who set DOTNET_ROOT typically have an explicit scenario that they want.

This was backed out because we need to do auto update of the local installed runtimes for this feature to be compatible with the API shape of keeping customers secure. We will do that in this release.