### PR TITLE
Create API to get output of --list-runtimes and --list-sdks with arch

### DIFF
--- a/vscode-dotnet-runtime-library/src/IDotnetSearchContext.ts
+++ b/vscode-dotnet-runtime-library/src/IDotnetSearchContext.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+
+import { DotnetInstallMode } from './Acquisition/DotnetInstallMode';
+import { AcquireErrorConfiguration } from './Utils/ErrorHandler';
+
+export interface IDotnetSearchContext
+{
+    /**
+     * @remarks
+     * An API request data structure used for us to find installs that the specified host (dotnet.exe) can use.
+     *
+     * @property dotnetExecutablePath : A path to the dotnet executable, otherwise known as the dotnet host.
+     * A full path is preferred, as 'dotnet' will fail if 'which' or 'where' is corrupted.
+     * This property is optional. If it is not used, the value of the PATH will be used. This is not recommended.
+     * Instead, you should call 'dotnet.findPath' to find the host path that you'd like to use which contains the installs you want.
+     * Or, you should only call this API when you already know the host path you want to use.
+     *
+     * @property requestingExtensionId - The Extension that relies on our extension to acquire the runtime or .NET SDK. It MUST be provided.
+     *
+     * @property errorConfiguration - An set of options for the desired treat as error and error verbosity behaviors of the extension.
+
+     * @property architecture - Optional: The architecture of the host path given: (accepts 'x64', 'x86', 'arm64') - Will default to the executable architecture if detectable, else the `os.arch()`
+     *
+     * @property mode - Whether the install should be of the sdk, runtime, or aspnetcore (runtime).
+     * The 'runtime' modes will return both runtimes.
+     */
+    dotnetExecutablePath?: string;
+    requestingExtensionId?: string;
+    errorConfiguration?: AcquireErrorConfiguration;
+    architecture?: string;
+    mode: DotnetInstallMode;
+}

--- a/vscode-dotnet-runtime-library/src/IDotnetSearchResult.ts
+++ b/vscode-dotnet-runtime-library/src/IDotnetSearchResult.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+
+import { DotnetInstallMode } from './Acquisition/DotnetInstallMode';
+
+export interface IDotnetSearchResult
+{
+    mode: DotnetInstallMode,
+    version: string,
+    directory: string,
+    architecture: string // Architecture will default to os.arch() if it cannot be determined, which should not happen except in cases such as: a dotnet executable built for arm32 or custom architecture such as `Silicon Graphics SVx`, or a corrupt dotnet executable.
+};

--- a/vscode-dotnet-runtime-library/src/index.ts
+++ b/vscode-dotnet-runtime-library/src/index.ts
@@ -43,6 +43,8 @@ export * from './IDotnetAcquireResult';
 export * from './IDotnetEnsureDependenciesContext';
 export * from './IDotnetFindPathContext';
 export * from './IDotnetListVersionsContext';
+export * from './IDotnetSearchContext';
+export * from './IDotnetSearchResult';
 export * from './IDotnetUninstallContext';
 export * from './IExtensionContext';
 export * from './IExtensionState';


### PR DESCRIPTION
The motivation to do this is described in https://github.com/dotnet/vscode-dotnet-runtime/issues/2315 as well as the spec.

This will enable the caching and performance related code to be shared and was mainly implemented for the debugger so they can remove their call to dotnet --info.