### PR TITLE
acquireStatus aware of offline Installs

### DIFF
--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -387,15 +387,25 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
     {
         const pathResult = await callWithErrorHandling(async () =>
         {
-            const mode = commandContext.mode ?? 'runtime' as DotnetInstallMode;
+            commandContext.mode ??= 'runtime' as DotnetInstallMode;
+            commandContext.architecture ??= DotnetCoreAcquisitionWorker.defaultArchitecture();
+            commandContext.installType ??= 'local' as DotnetInstallType;
+            commandContext.requestingExtensionId ??= 'unspecified';
             const worker = getAcquisitionWorker();
-            const workerContext = getAcquisitionWorkerContext(mode, commandContext);
+            const workerContext = getAcquisitionWorkerContext(commandContext.mode, commandContext);
 
             globalEventStream.post(new DotnetAcquisitionStatusRequested(commandContext.version, commandContext.requestingExtensionId));
+
+            const existingOfflinePath = await getExistingInstallIfOffline(worker, workerContext);
+            if (existingOfflinePath)
+            {
+                return Promise.resolve(existingOfflinePath);
+            }
+
             const runtimeVersionResolver = new VersionResolver(workerContext);
-            const resolvedVersion = await runtimeVersionResolver.getFullVersion(commandContext.version, mode);
+            const resolvedVersion = await runtimeVersionResolver.getFullVersion(commandContext.version, commandContext.mode);
             commandContext.version = resolvedVersion;
-            const dotnetPath = await worker.acquireStatus(workerContext, mode);
+            const dotnetPath = await worker.acquireStatus(workerContext, commandContext.mode);
             return dotnetPath;
         }, getIssueContext(existingPathConfigWorker)(commandContext.errorConfiguration, 'acquireStatus'));
         return pathResult;

--- a/vscode-dotnet-runtime-library/src/Utils/WebRequestWorkerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/WebRequestWorkerSingleton.ts
@@ -62,7 +62,7 @@ export class WebRequestWorkerSingleton
     private clientCreationError: any;
 
     protected constructor()
-{
+    {
         try
         {
             const uncachedAxiosClient = Axios.create();
@@ -272,7 +272,7 @@ export class WebRequestWorkerSingleton
     public async isOnline(timeoutSec: number, eventStream: IEventStream): Promise<boolean>
     {
         const microsoftServerHostName = 'www.microsoft.com';
-        const expectedDNSResolutionTimeMs = Math.max(timeoutSec * 10 * 2, 100); // Assumption: DNS resolution should take less than 1/50th of the time it'd take to download .NET.
+        const expectedDNSResolutionTimeMs = Math.max(timeoutSec * 2, 100); // Assumption: DNS resolution should take less than 1/50th of the time it'd take to download .NET.
         // ... 100 ms is there as a default to prevent the dns resolver from throwing a runtime error if the user sets timeoutSeconds to 0.
 
         const dnsResolver = new dns.promises.Resolver({ timeout: expectedDNSResolutionTimeMs });


### PR DESCRIPTION
The `acquireStatus` API does not use the offline detection logic to fallback to installed runtimes. This API in general is not needed anymore but it looks like we still have some API dependents and it was never officially deprecated, so we should support that.

This reimplements the same logic to do so and should help resolve https://github.com/dotnet/vscode-dotnet-runtime/issues/2325