### PR TITLE
Prep 2.3.7 Pre-Release, Try to make prerelease depending on condition

### DIFF
--- a/1es-azure-pipeline.yml
+++ b/1es-azure-pipeline.yml
@@ -58,9 +58,6 @@ parameters:
   displayName: Prerelease
   type: boolean
   default: false
-  values:
-  - true
-  - false
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines

--- a/1es-azure-pipeline.yml
+++ b/1es-azure-pipeline.yml
@@ -54,6 +54,13 @@ parameters:
   type: string
   default: Test
   values: [ 'Test', 'Real' ]
+- name: PRERELEASE
+  displayName: Prerelease
+  type: boolean
+  default: false
+  values:
+  - true
+  - false
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
@@ -106,6 +113,7 @@ extends:
             os: windows
           useOneEngineeringPool: true
           SignType: ${{ parameters.SignType }}
+          PREELEASE: ${{ parameters.PRERELEASE }}
       - template: pipeline-templates/sbom.yaml@self
         parameters:
           pool:

--- a/1pr-azure-pipeline.yml
+++ b/1pr-azure-pipeline.yml
@@ -75,3 +75,4 @@ stages:
         os: windows
       useOneEngineeringPool: false
       SignType: Test
+      PRERELEASE: true

--- a/pipeline-templates/package-vsix.yaml
+++ b/pipeline-templates/package-vsix.yaml
@@ -1,6 +1,7 @@
 parameters:
   pool: ''
   SignType: ''
+  PRERELEASE: false
 
 jobs:
 - job: ${{ parameters.pool.os }}_Package
@@ -39,7 +40,11 @@ jobs:
   - bash: |
       npm i -g rimraf
       npm i -g @vscode/vsce
-      vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn
+      if [ "${{ parameters.PRERELEASE }}" = "true" ]; then
+        vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn --pre-release
+      else
+        vsce package -o $(package-name)-$(GetVersion.version).vsix --ignoreFile ../.vscodeignore --yarn
+      fi
       cp $(package-name)-$(GetVersion.version).vsix ../packages/$(package-name)-$(GetVersion.version).vsix
     displayName: 📦 Package Artifact
     workingDirectory: $(dir-name)

--- a/vscode-dotnet-runtime-extension/CHANGELOG.md
+++ b/vscode-dotnet-runtime-extension/CHANGELOG.md
@@ -11,11 +11,21 @@ and this project adheres to [Semantic Versioning].
 
 Breaking change: No longer download the latest runtime per every single request with `acquire`.
 Instead, update periodically, to prevent slow down on startup when new tooling must be acquired to be secure.
-Improve error messages and output minimization.
 Add API surface to get dotnet --list-sdks --arch or dotnet --list-runtimes --arch output.
+Add setting to specify a local .NET SDK.
+Reduce error messages and add verbose setting.
+
+## [2.3.7] - 2025-7-28 (Prerelease)
+
+Improve error messages and output minimization.
+Add setting to disable all messages.
+Improve logic for offline handling.
+Improve fallback logic for failure edge cases.
+Add a fallback for distro detection.
+Migrate to Node 22.
+Update dependencies.
 
 ## [2.3.6] - 2025-6-23
-
 
 Further performance enhancements.
 Increase aggression of caching.


### PR DESCRIPTION
This version should be a pre-release, and we want to add logic to automate that and do it more often. Code insiders uses pre-release builds by default and we want to use that to ensure safety with updates before a broader audience.