### PR TITLE
Add CoPilot Workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,28 @@
+name: Copilot Setup Steps
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+permissions:
+  contents: read
+
+env:
+  # Allow Copilot to access Visual Studio assets URLs needed for NuGet restore
+  COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: "vsblob.vsassets.io"
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Do an initial build to ensure all dependencies are restored
+        run: |
+          ./build.sh


### PR DESCRIPTION
Resolves https://github.com/dotnet/org-policy-violations/issues/5800

This is based off the SDK repo workflow. We also do a nuget restore for signing validation so included those assets here. The build layout is exactly the same.