### PR TITLE
No longer include color in output

### DIFF
--- a/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/CommandExecutor.ts
@@ -451,12 +451,18 @@ ${stderr}`));
             options.env.DOTNET_CLI_UI_LANGUAGE ??= 'en-US';
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             options.env.DOTNET_NOLOGO ??= 'true';
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            options.env.NO_COLOR ??= '1';
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            options.env.TERM ??= 'dumb';
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            options.env.GREP_OPTIONS = undefined;
         }
         else
         {
             options = {
                 cwd: path.resolve(__dirname), shell: true, encoding: 'utf8', env:
-                    { ...process.env, DOTNET_CLI_UI_LANGUAGE: 'en-US', DOTNET_NOLOGO: 'true' }
+                    { ...process.env, DOTNET_CLI_UI_LANGUAGE: 'en-US', DOTNET_NOLOGO: 'true', NO_COLOR: '1', TERM: 'dumb', GREP_OPTIONS: undefined }
             };
         }
 

--- a/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
@@ -132,6 +132,8 @@ const possiblyUsefulUpperCaseEnvVars = new Set<string>([ // This is a local vari
     'PWD',
     'BASHOPTS',
     'SHELLOPTS',
+    'GREP_OPTIONS'
+    'NO_COLOR',
     'PS1',
     'PS2',
     'DOTNET_INSTALL_TOOL_UNDER_TEST',


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/2269
The old env variables may mess up our output parsing, so we should unset them or prevent color formatting in output. Please see https://github.com/dotnet/vscode-dotnet-runtime/issues/2269

One concern is whether TERM=dumb would cause other failures, but in general this is only meant to disable ansi scape codes (for color and formatting) which we dont want, and this is recommended to be set for scripting. https://linux.die.net/man/7/term