### PR TITLE
Simplify Mac Installation Process

### DIFF
--- a/vscode-dotnet-runtime-library/src/Acquisition/IInstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IInstallationValidator.ts
@@ -10,5 +10,5 @@ export abstract class IInstallationValidator
 {
     constructor(protected readonly eventStream: IEventStream) {}
 
-    public abstract validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder?: boolean, failOnErr?: boolean): boolean;
+    public abstract validateDotnetInstall(install: DotnetInstall, dotnetPath: string, validateDirectory?: boolean, failOnErr?: boolean): boolean;
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/IInstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IInstallationValidator.ts
@@ -10,5 +10,5 @@ export abstract class IInstallationValidator
 {
     constructor(protected readonly eventStream: IEventStream) {}
 
-    public abstract validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder?: boolean, failOnErr?: boolean): void;
+    public abstract validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder?: boolean, failOnErr?: boolean): boolean;
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
@@ -114,7 +114,7 @@ export class InstallationValidator extends IInstallationValidator
         } catch (error)
         {
             return this.handleValidationError(
-                `${baseErrorMessage} Unable to verify that "${dotnetPath}" is a file: ${error}`,
+                `${baseErrorMessage} Unable to verify that "${dotnetPath}" is a file: ${JSON.stringify(error ?? '')}`,
                 context,
                 failOnErr
             );
@@ -155,7 +155,7 @@ export class InstallationValidator extends IInstallationValidator
         catch (error)
         {
             return this.handleValidationError(
-                `${baseErrorMessage} Unable to read dotnet directory "${dotnetPath}": ${error}`,
+                `${baseErrorMessage} Unable to read dotnet directory "${dotnetPath}": ${JSON.stringify(error ?? '')}`,
                 context,
                 failOnErr
             );

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
@@ -3,76 +3,209 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
 import * as fs from 'fs';
-import * as path from 'path';
 import * as os from 'os';
-import {
+import * as path from 'path';
+import
+{
     DotnetInstallationValidated,
     DotnetInstallationValidationError,
-    EventBasedError,
-    DotnetInstallationValidationMissed
+    DotnetInstallationValidationMissed,
+    EventBasedError
 } from '../EventStream/EventStreamEvents';
-import { IInstallationValidator } from './IInstallationValidator';
 import { DotnetInstall } from './DotnetInstall';
+import { IInstallationValidator } from './IInstallationValidator';
 
-export class InstallationValidator extends IInstallationValidator {
-    public validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder = false, failOnErr = true): boolean {
-        const dotnetValidationFailed = `Validation of .dotnet installation for version ${JSON.stringify(install)} failed:`;
-        const folder = path.dirname(dotnetPath);
+/**
+ * Context object containing information needed for validation operations.
+ */
+interface ValidationContext
+{
+    install: DotnetInstall;
+    dotnetPath: string;
+    baseErrorMessage: string;
+}
 
-        if(!isDotnetFolder)
+/**
+ * Validates .NET installations by checking for the existence and validity of .NET executables or directories.
+ * Provides options to either throw errors or return false on validation failure.
+ */
+export class InstallationValidator extends IInstallationValidator
+{
+    /**
+     * Validates a .NET installation by checking either an executable file or installation directory.
+     *
+     * @param install - The DotnetInstall object containing installation details
+     * @param dotnetPath - Path to the .NET executable or installation directory to validate
+     * @param validateDirectory - If true, validates the path as a directory; if false, validates as an executable file
+     * @param failOnErr - If true, throws an error on validation failure; if false, returns false and posts a validation missed event
+     * @returns true if validation passes, false if validation fails. Throws if failOnErr is true and validation fails.
+     * @remarks Validation is not completely exhaustive. Runtime files besides the executable may be missing.
+     * @throws EventBasedError if validation fails and failOnErr is true
+     */
+    public validateDotnetInstall(install: DotnetInstall, dotnetPath: string, validateDirectory = false, failOnErr = true): boolean
+    {
+        const validationContext = {
+            install,
+            dotnetPath,
+            baseErrorMessage: `Validation of .dotnet installation for version ${JSON.stringify(install)} failed:`
+        };
+
+        const isValid = validateDirectory
+            ? this.validateDotnetDirectory(validationContext, failOnErr)
+            : this.validateDotnetExecutable(validationContext, failOnErr);
+
+        if (isValid)
         {
-            if(!fs.existsSync(folder))
-            {
-                // this class should be rewritten to return false in this case and throw if desired by calling the func, also why is ichecking the folder if !isdotnetfolder...
-            }
-            this.assertOrThrowError(failOnErr, fs.existsSync(folder),
-            `${dotnetValidationFailed} Expected installation folder ${folder} does not exist.`, install, dotnetPath);
-
-            this.assertOrThrowError(failOnErr, fs.existsSync(dotnetPath),
-                `${dotnetValidationFailed} Expected executable does not exist at "${dotnetPath}"`, install, dotnetPath);
-
-            this.assertOrThrowError(failOnErr, fs.lstatSync(dotnetPath).isFile(),
-                `${dotnetValidationFailed} Expected executable file exists but is not a file: "${dotnetPath}"`, install, dotnetPath);
+            this.eventStream.post(new DotnetInstallationValidated(install));
         }
-        else
+
+        return isValid;
+    }
+
+    /**
+     * Validates a .NET executable file by checking:
+     * 1. Parent directory exists
+     * 2. Executable file exists
+     * 3. Path points to a file (not a directory)
+     *
+     * @param context - Validation context containing install details and paths
+     * @param failOnErr - Whether to throw on validation failure or return false
+     * @returns true if all validations pass, false otherwise
+     */
+    private validateDotnetExecutable(context: ValidationContext, failOnErr: boolean): boolean
+    {
+        const { dotnetPath, baseErrorMessage } = context;
+        const parentDirectory = path.dirname(dotnetPath);
+
+        // Check if parent directory exists
+        if (!this.validateCondition(
+            fs.existsSync(parentDirectory),
+            `${baseErrorMessage} Expected installation folder ${parentDirectory} does not exist.`,
+            context,
+            failOnErr
+        ))
         {
-            this.assertOrThrowError(failOnErr, fs.existsSync(folder),
-            `${dotnetValidationFailed} Expected dotnet folder ${dotnetPath} does not exist.`, install, dotnetPath);
-
-            try
-            {
-                this.assertOrThrowError(failOnErr, fs.readdirSync(folder).length !== 0,
-                `${dotnetValidationFailed} The dotnet folder is empty "${dotnetPath}"`, install, dotnetPath);
-            }
-            catch(error : any) // fs.readdirsync throws ENOENT so we need to recall the function
-            {
-                this.assertOrThrowError(failOnErr, false,
-                `${dotnetValidationFailed} The dotnet file dne "${dotnetPath}"`, install, dotnetPath);
-            }
+            return false;
         }
 
-        this.eventStream.post(new DotnetInstallationValidated(install));
+        // Check if executable exists
+        if (!this.validateCondition(
+            fs.existsSync(dotnetPath),
+            `${baseErrorMessage} Expected executable does not exist at "${dotnetPath}"`,
+            context,
+            failOnErr
+        ))
+        {
+            return false;
+        }
+
+        // Check if path points to a file (not a directory)
+        try
+        {
+            if (!this.validateCondition(
+                fs.lstatSync(dotnetPath).isFile(),
+                `${baseErrorMessage} Expected executable file exists but is not a file: "${dotnetPath}"`,
+                context,
+                failOnErr
+            ))
+            {
+                return false;
+            }
+        } catch (error)
+        {
+            return this.handleValidationError(
+                `${baseErrorMessage} Unable to verify that "${dotnetPath}" is a file: ${error}`,
+                context,
+                failOnErr
+            );
+        }
+
         return true;
     }
 
-    private assertOrThrowError(failOnErr : boolean, passedValidation: boolean, message: string, install: DotnetInstall, dotnetPath: string) {
-        if (!passedValidation && failOnErr)
+    private validateDotnetDirectory(context: ValidationContext, failOnErr: boolean): boolean
+    {
+        const { dotnetPath, baseErrorMessage } = context;
+
+        // Check if directory exists
+        if (!this.validateCondition(
+            fs.existsSync(dotnetPath),
+            `${baseErrorMessage} Expected dotnet folder ${dotnetPath} does not exist.`,
+            context,
+            failOnErr
+        ))
+        {
+            return false;
+        }
+
+        // Check if directory is not empty
+        try
+        {
+            const directoryContents = fs.readdirSync(dotnetPath);
+            if (!this.validateCondition(
+                directoryContents.length > 0,
+                `${baseErrorMessage} The dotnet folder is empty "${dotnetPath}"`,
+                context,
+                failOnErr
+            ))
+            {
+                return false;
+            }
+        }
+        catch (error)
+        {
+            return this.handleValidationError(
+                `${baseErrorMessage} Unable to read dotnet directory "${dotnetPath}": ${error}`,
+                context,
+                failOnErr
+            );
+        }
+
+        return true;
+    }
+
+    private validateCondition(
+        condition: boolean,
+        errorMessage: string,
+        context: ValidationContext,
+        failOnErr: boolean
+    ): boolean
+    {
+        if (!condition)
+        {
+            return this.handleValidationError(errorMessage, context, failOnErr);
+        }
+        return true;
+    }
+
+    private handleValidationError(
+        message: string,
+        context: ValidationContext,
+        failOnErr: boolean
+    ): boolean
+    {
+        const { install, dotnetPath } = context;
+
+        if (failOnErr)
         {
             this.eventStream.post(new DotnetInstallationValidationError(new Error(message), install, dotnetPath));
-            throw new EventBasedError('DotnetInstallationValidationError', message);
+            throw new EventBasedError('DotnetInstallationValidationError', this.enhanceErrorMessageForMacOS(message));
         }
-
-        if(os.platform() === 'darwin')
-        {
-            message = `Did you close the .NET Installer, cancel the installation, or refuse the password prompt? If you want to install the .NET SDK, please try again. If you are facing an error, please report it at https://github.com/dotnet/vscode-dotnet-runtime/issues.
-${message}`;
-        }
-
-        if(!passedValidation && !failOnErr)
+        else
         {
             this.eventStream?.post(new DotnetInstallationValidationMissed(new Error(message), message));
         }
 
         return false;
+    }
+
+    private enhanceErrorMessageForMacOS(message: string): string
+    {
+        if (os.platform() === 'darwin')
+        {
+            return `Did you close the .NET Installer, cancel the installation, or refuse the password prompt? If you want to install the .NET SDK, please try again. If you are facing an error, please report it at https://github.com/dotnet/vscode-dotnet-runtime/issues.
+${message}`;
+        }
+        return message;
     }
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallationValidator.ts
@@ -15,12 +15,16 @@ import { IInstallationValidator } from './IInstallationValidator';
 import { DotnetInstall } from './DotnetInstall';
 
 export class InstallationValidator extends IInstallationValidator {
-    public validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder = false, failOnErr = true): void {
+    public validateDotnetInstall(install: DotnetInstall, dotnetPath: string, isDotnetFolder = false, failOnErr = true): boolean {
         const dotnetValidationFailed = `Validation of .dotnet installation for version ${JSON.stringify(install)} failed:`;
         const folder = path.dirname(dotnetPath);
 
         if(!isDotnetFolder)
         {
+            if(!fs.existsSync(folder))
+            {
+                // this class should be rewritten to return false in this case and throw if desired by calling the func, also why is ichecking the folder if !isdotnetfolder...
+            }
             this.assertOrThrowError(failOnErr, fs.existsSync(folder),
             `${dotnetValidationFailed} Expected installation folder ${folder} does not exist.`, install, dotnetPath);
 
@@ -48,6 +52,7 @@ export class InstallationValidator extends IInstallationValidator {
         }
 
         this.eventStream.post(new DotnetInstallationValidated(install));
+        return true;
     }
 
     private assertOrThrowError(failOnErr : boolean, passedValidation: boolean, message: string, install: DotnetInstall, dotnetPath: string) {
@@ -65,7 +70,9 @@ ${message}`;
 
         if(!passedValidation && !failOnErr)
         {
-            this.eventStream?.post(new DotnetInstallationValidationMissed(new Error(message), message))
+            this.eventStream?.post(new DotnetInstallationValidationMissed(new Error(message), message));
         }
+
+        return false;
     }
 }

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -18,6 +18,9 @@ import
     DotnetUnexpectedInstallerOSError,
     EventBasedError,
     EventCancellationError,
+    MacInstallerBackupFailure,
+    MacInstallerBackupSuccess,
+    MacInstallerFailure,
     NetInstallerBeginExecutionEvent,
     NetInstallerEndExecutionEvent,
     OSXOpenNotAvailableError,
@@ -42,6 +45,7 @@ import { IGlobalInstaller } from './IGlobalInstaller';
 import { IRegistryReader } from './IRegistryReader';
 import { RegistryReader } from './RegistryReader';
 import { GLOBAL_INSTALL_STATE_MODIFIER_LOCK, UNABLE_TO_ACQUIRE_GLOBAL_LOCK_ERR } from './StringConstants';
+import { DotnetCoreAcquisitionWorker } from './DotnetCoreAcquisitionWorker';
 
 namespace validationPromptConstants
 {
@@ -416,6 +420,39 @@ If you were waiting for the install to succeed, please extend the timeout settin
         return arm64EmulationHostPath;
     }
 
+    private async darwinInstallBackup(installerPath: string) : Promise<string>
+    {
+        // The -W flag makes it so we wait for the installer .pkg to exit, though we are unable to get the exit code.
+        const possibleCommands =
+            [
+                CommandExecutor.makeCommand(`command`, [`-v`, `open`]),
+                CommandExecutor.makeCommand(`/usr/bin/open`, [])
+            ];
+
+        let workingCommand = await this.commandRunner.tryFindWorkingCommand(possibleCommands);
+        if (!workingCommand)
+        {
+            const error = new EventBasedError('OSXOpenNotAvailableError',
+                `The 'open' command on OSX was not detected. This is likely due to the PATH environment variable on your system being clobbered by another program.
+Please correct your PATH variable or make sure the 'open' utility is installed so .NET can properly execute.`);
+            this.acquisitionContext.eventStream.post(new OSXOpenNotAvailableError(error, getInstallFromContext(this.acquisitionContext)));
+            throw error;
+        }
+        else if (workingCommand.commandRoot === 'command')
+        {
+            workingCommand = CommandExecutor.makeCommand(`open`, [`-W`, `"${path.resolve(installerPath)}"`]);
+        }
+
+        this.acquisitionContext.eventStream.post(new NetInstallerBeginExecutionEvent(`The OS X .NET Installer has been launched.`));
+
+        const commandResult = await this.commandRunner.execute(workingCommand, { timeout: this.acquisitionContext.timeoutSeconds * 1000 }, false);
+
+        this.acquisitionContext.eventStream.post(new NetInstallerEndExecutionEvent(`The OS X .NET Installer has closed.`));
+        this.handleTimeout(commandResult);
+
+        return commandResult.status;
+    }
+
     /**
      *
      * @param installerPath The path to the installer file to run.
@@ -426,36 +463,37 @@ If you were waiting for the install to succeed, please extend the timeout settin
         if (os.platform() === 'darwin')
         {
             // For Mac:
-            // We don't rely on the installer because it doesn't allow us to run without sudo, and we don't want to handle the user password.
-            // The -W flag makes it so we wait for the installer .pkg to exit, though we are unable to get the exit code.
-            const possibleCommands =
-                [
-                    CommandExecutor.makeCommand(`command`, [`-v`, `open`]),
-                    CommandExecutor.makeCommand(`/usr/bin/open`, [])
-                ];
-
-            let workingCommand = await this.commandRunner.tryFindWorkingCommand(possibleCommands);
-            if (!workingCommand)
-            {
-                const error = new EventBasedError('OSXOpenNotAvailableError',
-                    `The 'open' command on OSX was not detected. This is likely due to the PATH environment variable on your system being clobbered by another program.
-Please correct your PATH variable or make sure the 'open' utility is installed so .NET can properly execute.`);
-                this.acquisitionContext.eventStream.post(new OSXOpenNotAvailableError(error, getInstallFromContext(this.acquisitionContext)));
-                throw error;
-            }
-            else if (workingCommand.commandRoot === 'command')
-            {
-                workingCommand = CommandExecutor.makeCommand(`open`, [`-W`, `"${path.resolve(installerPath)}"`]);
-            }
-
-            this.acquisitionContext.eventStream.post(new NetInstallerBeginExecutionEvent(`The OS X .NET Installer has been launched.`));
-
-            const commandResult = await this.commandRunner.execute(workingCommand, { timeout: this.acquisitionContext.timeoutSeconds * 1000 }, false);
-
+            const sudoInstallerCommand = CommandExecutor.makeCommand('installer', ['-pkg', `"${path.resolve(installerPath)}"`, '-target', '/'], true);
+                        this.acquisitionContext.eventStream.post(new NetInstallerBeginExecutionEvent(`The OS X .NET Installer has been launched.`));
+            const installerResult = await this.commandRunner.execute(sudoInstallerCommand);
             this.acquisitionContext.eventStream.post(new NetInstallerEndExecutionEvent(`The OS X .NET Installer has closed.`));
-            this.handleTimeout(commandResult);
+            this.handleTimeout(installerResult);
+ 
+            if(installerResult.status !== '0')
+            {
+                // Try to have the user manually go through the installation process
+                // Osascript has some issues running the installer for a pkg, and open does not have an exit code besides 0 if the user cancels/denies.
+                // For understanding the success rates, we can subtract the MacInstallerFailure amount but add back in MacInstallerBackupSuccess for when the user does succeed.
+                // This prevents counting a user who leaves the PC as a failure.
+                // The error code from the installer will give us a better understading of the installer issues and not count them as an issue in the VS Code setup logic
+                this.acquisitionContext.eventStream.post(new MacInstallerFailure(`The installer failed.`, installerResult.status, installerResult.stderr, installerResult.stdout));
+                await this.darwinInstallBackup(installerPath);
 
-            return commandResult.status;
+                const expectedDotnetHostPath = await this.getExpectedGlobalSDKPath(this.acquisitionContext.acquisitionContext.version, this.acquisitionContext.acquisitionContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture());
+                const expectedInstall = getInstallFromContext(this.acquisitionContext);
+                const validatedInstall = this.acquisitionContext.installationValidator.validateDotnetInstall(expectedInstall, expectedDotnetHostPath, os.platform() === 'darwin', false);
+                if()
+                {
+                    this.acquisitionContext.eventStream.post(new MacInstallerBackupSuccess(`The installer succeeded when invoked manually.`));
+                    return '0';
+                }
+                else
+                {
+                    // Add this back to the failure count as it gets accounted for in the platfom agnostic logc
+                                        this.acquisitionContext.eventStream.post(new MacInstallerBackupFailure(`The installer also failed when invoked manually.`));
+                }
+            }
+            return installerResult.status;
         }
         else
         {

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -481,7 +481,7 @@ Please correct your PATH variable or make sure the 'open' utility is installed s
 
                 const expectedDotnetHostPath = await this.getExpectedGlobalSDKPath(this.acquisitionContext.acquisitionContext.version, this.acquisitionContext.acquisitionContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture());
                 const expectedInstall = getInstallFromContext(this.acquisitionContext);
-                const validatedInstall = this.acquisitionContext.installationValidator.validateDotnetInstall(expectedInstall, expectedDotnetHostPath, os.platform() === 'darwin', false);
+                const validatedInstall = this.acquisitionContext.installationValidator.validateDotnetInstall(expectedInstall, expectedDotnetHostPath, false, false);
                 if (validatedInstall)
                 {
                     this.acquisitionContext.eventStream.post(new MacInstallerBackupSuccess(`The installer succeeded when invoked manually.`));

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -13,36 +13,44 @@ import { EventType } from './EventType';
 import { IEvent } from './IEvent';
 import { TelemetryUtilities } from './TelemetryUtilities';
 
-export class EventCancellationError extends Error {
-    constructor(public readonly eventType: string, msg: string, stack?: string) {
+export class EventCancellationError extends Error
+{
+    constructor(public readonly eventType: string, msg: string, stack?: string)
+    {
         super(msg);
     }
 }
 
-export class EventBasedError extends Error {
-    constructor(public readonly eventType: string, msg: string, stack?: string) {
+export class EventBasedError extends Error
+{
+    constructor(public readonly eventType: string, msg: string, stack?: string)
+    {
         super(msg);
     }
 }
 
-export abstract class GenericModalEvent extends IEvent {
+export abstract class GenericModalEvent extends IEvent
+{
     abstract readonly mode: DotnetInstallMode;
     abstract readonly installType: DotnetInstallType;
 }
 
-export class DotnetAcquisitionStarted extends GenericModalEvent {
+export class DotnetAcquisitionStarted extends GenericModalEvent
+{
     public readonly eventName = 'DotnetAcquisitionStarted';
     public readonly type = EventType.DotnetAcquisitionStart;
     public readonly mode: DotnetInstallMode;
     public readonly installType: DotnetInstallType;
 
-    constructor(public readonly install: DotnetInstall, public readonly startingVersion: string, public readonly requestingExtensionId = '') {
+    constructor(public readonly install: DotnetInstall, public readonly startingVersion: string, public readonly requestingExtensionId = '')
+    {
         super();
         this.mode = install.installMode;
         this.installType = install.isGlobal ? 'global' : 'local';
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             ...InstallToStrings(this.install),
             AcquisitionStartVersion: this.startingVersion,
@@ -52,49 +60,59 @@ export class DotnetAcquisitionStarted extends GenericModalEvent {
     }
 }
 
-abstract class DotnetAcquisitionStartedBase extends IEvent {
-    constructor(public readonly requestingExtensionId = '') {
+abstract class DotnetAcquisitionStartedBase extends IEvent
+{
+    constructor(public readonly requestingExtensionId = '')
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return { extensionId: TelemetryUtilities.HashData(this.requestingExtensionId) };
     }
 }
 
-export class DotnetRuntimeAcquisitionStarted extends DotnetAcquisitionStartedBase {
+export class DotnetRuntimeAcquisitionStarted extends DotnetAcquisitionStartedBase
+{
     public readonly eventName = 'DotnetRuntimeAcquisitionStarted';
     public readonly type = EventType.DotnetModalChildEvent;
 }
 
-export class DotnetSDKAcquisitionStarted extends DotnetAcquisitionStartedBase {
+export class DotnetSDKAcquisitionStarted extends DotnetAcquisitionStartedBase
+{
     public readonly eventName = 'DotnetSDKAcquisitionStarted';
     public readonly type = EventType.DotnetModalChildEvent;
 }
 
-export class DotnetGlobalSDKAcquisitionStarted extends DotnetAcquisitionStartedBase {
+export class DotnetGlobalSDKAcquisitionStarted extends DotnetAcquisitionStartedBase
+{
     public readonly eventName = 'DotnetGlobalSDKAcquisitionStarted';
     public readonly type = EventType.DotnetModalChildEvent;
 }
 
-export class DotnetASPNetRuntimeAcquisitionStarted extends DotnetAcquisitionStartedBase {
+export class DotnetASPNetRuntimeAcquisitionStarted extends DotnetAcquisitionStartedBase
+{
     public readonly eventName = 'DotnetASPNetRuntimeAcquisitionStarted';
     public readonly type = EventType.DotnetModalChildEvent;
 }
 
-export class DotnetAcquisitionTotalSuccessEvent extends GenericModalEvent {
+export class DotnetAcquisitionTotalSuccessEvent extends GenericModalEvent
+{
     public readonly type = EventType.DotnetTotalSuccessEvent;
     public readonly eventName = 'DotnetAcquisitionTotalSuccessEvent';
     public readonly mode;
     public readonly installType: DotnetInstallType;
 
-    constructor(public readonly startingVersion: string, public readonly install: DotnetInstall, public readonly requestingExtensionId = '', public readonly finalPath: string) {
+    constructor(public readonly startingVersion: string, public readonly install: DotnetInstall, public readonly requestingExtensionId = '', public readonly finalPath: string)
+    {
         super();
         this.mode = install.installMode;
         this.installType = install.isGlobal ? 'global' : 'local';
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             AcquisitionStartVersion: this.startingVersion,
             AcquisitionInstallId: this.install.installId,
@@ -105,46 +123,55 @@ export class DotnetAcquisitionTotalSuccessEvent extends GenericModalEvent {
     }
 }
 
-abstract class DotnetAcquisitionTotalSuccessEventBase extends IEvent {
+abstract class DotnetAcquisitionTotalSuccessEventBase extends IEvent
+{
     public readonly type = EventType.DotnetModalChildEvent;
 
-    constructor(public readonly installId: DotnetInstall) {
+    constructor(public readonly installId: DotnetInstall)
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             ...InstallToStrings(this.installId),
         };
     }
 }
 
-export class DotnetRuntimeAcquisitionTotalSuccessEvent extends DotnetAcquisitionTotalSuccessEventBase {
+export class DotnetRuntimeAcquisitionTotalSuccessEvent extends DotnetAcquisitionTotalSuccessEventBase
+{
     public readonly eventName = 'DotnetRuntimeAcquisitionTotalSuccessEvent';
 }
 
-export class DotnetGlobalSDKAcquisitionTotalSuccessEvent extends DotnetAcquisitionTotalSuccessEventBase {
+export class DotnetGlobalSDKAcquisitionTotalSuccessEvent extends DotnetAcquisitionTotalSuccessEventBase
+{
     public readonly eventName = 'DotnetGlobalSDKAcquisitionTotalSuccessEvent';
 }
 
-export class DotnetASPNetRuntimeAcquisitionTotalSuccessEvent extends DotnetAcquisitionTotalSuccessEventBase {
+export class DotnetASPNetRuntimeAcquisitionTotalSuccessEvent extends DotnetAcquisitionTotalSuccessEventBase
+{
     public readonly eventName = 'DotnetASPNetRuntimeAcquisitionTotalSuccessEvent';
 }
 
 
-export class DotnetAcquisitionRequested extends GenericModalEvent {
+export class DotnetAcquisitionRequested extends GenericModalEvent
+{
     public readonly eventName = 'DotnetAcquisitionRequested';
     public readonly type = EventType.DotnetTotalSuccessEvent;
     public readonly mode;
     public readonly installType: DotnetInstallType;
 
-    constructor(public readonly startingVersion: string, public readonly requestingId = '', mode: DotnetInstallMode, installType: DotnetInstallType) {
+    constructor(public readonly startingVersion: string, public readonly requestingId = '', mode: DotnetInstallMode, installType: DotnetInstallType)
+    {
         super();
         this.mode = mode;
         this.installType = installType;
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             AcquisitionStartVersion: this.startingVersion,
             RequestingExtensionId: TelemetryUtilities.HashData(this.requestingId)
@@ -153,14 +180,17 @@ export class DotnetAcquisitionRequested extends GenericModalEvent {
 }
 
 
-abstract class DotnetAcquisitionRequestedEventBase extends IEvent {
+abstract class DotnetAcquisitionRequestedEventBase extends IEvent
+{
     public readonly type = EventType.DotnetModalChildEvent;
 
-    constructor(public readonly startingVersion: string, public readonly requestingId = '', public readonly mode: DotnetInstallMode) {
+    constructor(public readonly startingVersion: string, public readonly requestingId = '', public readonly mode: DotnetInstallMode)
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             AcquisitionStartVersion: this.startingVersion,
             RequestingExtensionId: TelemetryUtilities.HashData(this.requestingId),
@@ -169,36 +199,44 @@ abstract class DotnetAcquisitionRequestedEventBase extends IEvent {
     }
 }
 
-export class DotnetRuntimeAcquisitionRequested extends DotnetAcquisitionRequestedEventBase {
+export class DotnetRuntimeAcquisitionRequested extends DotnetAcquisitionRequestedEventBase
+{
     public readonly eventName = 'DotnetRuntimeAcquisitionRequested';
 }
 
-export class DotnetGlobalSDKAcquisitionRequested extends DotnetAcquisitionRequestedEventBase {
+export class DotnetGlobalSDKAcquisitionRequested extends DotnetAcquisitionRequestedEventBase
+{
     public readonly eventName = 'DotnetGlobalSDKAcquisitionRequested';
 }
 
-export class DotnetASPNetRuntimeAcquisitionRequested extends DotnetAcquisitionRequestedEventBase {
+export class DotnetASPNetRuntimeAcquisitionRequested extends DotnetAcquisitionRequestedEventBase
+{
     public readonly eventName = 'DotnetASPNetRuntimeAcquisitionRequested';
 }
 
 
-export class DotnetAcquisitionCompleted extends IEvent {
+export class DotnetAcquisitionCompleted extends IEvent
+{
     public readonly eventName = 'DotnetAcquisitionCompleted';
     public readonly type = EventType.DotnetAcquisitionCompleted;
 
-    constructor(public readonly install: DotnetInstall, public readonly dotnetPath: string, public readonly version: string) {
+    constructor(public readonly install: DotnetInstall, public readonly dotnetPath: string, public readonly version: string)
+    {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        if (telemetry) {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
+        if (telemetry)
+        {
             return {
                 ...InstallToStrings(this.install),
                 AcquisitionCompletedInstallId: this.install.installId,
                 AcquisitionCompletedVersion: this.version
             };
         }
-        else {
+        else
+        {
             return {
                 ...InstallToStrings(this.install),
                 AcquisitionCompletedVersion: this.version,
@@ -209,7 +247,8 @@ export class DotnetAcquisitionCompleted extends IEvent {
     }
 }
 
-export abstract class DotnetAcquisitionError extends IEvent {
+export abstract class DotnetAcquisitionError extends IEvent
+{
     public type = EventType.DotnetAcquisitionError;
     public isError = true;
 
@@ -219,11 +258,13 @@ export abstract class DotnetAcquisitionError extends IEvent {
      * @param install For acquisition errors, you MUST include this install id. For commands unrelated to acquiring or managing a specific dotnet version, you
      * have the option to leave this parameter null. If it is NULL during acquisition the extension CANNOT properly manage what it has finished installing or not.
      */
-    constructor(public readonly error: Error, public readonly install: DotnetInstall | null) {
+    constructor(public readonly error: Error, public readonly install: DotnetInstall | null)
+    {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
             ErrorName: this.error.name,
             ErrorMessage: this.error.message,
@@ -234,19 +275,22 @@ export abstract class DotnetAcquisitionError extends IEvent {
     }
 }
 
-export class DotnetAcquisitionFinalError extends GenericModalEvent {
+export class DotnetAcquisitionFinalError extends GenericModalEvent
+{
     public readonly type = EventType.DotnetAcquisitionFinalError;
     public readonly eventName = 'DotnetAcquisitionFinalError';
     public readonly mode;
     public readonly installType: DotnetInstallType;
 
-    constructor(public readonly error: Error, public readonly originalEventName: string, public readonly install: DotnetInstall) {
+    constructor(public readonly error: Error, public readonly originalEventName: string, public readonly install: DotnetInstall)
+    {
         super();
         this.mode = install.installMode;
         this.installType = install.isGlobal ? 'global' : 'local';
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
             ErrorName: this.error.name,
             ErrorMessage: this.error.message,
@@ -262,14 +306,17 @@ export class DotnetAcquisitionFinalError extends GenericModalEvent {
  * This allows us to count all errors and analyze them into categories.
  * The event name for the failure cause is stored in the originalEventName property.
  */
-abstract class DotnetAcquisitionFinalErrorBase extends DotnetAcquisitionError {
+abstract class DotnetAcquisitionFinalErrorBase extends DotnetAcquisitionError
+{
 
-    constructor(public readonly error: Error, public readonly originalEventName: string, public readonly install: DotnetInstall) {
+    constructor(public readonly error: Error, public readonly originalEventName: string, public readonly install: DotnetInstall)
+    {
         super(error, install);
         this.type = EventType.DotnetAcquisitionFinalError;
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
             FailureMode: this.originalEventName,
             ErrorName: this.error.name,
@@ -281,27 +328,33 @@ abstract class DotnetAcquisitionFinalErrorBase extends DotnetAcquisitionError {
     }
 }
 
-export class DotnetGlobalSDKAcquisitionError extends DotnetAcquisitionFinalErrorBase {
+export class DotnetGlobalSDKAcquisitionError extends DotnetAcquisitionFinalErrorBase
+{
     public eventName = 'DotnetGlobalSDKAcquisitionError';
 }
 
-export class DotnetRuntimeFinalAcquisitionError extends DotnetAcquisitionFinalErrorBase {
+export class DotnetRuntimeFinalAcquisitionError extends DotnetAcquisitionFinalErrorBase
+{
     public eventName = 'DotnetRuntimeFinalAcquisitionError';
 }
 
-export class DotnetASPNetRuntimeFinalAcquisitionError extends DotnetAcquisitionFinalErrorBase {
+export class DotnetASPNetRuntimeFinalAcquisitionError extends DotnetAcquisitionFinalErrorBase
+{
     public eventName = 'DotnetASPNetRuntimeFinalAcquisitionError';
 }
 
-export abstract class DotnetNonAcquisitionError extends IEvent {
+export abstract class DotnetNonAcquisitionError extends IEvent
+{
     public readonly type = EventType.DotnetAcquisitionError;
     public isError = true;
 
-    constructor(public readonly error: Error) {
+    constructor(public readonly error: Error)
+    {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
             ErrorName: this.error.name,
             ErrorMessage: this.error.message,
@@ -310,7 +363,8 @@ export abstract class DotnetNonAcquisitionError extends IEvent {
     }
 }
 
-export abstract class DotnetInstallExpectedAbort extends IEvent {
+export abstract class DotnetInstallExpectedAbort extends IEvent
+{
     public readonly type = EventType.DotnetInstallExpectedAbort;
     public isError = true;
 
@@ -320,12 +374,15 @@ export abstract class DotnetInstallExpectedAbort extends IEvent {
      * @param install For acquisition errors, you MUST include this install id. For commands unrelated to acquiring or managing a specific dotnet version, you
      * have the option to leave this parameter null. If it is NULL during acquisition the extension CANNOT properly manage what it has finished installing or not.
      */
-    constructor(public readonly error: Error, public readonly install: DotnetInstall | null) {
+    constructor(public readonly error: Error, public readonly install: DotnetInstall | null)
+    {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        if (this.install) {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
+        if (this.install)
+        {
             return {
                 ErrorName: this.error?.name ?? 'GenericError',
                 ErrorMessage: this.error?.message ?? 'ErrorMessage not provided',
@@ -334,7 +391,8 @@ export abstract class DotnetInstallExpectedAbort extends IEvent {
                 ...InstallToStrings(this.install) ?? 'No Install Info'
             };
         }
-        else {
+        else
+        {
             return {
                 ErrorName: this.error.name,
                 ErrorMessage: this.error.message,
@@ -345,15 +403,18 @@ export abstract class DotnetInstallExpectedAbort extends IEvent {
     }
 }
 
-export class SuppressedAcquisitionError extends IEvent {
+export class SuppressedAcquisitionError extends IEvent
+{
     public eventName = 'SuppressedAcquisitionError';
     public readonly type = EventType.SuppressedAcquisitionError;
 
-    constructor(public readonly error: Error, public readonly supplementalMessage: string) {
+    constructor(public readonly error: Error, public readonly supplementalMessage: string)
+    {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
             SupplementMessage: this.supplementalMessage,
             ErrorName: this.error.name,
@@ -363,62 +424,77 @@ export class SuppressedAcquisitionError extends IEvent {
     }
 }
 
-export class DotnetInstallScriptAcquisitionError extends DotnetAcquisitionError {
+export class DotnetInstallScriptAcquisitionError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetInstallScriptAcquisitionError';
 }
 
-export class UserManualInstallFailure extends SuppressedAcquisitionError {
+export class UserManualInstallFailure extends SuppressedAcquisitionError
+{
     eventName = 'UserManualInstallFailure';
 }
 
-export class OfflineDetectionLogicTriggered extends SuppressedAcquisitionError {
+export class OfflineDetectionLogicTriggered extends SuppressedAcquisitionError
+{
     eventName = 'OfflineDetectionLogicTriggered';
 }
 
-export class DotnetInstallationValidationMissed extends SuppressedAcquisitionError {
+export class DotnetInstallationValidationMissed extends SuppressedAcquisitionError
+{
     eventName = 'DotnetInstallationValidationMissed';
 }
 
-export class OSXOpenNotAvailableError extends DotnetAcquisitionError {
+export class OSXOpenNotAvailableError extends DotnetAcquisitionError
+{
     public readonly eventName = 'OSXOpenNotAvailableError';
 }
 
-export class WebRequestError extends DotnetAcquisitionError {
+export class WebRequestError extends DotnetAcquisitionError
+{
     public readonly eventName = 'WebRequestError';
 }
 
-export class DiskIsFullError extends DotnetAcquisitionError {
+export class DiskIsFullError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DiskIsFullError';
 }
 
-export class DotnetDownloadFailure extends DotnetAcquisitionError {
+export class DotnetDownloadFailure extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetDownloadFailure';
 }
 
-export class DotnetPreinstallDetectionError extends DotnetAcquisitionError {
+export class DotnetPreinstallDetectionError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetPreinstallDetectionError';
 }
 
-export class TimeoutSudoProcessSpawnerError extends DotnetAcquisitionError {
+export class TimeoutSudoProcessSpawnerError extends DotnetAcquisitionError
+{
     public readonly eventName = 'TimeoutSudoProcessSpawnerError';
 }
 
-export class TimeoutSudoCommandExecutionError extends DotnetAcquisitionError {
+export class TimeoutSudoCommandExecutionError extends DotnetAcquisitionError
+{
     public readonly eventName = 'TimeoutSudoCommandExecutionError';
 }
 
-export class CommandExecutionNonZeroExitFailure extends DotnetAcquisitionError {
+export class CommandExecutionNonZeroExitFailure extends DotnetAcquisitionError
+{
     public readonly eventName = 'CommandExecutionNonZeroExitFailure';
 }
 
-export class DotnetNotInstallRelatedCommandFailed extends DotnetNonAcquisitionError {
+export class DotnetNotInstallRelatedCommandFailed extends DotnetNonAcquisitionError
+{
     public readonly eventName = 'DotnetNotInstallRelatedCommandFailed';
 
-    constructor(error: Error, public readonly command: string) {
+    constructor(error: Error, public readonly command: string)
+    {
         super(error);
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
             ErrorMessage: this.error.message,
             CommandName: this.command,
@@ -428,18 +504,22 @@ export class DotnetNotInstallRelatedCommandFailed extends DotnetNonAcquisitionEr
     }
 }
 
-export class InvalidUninstallRequest extends DotnetNonAcquisitionError {
+export class InvalidUninstallRequest extends DotnetNonAcquisitionError
+{
     public readonly eventName = 'InvalidUninstallRequest';
 }
 
-export class DotnetCommandFailed extends DotnetAcquisitionError {
+export class DotnetCommandFailed extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetCommandFailed';
 
-    constructor(error: Error, public readonly command: string, install: DotnetInstall | null) {
+    constructor(error: Error, public readonly command: string, install: DotnetInstall | null)
+    {
         super(error, install);
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
             ErrorMessage: this.error.message,
             CommandName: this.command,
@@ -451,44 +531,55 @@ export class DotnetCommandFailed extends DotnetAcquisitionError {
     }
 }
 
-export class DotnetInvalidReleasesJSONError extends DotnetAcquisitionError {
+export class DotnetInvalidReleasesJSONError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetInvalidReleasesJSONError';
 }
 
-export class DotnetNoInstallerFileExistsError extends DotnetAcquisitionError {
+export class DotnetNoInstallerFileExistsError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetNoInstallerFileExistsError';
 }
 
-export class DotnetNoInstallerResponseError extends DotnetInstallExpectedAbort {
+export class DotnetNoInstallerResponseError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetNoInstallerResponseError';
 }
 
-export class DotnetUnexpectedInstallerOSError extends DotnetAcquisitionError {
+export class DotnetUnexpectedInstallerOSError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetUnexpectedInstallerOSError';
 }
 
-export class DotnetUnexpectedInstallerArchitectureError extends DotnetAcquisitionError {
+export class DotnetUnexpectedInstallerArchitectureError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetUnexpectedInstallerArchitectureError';
 }
 
-export class DotnetFeatureBandDoesNotExistError extends DotnetAcquisitionError {
+export class DotnetFeatureBandDoesNotExistError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetFeatureBandDoesNotExistError';
 }
 
-export class DotnetInvalidRuntimePatchVersion extends DotnetAcquisitionError {
+export class DotnetInvalidRuntimePatchVersion extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetInvalidRuntimePatchVersion';
 }
 
-export class DotnetWSLSecurityError extends DotnetInstallExpectedAbort {
+export class DotnetWSLSecurityError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetWSLSecurityError';
 }
 
-export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionError {
-    constructor(error: Error, public readonly install: DotnetInstall | null) {
+export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionError
+{
+    constructor(error: Error, public readonly install: DotnetInstall | null)
+    {
         super(error, install);
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return this.install ? {
             ErrorMessage: this.error.message,
             AcquisitionErrorInstallId: this.install.installId ?? 'null',
@@ -506,52 +597,65 @@ export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionErr
     }
 }
 
-export class DotnetAcquisitionUnexpectedError extends DotnetAcquisitionVersionError {
+export class DotnetAcquisitionUnexpectedError extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'DotnetAcquisitionUnexpectedError';
 }
 
-export class DotnetAcquisitionInstallError extends DotnetAcquisitionVersionError {
+export class DotnetAcquisitionInstallError extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'DotnetAcquisitionInstallError';
 }
 
-export class DotnetAcquisitionScriptError extends DotnetAcquisitionVersionError {
+export class DotnetAcquisitionScriptError extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'DotnetAcquisitionScriptError';
 }
 
-export class DotnetConflictingGlobalWindowsInstallError extends DotnetInstallExpectedAbort {
+export class DotnetConflictingGlobalWindowsInstallError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetConflictingGlobalWindowsInstallError';
 }
 
-export class DotnetInstallCancelledByUserError extends DotnetInstallExpectedAbort {
+export class DotnetInstallCancelledByUserError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetInstallCancelledByUserError';
 }
 
 
 
-export class DotnetNonZeroInstallerExitCodeError extends DotnetAcquisitionError {
+export class DotnetNonZeroInstallerExitCodeError extends DotnetAcquisitionError
+{
     public readonly eventName = 'DotnetNonZeroInstallerExitCodeError';
 }
 
-export class DotnetOfflineFailure extends DotnetAcquisitionVersionError {
+export class DotnetOfflineFailure extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'DotnetOfflineFailure';
 }
 
-export class PowershellBadLanguageMode extends DotnetAcquisitionVersionError {
+export class PowershellBadLanguageMode extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'PowershellBadLanguageMode';
 }
 
-export class PowershellBadExecutionPolicy extends DotnetAcquisitionVersionError {
+export class PowershellBadExecutionPolicy extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'PowershellBadExecutionPolicy';
 }
-export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError {
+export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'DotnetAcquisitionTimeoutError';
 
-    constructor(error: Error, installId: DotnetInstall | null, public readonly timeoutValue: number) {
+    constructor(error: Error, installId: DotnetInstall | null, public readonly timeoutValue: number)
+    {
         super(error, installId);
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        if (this.install) {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
+        if (this.install)
+        {
             return {
                 ErrorMessage: this.error.message,
                 TimeoutValue: this.timeoutValue.toString(),
@@ -560,7 +664,8 @@ export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError
                 StackTrace: this.error.stack ? this.error.stack : ''
             };
         }
-        else {
+        else
+        {
             return {
                 ErrorMessage: this.error.message,
                 TimeoutValue: this.timeoutValue.toString(),
@@ -572,28 +677,35 @@ export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError
 
 }
 
-export class DotnetVersionResolutionError extends DotnetInstallExpectedAbort {
+export class DotnetVersionResolutionError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetVersionResolutionError';
 }
 
-export class DotnetConflictingLinuxInstallTypesError extends DotnetInstallExpectedAbort {
+export class DotnetConflictingLinuxInstallTypesError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetConflictingLinuxInstallTypesError';
 }
 
-export class DotnetCustomLinuxInstallExistsError extends DotnetInstallExpectedAbort {
+export class DotnetCustomLinuxInstallExistsError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetCustomLinuxInstallExistsError';
 }
 
-export class DotnetInstallationValidationError extends DotnetAcquisitionVersionError {
+export class DotnetInstallationValidationError extends DotnetAcquisitionVersionError
+{
     public readonly eventName = 'DotnetInstallationValidationError';
     public readonly fileStructure: string;
-    constructor(error: Error, install: DotnetInstall, public readonly dotnetPath: string) {
+    constructor(error: Error, install: DotnetInstall, public readonly dotnetPath: string)
+    {
         super(error, install);
         this.fileStructure = this.getFileStructure();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
-        if (this.install) {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
+        if (this.install)
+        {
             return {
                 ErrorMessage: this.error.message,
                 AcquisitionErrorInstallId: this.install?.installId ?? 'null',
@@ -604,7 +716,8 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
                 FileStructure: this.fileStructure
             };
         }
-        else {
+        else
+        {
             return {
                 ErrorMessage: this.error.message,
                 AcquisitionErrorInstallId: 'null',
@@ -616,20 +729,25 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
         }
     }
 
-    private getFileStructure(): string {
+    private getFileStructure(): string
+    {
         const folderPath = path.dirname(this.dotnetPath);
-        if (!fs.existsSync(folderPath)) {
+        if (!fs.existsSync(folderPath))
+        {
             return `Dotnet Path (${path.basename(folderPath)}) does not exist`;
         }
         // Get 2 levels worth of content of the folder
         let files = fs.readdirSync(folderPath).map(file => path.join(folderPath, file));
-        for (const file of files) {
-            if (fs.statSync(file).isDirectory()) {
+        for (const file of files)
+        {
+            if (fs.statSync(file).isDirectory())
+            {
                 files = files.concat(fs.readdirSync(file).map(fileName => path.join(file, fileName)));
             }
         }
         const relativeFiles: string[] = [];
-        for (const file of files) {
+        for (const file of files)
+        {
             relativeFiles.push(path.relative(path.dirname(folderPath), file));
         }
 
@@ -637,10 +755,12 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
     }
 }
 
-export class DotnetAcquisitionDistroUnknownError extends DotnetInstallExpectedAbort {
+export class DotnetAcquisitionDistroUnknownError extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'DotnetAcquisitionDistroUnknownError';
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
             ErrorMessage: this.error.message,
             ErrorName: this.error.name,
@@ -652,38 +772,46 @@ export class DotnetAcquisitionDistroUnknownError extends DotnetInstallExpectedAb
 }
 
 
-export abstract class DotnetAcquisitionSuccessEvent extends IEvent {
+export abstract class DotnetAcquisitionSuccessEvent extends IEvent
+{
     public readonly type = EventType.DotnetAcquisitionSuccessEvent;
 
-    public getProperties(): { [id: string]: string } | undefined {
+    public getProperties(): { [id: string]: string } | undefined
+    {
         return undefined;
     }
 }
 
-export class DotnetCommandSucceeded extends DotnetAcquisitionSuccessEvent {
+export class DotnetCommandSucceeded extends DotnetAcquisitionSuccessEvent
+{
     public readonly eventName = 'DotnetCommandSucceeded';
 
     constructor(public readonly commandName: string) { super(); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return { CommandName: this.commandName };
     }
 }
 
-export class DotnetUninstallAllStarted extends DotnetAcquisitionSuccessEvent {
+export class DotnetUninstallAllStarted extends DotnetAcquisitionSuccessEvent
+{
     public readonly eventName = 'DotnetUninstallAllStarted';
 }
 
-export class DotnetUninstallAllCompleted extends DotnetAcquisitionSuccessEvent {
+export class DotnetUninstallAllCompleted extends DotnetAcquisitionSuccessEvent
+{
     public readonly eventName = 'DotnetUninstallAllCompleted';
 }
 
-export class DotnetVersionResolutionCompleted extends DotnetAcquisitionSuccessEvent {
+export class DotnetVersionResolutionCompleted extends DotnetAcquisitionSuccessEvent
+{
     public readonly eventName = 'DotnetVersionResolutionCompleted';
 
     constructor(public readonly requestedVersion: string, public readonly resolvedVersion: string) { super(); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             RequestedVersion: this.requestedVersion,
             ResolvedVersion: this.resolvedVersion
@@ -691,100 +819,123 @@ export class DotnetVersionResolutionCompleted extends DotnetAcquisitionSuccessEv
     }
 }
 
-export class DotnetInstallScriptAcquisitionCompleted extends DotnetAcquisitionSuccessEvent {
+export class DotnetInstallScriptAcquisitionCompleted extends DotnetAcquisitionSuccessEvent
+{
     public readonly eventName = 'DotnetInstallScriptAcquisitionCompleted';
 }
 
-export class DotnetExistingPathResolutionCompleted extends DotnetAcquisitionSuccessEvent {
+export class DotnetExistingPathResolutionCompleted extends DotnetAcquisitionSuccessEvent
+{
     public readonly eventName = 'DotnetExistingPathResolutionCompleted';
 
     constructor(public readonly resolvedPath: string) { super(); }
 
-    public getProperties(telemetry = false) {
+    public getProperties(telemetry = false)
+    {
         return telemetry ? undefined : { ConfiguredPath: this.resolvedPath };
     }
 }
 
-export abstract class DotnetAcquisitionMessage extends IEvent {
+export abstract class DotnetAcquisitionMessage extends IEvent
+{
     public type = EventType.DotnetAcquisitionMessage;
 
-    public getProperties(): { [id: string]: string } | undefined {
+    public getProperties(): { [id: string]: string } | undefined
+    {
         return {};
     }
 }
 
-export class DotnetAcquisitionDeletion extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionDeletion extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionDeletion';
     constructor(public readonly folderPath: string) { super(); }
 
-    public getProperties(telemetry = false) {
+    public getProperties(telemetry = false)
+    {
         return telemetry ? undefined : { DeletedFolderPath: this.folderPath };
     }
 }
 
-export class DotnetFallbackInstallScriptUsed extends DotnetAcquisitionMessage {
+export class DotnetFallbackInstallScriptUsed extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetFallbackInstallScriptUsed';
 }
 
-export abstract class DotnetCustomMessageEvent extends DotnetAcquisitionMessage {
+export abstract class DotnetCustomMessageEvent extends DotnetAcquisitionMessage
+{
     constructor(public readonly eventMessage: string) { super(); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return { Message: this.eventMessage };
     }
 }
 
-export abstract class DotnetVisibleWarningEvent extends DotnetCustomMessageEvent {
+export abstract class DotnetVisibleWarningEvent extends DotnetCustomMessageEvent
+{
     public readonly type = EventType.DotnetVisibleWarning;
 }
 
-export class DotnetFileIntegrityFailureEvent extends DotnetVisibleWarningEvent {
+export class DotnetFileIntegrityFailureEvent extends DotnetVisibleWarningEvent
+{
     public readonly eventName = 'DotnetFileIntegrityFailureEvent';
 }
 
-export class DotnetUnableToCheckPATHArchitecture extends DotnetVisibleWarningEvent {
+export class DotnetUnableToCheckPATHArchitecture extends DotnetVisibleWarningEvent
+{
     public readonly eventName = 'DotnetUnableToCheckPATHArchitecture';
 }
 
-export class UtilizingExistingInstallPromise extends DotnetCustomMessageEvent {
+export class UtilizingExistingInstallPromise extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'UtilizingExistingInstallPromise';
 }
 
-export class FileIsBusy extends DotnetCustomMessageEvent {
+export class FileIsBusy extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FileIsBusy';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { ...super.getProperties(), ...getDisabledTelemetryOnChance(1) };
     }
 }
 
-export class FileIsNotBusy extends DotnetCustomMessageEvent {
+export class FileIsNotBusy extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FileIsNotBusy';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { ...super.getProperties(), ...getDisabledTelemetryOnChance(1) };
     }
 }
 
-export class DotnetVersionCategorizedEvent extends DotnetCustomMessageEvent {
+export class DotnetVersionCategorizedEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetVersionCategorizedEvent';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DuplicateInstallDetected extends DotnetCustomMessageEvent {
+export class DuplicateInstallDetected extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DuplicateInstallDetected';
 }
 
-export abstract class WebRequestTimer extends DotnetCustomMessageEvent {
+export abstract class WebRequestTimer extends DotnetCustomMessageEvent
+{
 
     constructor(public readonly eventMessage: string, public readonly durationMs: string,
         public readonly finished: string, public readonly url: string, public readonly status: string
     ) { super(eventMessage); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             Message: this.eventMessage,
             DurationMs: this.durationMs,
@@ -796,12 +947,14 @@ export abstract class WebRequestTimer extends DotnetCustomMessageEvent {
     }
 }
 
-export class CommandExecutionTimer extends DotnetCustomMessageEvent {
+export class CommandExecutionTimer extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionTimer';
 
     constructor(public readonly eventMessage: string, public readonly durationMs: string, public readonly commandRoot: string, public readonly fullCommandString: string) { super(eventMessage); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             ...super.getProperties(), DurationMs: this.durationMs, CommandRoot: TelemetryUtilities.HashAllPaths(this.fullCommandString),
             HashedFullCommand: TelemetryUtilities.HashData(this.commandRoot)
@@ -809,585 +962,729 @@ export class CommandExecutionTimer extends DotnetCustomMessageEvent {
     }
 }
 
-export class WebRequestTime extends WebRequestTimer {
+export class WebRequestTime extends WebRequestTimer
+{
     public readonly eventName = 'WebRequestTime';
 }
 
-export class WebRequestCachedTime extends WebRequestTimer {
+export class WebRequestCachedTime extends WebRequestTimer
+{
     public readonly eventName = 'WebRequestCachedTime';
 }
 
-export class WebRequestTimeUnknown extends WebRequestTimer {
+export class WebRequestTimeUnknown extends WebRequestTimer
+{
     public readonly eventName = 'WebRequestTimeUnknown';
 }
 
-export class EmptyDirectoryToWipe extends DotnetCustomMessageEvent {
+export class EmptyDirectoryToWipe extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'EmptyDirectoryToWipe';
 }
 
-export class ProxyUsed extends DotnetCustomMessageEvent {
+export class ProxyUsed extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'ProxyUsed';
 }
 
-export class FileToWipe extends DotnetCustomMessageEvent {
+export class FileToWipe extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FileToWipe';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { ...getDisabledTelemetryOnChance(1), ...super.getProperties() };
     }
 }
 
-export class TriedToExitMasterSudoProcess extends DotnetCustomMessageEvent {
+export class TriedToExitMasterSudoProcess extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'TriedToExitMasterSudoProcess';
 }
 
-export class FeatureBandDoesNotExist extends DotnetCustomMessageEvent {
+export class FeatureBandDoesNotExist extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FeatureBandDoesNotExist';
 }
 
-export class FileDoesNotExist extends DotnetCustomMessageEvent {
+export class FileDoesNotExist extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FileDoesNotExist';
 }
 
-export class DotnetUninstallStarted extends DotnetCustomMessageEvent {
+export class DotnetUninstallStarted extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetUninstallStarted';
     public type = EventType.DotnetUninstallMessage;
 }
 
-export class DotnetUninstallCompleted extends DotnetCustomMessageEvent {
+export class DotnetUninstallCompleted extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetUninstallStarted';
     public type = EventType.DotnetUninstallMessage;
 }
 
-export class DotnetUninstallFailed extends DotnetCustomMessageEvent {
+export class DotnetUninstallFailed extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetUninstallStarted';
     public type = EventType.DotnetUninstallMessage;
 }
 
 
-export class DotnetUninstallSkipped extends DotnetCustomMessageEvent {
+export class DotnetUninstallSkipped extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetUninstallSkipped';
     public type = EventType.DotnetUninstallMessage;
 }
 
-export class NoExtensionIdProvided extends DotnetCustomMessageEvent {
+export class NoExtensionIdProvided extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'NoExtensionIdProvided';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { ...getDisabledTelemetryOnChance(1), ...super.getProperties() };
     }
 }
 
-export class ConvertingLegacyInstallRecord extends DotnetCustomMessageEvent {
+export class ConvertingLegacyInstallRecord extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'ConvertingLegacyInstallRecord';
 }
-export class FoundTrackingVersions extends DotnetCustomMessageEvent {
+export class FoundTrackingVersions extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FoundTrackingVersions';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class RemovingVersionFromExtensionState extends DotnetCustomMessageEvent {
+export class RemovingVersionFromExtensionState extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'RemovingVersionFromExtensionState';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class RemovingExtensionFromList extends DotnetCustomMessageEvent {
+export class RemovingExtensionFromList extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'RemovingExtensionFromList';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class RemovingOwnerFromList extends DotnetCustomMessageEvent {
+export class RemovingOwnerFromList extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'RemovingOwnerFromList';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class SkipAddingInstallEvent extends DotnetCustomMessageEvent {
+export class SkipAddingInstallEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SkipAddingInstallEvent';
 }
 
-export class AddTrackingVersions extends DotnetCustomMessageEvent {
+export class AddTrackingVersions extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'AddTrackingVersions';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetWSLCheckEvent extends DotnetCustomMessageEvent {
+export class DotnetWSLCheckEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetWSLCheckEvent';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetWSLOperationOutputEvent extends DotnetCustomMessageEvent {
+export class DotnetWSLOperationOutputEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetWSLOperationOutputEvent';
 }
 
-export class DotnetFindPathCommandInvoked extends DotnetCustomMessageEvent {
+export class DotnetFindPathCommandInvoked extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathCommandInvoked';
     constructor(public readonly eventMessage: string, public readonly request: IDotnetFindPathContext) { super(eventMessage); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return { Message: this.eventMessage, Context: JSON.stringify(this.request) };
     };
 }
 
-export class WebCacheClearEvent extends DotnetCustomMessageEvent {
+export class WebCacheClearEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'WebCacheClearEvent';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { ...getDisabledTelemetryOnChance(1), ...super.getProperties() };
     }
 }
 
-export class CacheClearEvent extends DotnetCustomMessageEvent {
+export class CacheClearEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CacheClearEvent';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { ...getDisabledTelemetryOnChance(1), ...super.getProperties() };
     }
 }
 
-export class CachePutEvent extends DotnetCustomMessageEvent {
+export class CachePutEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CachePutEvent';
     constructor(public readonly eventMessage: string, public readonly indexStr: string, public readonly value: string, public readonly ttl: string) { super(eventMessage); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return { Message: this.eventMessage, indexStr: this.indexStr, value: this.value, ttl: this.ttl, ...getDisabledTelemetryOnChance(1) };
     };
 }
 
-export class CacheGetEvent extends DotnetCustomMessageEvent {
+export class CacheGetEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CacheGetEvent';
     constructor(public readonly eventMessage: string, public readonly indexStr: string, public readonly value: string) { super(eventMessage); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return { Message: this.eventMessage, indexStr: this.indexStr, value: this.value, ...getDisabledTelemetryOnChance(1) };
     };
 }
 
-export class DotnetFindPathLookupSetting extends DotnetCustomMessageEvent {
+export class DotnetFindPathLookupSetting extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathLookupSetting';
 }
 
-export class CacheAliasCreated extends DotnetCustomMessageEvent {
+export class CacheAliasCreated extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CacheAliasCreated';
-    public getProperties() {
+    public getProperties()
+    {
         return { Message: this.eventMessage, ...getDisabledTelemetryOnChance(1) };
     };
 }
 
-export class DotnetFindPathSettingFound extends DotnetCustomMessageEvent {
+export class DotnetFindPathSettingFound extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathSettingFound';
 }
 
-export class DotnetFindPathLookupPATH extends DotnetCustomMessageEvent {
+export class DotnetFindPathLookupPATH extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathLookupPATH';
 }
 
-export class DotnetFindPathPATHFound extends DotnetCustomMessageEvent {
+export class DotnetFindPathPATHFound extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathPATHFound';
 }
 
-export class DotnetFindPathLookupRealPATH extends DotnetCustomMessageEvent {
+export class DotnetFindPathLookupRealPATH extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathLookupRealPATH';
 }
 
-export class DotnetFindPathRealPATHFound extends DotnetCustomMessageEvent {
+export class DotnetFindPathRealPATHFound extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
-export class DotnetConditionsValidated extends DotnetCustomMessageEvent {
+export class DotnetConditionsValidated extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetConditionsValidated';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { ...getDisabledTelemetryOnChance(1), ...super.getProperties() };
     }
 }
 
-export class DotnetFindPathHostFxrResolutionLookup extends DotnetCustomMessageEvent {
+export class DotnetFindPathHostFxrResolutionLookup extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathHostFxrResolutionLookup';
 }
 
-export class DotnetFindPathOnRegistry extends DotnetCustomMessageEvent {
+export class DotnetFindPathOnRegistry extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathOnRegistry';
 }
 
-export class DotnetFindPathNoHostOnRegistry extends DotnetCustomMessageEvent {
+export class DotnetFindPathNoHostOnRegistry extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathNoHostOnRegistry';
 }
 
-export class SudoDirCreationFailed extends DotnetCustomMessageEvent {
+export class SudoDirCreationFailed extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SudoDirCreationFailed';
 }
 
-export class SudoDirDeletionFailed extends DotnetCustomMessageEvent {
+export class SudoDirDeletionFailed extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SudoDirDeletionFailed';
 }
 
-export class DotnetFindPathOnFileSystem extends DotnetCustomMessageEvent {
+export class DotnetFindPathOnFileSystem extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathOnFileSystem';
 }
 
-export class DotnetFindPathNoHostOnFileSystem extends DotnetCustomMessageEvent {
+export class DotnetFindPathNoHostOnFileSystem extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathNoHostOnFileSystem';
 }
 
-export class DotnetFindPathNoRuntimesOnHost extends DotnetCustomMessageEvent {
+export class DotnetFindPathNoRuntimesOnHost extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathNoRuntimesOnHost';
 }
 
-export class DotnetFindPathLookupRootPATH extends DotnetCustomMessageEvent {
+export class DotnetFindPathLookupRootPATH extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathLookupRealPATH';
 }
 
-export class DotnetFindPathRootEmulationPATHFound extends DotnetCustomMessageEvent {
+export class DotnetFindPathRootEmulationPATHFound extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
-export class DotnetFindPathRootUnderEmulationButNoneSet extends DotnetCustomMessageEvent {
+export class DotnetFindPathRootUnderEmulationButNoneSet extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
-export class DotnetFindPathRootPATHFound extends DotnetCustomMessageEvent {
+export class DotnetFindPathRootPATHFound extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
-export class DotnetFindPathMetCondition extends DotnetCustomMessageEvent {
+export class DotnetFindPathMetCondition extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathMetCondition';
 }
 
-export class DotnetFindPathNoPathMetCondition extends DotnetCustomMessageEvent {
+export class DotnetFindPathNoPathMetCondition extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathNoPathMetCondition';
 }
 
-export class DotnetFindPathDidNotMeetCondition extends DotnetCustomMessageEvent {
+export class DotnetFindPathDidNotMeetCondition extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFindPathDidNotMeetCondition';
 }
 
-export class DotnetTelemetrySettingEvent extends DotnetCustomMessageEvent {
+export class DotnetTelemetrySettingEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetTelemetrySettingEvent';
 }
 
-export class MacInstallerFailure extends DotnetCustomMessageEvent {
+export class MacInstallerFailure extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'MacInstallerFailure';
 
-    constructor(message: string, private readonly status: string, private readonly stdout: string, private readonly stderr: string) {
+    constructor(message: string, private readonly status: string, private readonly stdout: string, private readonly stderr: string)
+    {
         super(message);
     }
-    public getProperties() {
+    public getProperties()
+    {
         return { Status: this.status, Stdout: this.stdout, StdErr: this.stderr, ...super.getProperties() };
     }
 }
 
-export class MacInstallerBackupSuccess extends DotnetCustomMessageEvent {
+export class MacInstallerBackupSuccess extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'MacInstallerBackupSuccess';
 }
 
-export class MacInstallerBackupFailure extends DotnetCustomMessageEvent {
+export class MacInstallerBackupFailure extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'MacInstallerBackupSuccess';
 }
 
-export class DistroSupport extends DotnetCustomMessageEvent {
+export class DistroSupport extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DistroSupport';
 }
 
-export class FeedInjection extends DotnetCustomMessageEvent {
+export class FeedInjection extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FeedInjection';
 }
 
-export class FeedInjectionStarted extends DotnetCustomMessageEvent {
+export class FeedInjectionStarted extends DotnetCustomMessageEvent
+{
     type = EventType.FeedInjectionMessage
     public readonly eventName = 'FeedInjectionStarted';
 }
 
-export class FeedInjectionFinished extends DotnetCustomMessageEvent {
+export class FeedInjectionFinished extends DotnetCustomMessageEvent
+{
     type = EventType.FeedInjectionMessage
     public readonly eventName = 'FeedInjectionFinished';
 }
 
-export class DistroPackagesSearch extends DotnetCustomMessageEvent {
+export class DistroPackagesSearch extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DistroPackagesSearch';
 }
 
-export class FoundDistroVersionDetails extends DotnetCustomMessageEvent {
+export class FoundDistroVersionDetails extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FoundDistroVersionDetails';
 }
 
-export class DotnetVSCodeExtensionFound extends DotnetCustomMessageEvent {
+export class DotnetVSCodeExtensionFound extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetVSCodeExtensionFound';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetVSCodeExtensionHasInstallRequest extends DotnetCustomMessageEvent {
+export class DotnetVSCodeExtensionHasInstallRequest extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetVSCodeExtensionHasInstallRequest';
 }
 
-export class DotnetVSCodeExtensionChange extends DotnetCustomMessageEvent {
+export class DotnetVSCodeExtensionChange extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetVSCodeExtensionChange';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetCommandNotFoundEvent extends DotnetCustomMessageEvent {
+export class DotnetCommandNotFoundEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetCommandNotFoundEvent';
 }
 
-export class DotnetFileIntegrityCheckEvent extends DotnetCustomMessageEvent {
+export class DotnetFileIntegrityCheckEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFileIntegrityCheckEvent';
 }
 
-export class GlobalAcquisitionContextMenuOpened extends DotnetCustomMessageEvent {
+export class GlobalAcquisitionContextMenuOpened extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'GlobalAcquisitionContextMenuOpened';
 }
 
-export class UserManualInstallVersionChosen extends DotnetCustomMessageEvent {
+export class UserManualInstallVersionChosen extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'UserManualInstallVersionChosen';
 }
 
-export class UserManualInstallRequested extends DotnetCustomMessageEvent {
+export class UserManualInstallRequested extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'UserManualInstallRequested';
 }
 
-export class UserManualInstallSuccess extends DotnetCustomMessageEvent {
+export class UserManualInstallSuccess extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'UserManualInstallSuccess';
 }
 
-export class CommandExecutionStdOut extends DotnetCustomMessageEvent {
+export class CommandExecutionStdOut extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionStdOut';
 }
 
-export class NoMatchingInstallToStopTracking extends DotnetCustomMessageEvent {
+export class NoMatchingInstallToStopTracking extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'NoMatchingInstallToStopTracking';
 }
 
-export class CommandExecutionStdError extends DotnetCustomMessageEvent {
+export class CommandExecutionStdError extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionStdError';
 }
 
-export class DotnetGlobalAcquisitionBeginEvent extends DotnetCustomMessageEvent {
+export class DotnetGlobalAcquisitionBeginEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetGlobalAcquisitionBeginEvent';
 }
 
-export class DotnetGlobalVersionResolutionCompletionEvent extends DotnetCustomMessageEvent {
+export class DotnetGlobalVersionResolutionCompletionEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetGlobalVersionResolutionCompletionEvent';
 }
 
-export class CommandProcessesExecutionFailureNonTerminal extends DotnetCustomMessageEvent {
+export class CommandProcessesExecutionFailureNonTerminal extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandProcessesExecutionFailureNonTerminal';
 }
 
-export class CommandProcessorExecutionBegin extends DotnetCustomMessageEvent {
+export class CommandProcessorExecutionBegin extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandProcessorExecutionBegin';
 }
 
-export class CommandProcessorExecutionEnd extends DotnetCustomMessageEvent {
+export class CommandProcessorExecutionEnd extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandProcessorExecutionEnd';
 }
 
-export class DotnetBeginGlobalInstallerExecution extends DotnetCustomMessageEvent {
+export class DotnetBeginGlobalInstallerExecution extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetBeginGlobalInstallerExecution';
 }
 
-export class DotnetCompletedGlobalInstallerExecution extends DotnetCustomMessageEvent {
+export class DotnetCompletedGlobalInstallerExecution extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetCompletedGlobalInstallerExecution';
 }
 
-export class DotnetGlobalAcquisitionCompletionEvent extends DotnetCustomMessageEvent {
+export class DotnetGlobalAcquisitionCompletionEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetGlobalAcquisitionCompletionEvent';
 }
 
-export class DotnetAlternativeCommandFoundEvent extends DotnetCustomMessageEvent {
+export class DotnetAlternativeCommandFoundEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetAlternativeCommandFoundEvent';
 }
 
-export class DotnetCommandFallbackArchitectureEvent extends DotnetCustomMessageEvent {
+export class DotnetCommandFallbackArchitectureEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetCommandFallbackArchitectureEvent';
 }
 
-export class DotnetCommandFallbackOSEvent extends DotnetCustomMessageEvent {
+export class DotnetCommandFallbackOSEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetCommandFallbackOSEvent';
 }
 
-export class DotnetInstallIdCreatedEvent extends DotnetCustomMessageEvent {
+export class DotnetInstallIdCreatedEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetInstallIdCreatedEvent';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetLegacyInstallDetectedEvent extends DotnetCustomMessageEvent {
+export class DotnetLegacyInstallDetectedEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetLegacyInstallDetectedEvent';
 }
 
-export class DotnetLegacyInstallRemovalRequestEvent extends DotnetCustomMessageEvent {
+export class DotnetLegacyInstallRemovalRequestEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetLegacyInstallRemovalRequestEvent';
 }
 
-export class DotnetFakeSDKEnvironmentVariableTriggered extends DotnetCustomMessageEvent {
+export class DotnetFakeSDKEnvironmentVariableTriggered extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetFakeSDKEnvironmentVariableTriggered';
 }
 
-export class CommandExecutionNoStatusCodeWarning extends DotnetCustomMessageEvent {
+export class CommandExecutionNoStatusCodeWarning extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionNoStatusCodeWarning';
 }
 
-export class CommandExecutionSignalSentEvent extends DotnetCustomMessageEvent {
+export class CommandExecutionSignalSentEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionSignalSentEvent';
 }
 
-export class CommandExecutionStatusEvent extends DotnetCustomMessageEvent {
+export class CommandExecutionStatusEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionStatusEvent';
 }
 
-export class CommandExecutionEvent extends DotnetCustomMessageEvent {
+export class CommandExecutionEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionEvent';
 }
 
-export class SudoProcAliveCheckBegin extends DotnetCustomMessageEvent {
+export class SudoProcAliveCheckBegin extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SudoProcAliveCheckBegin';
 }
 
-export class SudoProcAliveCheckEnd extends DotnetCustomMessageEvent {
+export class SudoProcAliveCheckEnd extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SudoProcAliveCheckEnd';
 }
 
-export class SudoProcCommandExchangeBegin extends DotnetCustomMessageEvent {
+export class SudoProcCommandExchangeBegin extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SudoProcCommandExchangeBegin';
 }
 
-export class SudoProcCommandExchangePing extends DotnetCustomMessageEvent {
+export class SudoProcCommandExchangePing extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SudoProcCommandExchangePing';
 }
 
-export class WaitingForDotnetInstallerResponse extends DotnetCustomMessageEvent {
+export class WaitingForDotnetInstallerResponse extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'WaitingForDotnetInstallerResponse';
 }
 
-export class SudoProcCommandExchangeEnd extends DotnetCustomMessageEvent {
+export class SudoProcCommandExchangeEnd extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'SudoProcCommandExchangeEnd';
 }
 
-export class CommandExecutionUserAskDialogueEvent extends DotnetCustomMessageEvent {
+export class CommandExecutionUserAskDialogueEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionUserAskDialogueEvent';
 }
 
-export class CommandExecutionUserCompletedDialogueEvent extends DotnetCustomMessageEvent {
+export class CommandExecutionUserCompletedDialogueEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionUserCompletedDialogueEvent';
 }
 
-export class CommandExecutionUnderSudoEvent extends DotnetCustomMessageEvent {
+export class CommandExecutionUnderSudoEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'CommandExecutionUnderSudoEvent';
-    public getProperties() {
+    public getProperties()
+    {
         return { ...getDisabledTelemetryOnChance(1), ...super.getProperties() };
     }
 }
 
-export class CommandExecutionUserRejectedPasswordRequest extends DotnetInstallExpectedAbort {
+export class CommandExecutionUserRejectedPasswordRequest extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'CommandExecutionUserRejectedPasswordRequest';
 }
 
-export class CommandExecutionUnknownCommandExecutionAttempt extends DotnetInstallExpectedAbort {
+export class CommandExecutionUnknownCommandExecutionAttempt extends DotnetInstallExpectedAbort
+{
     public readonly eventName = 'CommandExecutionUnknownCommandExecutionAttempt';
 }
 
-export class DotnetVersionParseEvent extends DotnetCustomMessageEvent {
+export class DotnetVersionParseEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetVersionParseEvent';
 }
 
-export class DotnetUpgradedEvent extends DotnetCustomMessageEvent {
+export class DotnetUpgradedEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetUpgradedEvent';
-    constructor(eventMsg: string) {
+    constructor(eventMsg: string)
+    {
         super(eventMsg);
         this.type = EventType.DotnetUpgradedEvent;
     }
 }
 
-export class DotnetOfflineInstallUsed extends DotnetCustomMessageEvent {
+export class DotnetOfflineInstallUsed extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetOfflineInstallUsed';
-    constructor(eventMsg: string) {
+    constructor(eventMsg: string)
+    {
         super(eventMsg);
         this.type = EventType.OfflineInstallUsed;
     }
 }
 
-export class DotnetOfflineWarning extends DotnetCustomMessageEvent {
+export class DotnetOfflineWarning extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetOfflineWarning';
-    constructor(eventMsg: string) {
+    constructor(eventMsg: string)
+    {
         super(eventMsg);
         this.type = EventType.OfflineWarning;
     }
 }
 
-export class NetInstallerBeginExecutionEvent extends DotnetCustomMessageEvent {
+export class NetInstallerBeginExecutionEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'NetInstallerBeginExecutionEvent';
 }
 
-export class NetInstallerEndExecutionEvent extends DotnetCustomMessageEvent {
+export class NetInstallerEndExecutionEvent extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'NetInstallerEndExecutionEvent';
 }
 
-export class FailedToRunSudoCommand extends DotnetCustomMessageEvent {
+export class FailedToRunSudoCommand extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'FailedToRunSudoCommand';
 }
 
-export class DotnetInstallLinuxChecks extends DotnetCustomMessageEvent {
+export class DotnetInstallLinuxChecks extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetInstallLinuxChecks';
 }
 
-export abstract class DotnetFileEvent extends DotnetAcquisitionMessage {
+export abstract class DotnetFileEvent extends DotnetAcquisitionMessage
+{
     constructor(public readonly eventMessage: string, public readonly time: string, public readonly file: string) { super(); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return { Message: this.eventMessage, Time: this.time, File: TelemetryUtilities.HashData(this.file) };
     }
 }
 
-export abstract class DotnetLockEvent extends DotnetFileEvent {
+export abstract class DotnetLockEvent extends DotnetFileEvent
+{
     constructor(public readonly eventMessage: string, public readonly time: string, public readonly lock: string, public readonly file: string) { super(eventMessage, time, file); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return { Message: this.eventMessage, Time: this.time, Lock: this.lock, File: this.file, ...getDisabledTelemetryOnChance(1) };
     }
 }
 
-export class GenericDotnetLockEvent extends DotnetLockEvent {
+export class GenericDotnetLockEvent extends DotnetLockEvent
+{
     public readonly eventName = 'GenericDotnetLockEvent';
 }
 
-export class DotnetFileWriteRequestEvent extends DotnetFileEvent {
+export class DotnetFileWriteRequestEvent extends DotnetFileEvent
+{
     public readonly eventName = 'DotnetFileWriteRequestEvent';
 
-    public getProperties() {
+    public getProperties()
+    {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetAcquisitionPartialInstallation extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionPartialInstallation extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionPartialInstallation';
     constructor(public readonly install: DotnetInstall) { super(); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             ...InstallToStrings(this.install!),
             PartialInstallationInstallId: this.install.installId
@@ -1395,13 +1692,15 @@ export class DotnetAcquisitionPartialInstallation extends DotnetAcquisitionMessa
     }
 }
 
-export class DotnetAcquisitionInProgress extends IEvent {
+export class DotnetAcquisitionInProgress extends IEvent
+{
     public readonly type = EventType.DotnetAcquisitionInProgress;
 
     public readonly eventName = 'DotnetAcquisitionInProgress';
     constructor(public readonly install: DotnetInstall, public readonly requestingExtensionId: string | null) { super(); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             InProgressInstallationInstallId: this.install.installId,
             ...InstallToStrings(this.install!),
@@ -1410,13 +1709,15 @@ export class DotnetAcquisitionInProgress extends IEvent {
     }
 }
 
-export class DotnetAcquisitionAlreadyInstalled extends IEvent {
+export class DotnetAcquisitionAlreadyInstalled extends IEvent
+{
     public readonly eventName = 'DotnetAcquisitionAlreadyInstalled';
     public readonly type = EventType.DotnetAcquisitionAlreadyInstalled;
 
     constructor(public readonly install: DotnetInstall, public readonly requestingExtensionId: string | null) { super(); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             ...InstallToStrings(this.install),
             extensionId: TelemetryUtilities.HashData(this.requestingExtensionId)
@@ -1424,20 +1725,24 @@ export class DotnetAcquisitionAlreadyInstalled extends IEvent {
     }
 }
 
-export class DotnetAcquisitionMissingLinuxDependencies extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionMissingLinuxDependencies extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionMissingLinuxDependencies';
 }
 
-export class DotnetAcquisitionThoughtInstalledButNot extends DotnetCustomMessageEvent {
+export class DotnetAcquisitionThoughtInstalledButNot extends DotnetCustomMessageEvent
+{
     public readonly eventName = 'DotnetAcquisitionThoughtInstalledButNot';
 }
 
-export class DotnetAcquisitionScriptOutput extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionScriptOutput extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionScriptOutput';
     public isError = true;
     constructor(public readonly install: DotnetInstall, public readonly output: string) { super(); }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
             AcquisitionInstallId: this.install.installId,
             ...InstallToStrings(this.install!),
@@ -1446,11 +1751,13 @@ export class DotnetAcquisitionScriptOutput extends DotnetAcquisitionMessage {
     }
 }
 
-export class DotnetInstallationValidated extends DotnetAcquisitionMessage {
+export class DotnetInstallationValidated extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetInstallationValidated';
     constructor(public readonly install: DotnetInstall) { super(); }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined
+    {
         return {
             ValidatedInstallId: this.install.installId,
             ...InstallToStrings(this.install!)
@@ -1458,15 +1765,18 @@ export class DotnetInstallationValidated extends DotnetAcquisitionMessage {
     }
 }
 
-export class DotnetAcquisitionStatusRequested extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionStatusRequested extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionStatusRequested';
 
     constructor(public readonly version: string,
-        public readonly requestingId = '') {
+        public readonly requestingId = '')
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             AcquisitionStartVersion: this.version,
             RequestingExtensionId: TelemetryUtilities.HashData(this.requestingId)
@@ -1474,14 +1784,17 @@ export class DotnetAcquisitionStatusRequested extends DotnetAcquisitionMessage {
     }
 }
 
-export class DotnetAcquisitionStatusUndefined extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionStatusUndefined extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionStatusUndefined';
 
-    constructor(public readonly installId: DotnetInstall) {
+    constructor(public readonly installId: DotnetInstall)
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             AcquisitionStatusInstallId: this.installId.installId,
             ...InstallToStrings(this.installId!)
@@ -1489,14 +1802,17 @@ export class DotnetAcquisitionStatusUndefined extends DotnetAcquisitionMessage {
     }
 }
 
-export class DotnetAcquisitionStatusResolved extends DotnetAcquisitionMessage {
+export class DotnetAcquisitionStatusResolved extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetAcquisitionStatusResolved';
 
-    constructor(public readonly installId: DotnetInstall, public readonly version: string) {
+    constructor(public readonly installId: DotnetInstall, public readonly version: string)
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             AcquisitionStatusInstallId: this.installId.installId,
             ...InstallToStrings(this.installId!),
@@ -1505,48 +1821,59 @@ export class DotnetAcquisitionStatusResolved extends DotnetAcquisitionMessage {
     }
 }
 
-export class WebRequestSent extends DotnetAcquisitionMessage {
+export class WebRequestSent extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'WebRequestSent';
 
-    constructor(public readonly url: string) {
+    constructor(public readonly url: string)
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return { WebRequestUri: this.url };
     }
 }
 
-export class WebRequestUsingAltClient extends DotnetAcquisitionMessage {
+export class WebRequestUsingAltClient extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'WebRequestUsingAltClient';
 
-    constructor(public readonly url: string, public readonly msg: string) {
+    constructor(public readonly url: string, public readonly msg: string)
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return { WebRequestUri: this.url, Message: this.msg };
     }
 }
 
 
-export class WebRequestInitiated extends DotnetAcquisitionMessage {
+export class WebRequestInitiated extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'WebRequestInitiated';
 
-    constructor(public readonly url: string) {
+    constructor(public readonly url: string)
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return { WebRequestUri: this.url };
     }
 }
 
-export class DotnetPreinstallDetected extends DotnetAcquisitionMessage {
+export class DotnetPreinstallDetected extends DotnetAcquisitionMessage
+{
     public readonly eventName = 'DotnetPreinstallDetected';
     constructor(public readonly installId: DotnetInstall) { super(); }
 
-    public getProperties() {
+    public getProperties()
+    {
         return {
             ...InstallToStrings(this.installId!),
             PreinstalledInstallId: this.installId.installId
@@ -1554,19 +1881,23 @@ export class DotnetPreinstallDetected extends DotnetAcquisitionMessage {
     }
 }
 
-export class TestAcquireCalled extends IEvent {
+export class TestAcquireCalled extends IEvent
+{
     public readonly eventName = 'TestAcquireCalled';
     public readonly type = EventType.DotnetAcquisitionTest;
 
-    constructor(public readonly context: IDotnetInstallationContext) {
+    constructor(public readonly context: IDotnetInstallationContext)
+    {
         super();
     }
 
-    public getProperties() {
+    public getProperties()
+    {
         return undefined;
     }
 }
 
-function getDisabledTelemetryOnChance(percentIntToSend: number): { [disableTelemetryId: string]: string } {
+function getDisabledTelemetryOnChance(percentIntToSend: number): { [disableTelemetryId: string]: string }
+{
     return { suppressTelemetry: (!(Math.random() < percentIntToSend / 100)).toString() };
 }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -13,44 +13,36 @@ import { EventType } from './EventType';
 import { IEvent } from './IEvent';
 import { TelemetryUtilities } from './TelemetryUtilities';
 
-export class EventCancellationError extends Error
-{
-    constructor(public readonly eventType: string, msg: string, stack?: string)
-    {
+export class EventCancellationError extends Error {
+    constructor(public readonly eventType: string, msg: string, stack?: string) {
         super(msg);
     }
 }
 
-export class EventBasedError extends Error
-{
-    constructor(public readonly eventType: string, msg: string, stack?: string)
-    {
+export class EventBasedError extends Error {
+    constructor(public readonly eventType: string, msg: string, stack?: string) {
         super(msg);
     }
 }
 
-export abstract class GenericModalEvent extends IEvent
-{
+export abstract class GenericModalEvent extends IEvent {
     abstract readonly mode: DotnetInstallMode;
     abstract readonly installType: DotnetInstallType;
 }
 
-export class DotnetAcquisitionStarted extends GenericModalEvent
-{
+export class DotnetAcquisitionStarted extends GenericModalEvent {
     public readonly eventName = 'DotnetAcquisitionStarted';
     public readonly type = EventType.DotnetAcquisitionStart;
     public readonly mode: DotnetInstallMode;
     public readonly installType: DotnetInstallType;
 
-    constructor(public readonly install: DotnetInstall, public readonly startingVersion: string, public readonly requestingExtensionId = '')
-    {
+    constructor(public readonly install: DotnetInstall, public readonly startingVersion: string, public readonly requestingExtensionId = '') {
         super();
         this.mode = install.installMode;
         this.installType = install.isGlobal ? 'global' : 'local';
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             ...InstallToStrings(this.install),
             AcquisitionStartVersion: this.startingVersion,
@@ -60,59 +52,49 @@ export class DotnetAcquisitionStarted extends GenericModalEvent
     }
 }
 
-abstract class DotnetAcquisitionStartedBase extends IEvent
-{
-    constructor(public readonly requestingExtensionId = '')
-    {
+abstract class DotnetAcquisitionStartedBase extends IEvent {
+    constructor(public readonly requestingExtensionId = '') {
         super();
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return { extensionId: TelemetryUtilities.HashData(this.requestingExtensionId) };
     }
 }
 
-export class DotnetRuntimeAcquisitionStarted extends DotnetAcquisitionStartedBase
-{
+export class DotnetRuntimeAcquisitionStarted extends DotnetAcquisitionStartedBase {
     public readonly eventName = 'DotnetRuntimeAcquisitionStarted';
     public readonly type = EventType.DotnetModalChildEvent;
 }
 
-export class DotnetSDKAcquisitionStarted extends DotnetAcquisitionStartedBase
-{
+export class DotnetSDKAcquisitionStarted extends DotnetAcquisitionStartedBase {
     public readonly eventName = 'DotnetSDKAcquisitionStarted';
     public readonly type = EventType.DotnetModalChildEvent;
 }
 
-export class DotnetGlobalSDKAcquisitionStarted extends DotnetAcquisitionStartedBase
-{
+export class DotnetGlobalSDKAcquisitionStarted extends DotnetAcquisitionStartedBase {
     public readonly eventName = 'DotnetGlobalSDKAcquisitionStarted';
     public readonly type = EventType.DotnetModalChildEvent;
 }
 
-export class DotnetASPNetRuntimeAcquisitionStarted extends DotnetAcquisitionStartedBase
-{
+export class DotnetASPNetRuntimeAcquisitionStarted extends DotnetAcquisitionStartedBase {
     public readonly eventName = 'DotnetASPNetRuntimeAcquisitionStarted';
     public readonly type = EventType.DotnetModalChildEvent;
 }
 
-export class DotnetAcquisitionTotalSuccessEvent extends GenericModalEvent
-{
+export class DotnetAcquisitionTotalSuccessEvent extends GenericModalEvent {
     public readonly type = EventType.DotnetTotalSuccessEvent;
     public readonly eventName = 'DotnetAcquisitionTotalSuccessEvent';
     public readonly mode;
     public readonly installType: DotnetInstallType;
 
-    constructor(public readonly startingVersion: string, public readonly install: DotnetInstall, public readonly requestingExtensionId = '', public readonly finalPath: string)
-    {
+    constructor(public readonly startingVersion: string, public readonly install: DotnetInstall, public readonly requestingExtensionId = '', public readonly finalPath: string) {
         super();
         this.mode = install.installMode;
         this.installType = install.isGlobal ? 'global' : 'local';
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             AcquisitionStartVersion: this.startingVersion,
             AcquisitionInstallId: this.install.installId,
@@ -123,55 +105,46 @@ export class DotnetAcquisitionTotalSuccessEvent extends GenericModalEvent
     }
 }
 
-abstract class DotnetAcquisitionTotalSuccessEventBase extends IEvent
-{
+abstract class DotnetAcquisitionTotalSuccessEventBase extends IEvent {
     public readonly type = EventType.DotnetModalChildEvent;
 
-    constructor(public readonly installId: DotnetInstall)
-    {
+    constructor(public readonly installId: DotnetInstall) {
         super();
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             ...InstallToStrings(this.installId),
         };
     }
 }
 
-export class DotnetRuntimeAcquisitionTotalSuccessEvent extends DotnetAcquisitionTotalSuccessEventBase
-{
+export class DotnetRuntimeAcquisitionTotalSuccessEvent extends DotnetAcquisitionTotalSuccessEventBase {
     public readonly eventName = 'DotnetRuntimeAcquisitionTotalSuccessEvent';
 }
 
-export class DotnetGlobalSDKAcquisitionTotalSuccessEvent extends DotnetAcquisitionTotalSuccessEventBase
-{
+export class DotnetGlobalSDKAcquisitionTotalSuccessEvent extends DotnetAcquisitionTotalSuccessEventBase {
     public readonly eventName = 'DotnetGlobalSDKAcquisitionTotalSuccessEvent';
 }
 
-export class DotnetASPNetRuntimeAcquisitionTotalSuccessEvent extends DotnetAcquisitionTotalSuccessEventBase
-{
+export class DotnetASPNetRuntimeAcquisitionTotalSuccessEvent extends DotnetAcquisitionTotalSuccessEventBase {
     public readonly eventName = 'DotnetASPNetRuntimeAcquisitionTotalSuccessEvent';
 }
 
 
-export class DotnetAcquisitionRequested extends GenericModalEvent
-{
+export class DotnetAcquisitionRequested extends GenericModalEvent {
     public readonly eventName = 'DotnetAcquisitionRequested';
     public readonly type = EventType.DotnetTotalSuccessEvent;
     public readonly mode;
     public readonly installType: DotnetInstallType;
 
-    constructor(public readonly startingVersion: string, public readonly requestingId = '', mode: DotnetInstallMode, installType: DotnetInstallType)
-    {
+    constructor(public readonly startingVersion: string, public readonly requestingId = '', mode: DotnetInstallMode, installType: DotnetInstallType) {
         super();
         this.mode = mode;
         this.installType = installType;
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             AcquisitionStartVersion: this.startingVersion,
             RequestingExtensionId: TelemetryUtilities.HashData(this.requestingId)
@@ -180,17 +153,14 @@ export class DotnetAcquisitionRequested extends GenericModalEvent
 }
 
 
-abstract class DotnetAcquisitionRequestedEventBase extends IEvent
-{
+abstract class DotnetAcquisitionRequestedEventBase extends IEvent {
     public readonly type = EventType.DotnetModalChildEvent;
 
-    constructor(public readonly startingVersion: string, public readonly requestingId = '', public readonly mode: DotnetInstallMode)
-    {
+    constructor(public readonly startingVersion: string, public readonly requestingId = '', public readonly mode: DotnetInstallMode) {
         super();
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             AcquisitionStartVersion: this.startingVersion,
             RequestingExtensionId: TelemetryUtilities.HashData(this.requestingId),
@@ -199,44 +169,36 @@ abstract class DotnetAcquisitionRequestedEventBase extends IEvent
     }
 }
 
-export class DotnetRuntimeAcquisitionRequested extends DotnetAcquisitionRequestedEventBase
-{
+export class DotnetRuntimeAcquisitionRequested extends DotnetAcquisitionRequestedEventBase {
     public readonly eventName = 'DotnetRuntimeAcquisitionRequested';
 }
 
-export class DotnetGlobalSDKAcquisitionRequested extends DotnetAcquisitionRequestedEventBase
-{
+export class DotnetGlobalSDKAcquisitionRequested extends DotnetAcquisitionRequestedEventBase {
     public readonly eventName = 'DotnetGlobalSDKAcquisitionRequested';
 }
 
-export class DotnetASPNetRuntimeAcquisitionRequested extends DotnetAcquisitionRequestedEventBase
-{
+export class DotnetASPNetRuntimeAcquisitionRequested extends DotnetAcquisitionRequestedEventBase {
     public readonly eventName = 'DotnetASPNetRuntimeAcquisitionRequested';
 }
 
 
-export class DotnetAcquisitionCompleted extends IEvent
-{
+export class DotnetAcquisitionCompleted extends IEvent {
     public readonly eventName = 'DotnetAcquisitionCompleted';
     public readonly type = EventType.DotnetAcquisitionCompleted;
 
-    constructor(public readonly install: DotnetInstall, public readonly dotnetPath: string, public readonly version: string)
-    {
+    constructor(public readonly install: DotnetInstall, public readonly dotnetPath: string, public readonly version: string) {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
-        if (telemetry)
-        {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+        if (telemetry) {
             return {
                 ...InstallToStrings(this.install),
                 AcquisitionCompletedInstallId: this.install.installId,
                 AcquisitionCompletedVersion: this.version
             };
         }
-        else
-        {
+        else {
             return {
                 ...InstallToStrings(this.install),
                 AcquisitionCompletedVersion: this.version,
@@ -247,8 +209,7 @@ export class DotnetAcquisitionCompleted extends IEvent
     }
 }
 
-export abstract class DotnetAcquisitionError extends IEvent
-{
+export abstract class DotnetAcquisitionError extends IEvent {
     public type = EventType.DotnetAcquisitionError;
     public isError = true;
 
@@ -258,13 +219,11 @@ export abstract class DotnetAcquisitionError extends IEvent
      * @param install For acquisition errors, you MUST include this install id. For commands unrelated to acquiring or managing a specific dotnet version, you
      * have the option to leave this parameter null. If it is NULL during acquisition the extension CANNOT properly manage what it has finished installing or not.
      */
-    constructor(public readonly error: Error, public readonly install: DotnetInstall | null)
-    {
+    constructor(public readonly error: Error, public readonly install: DotnetInstall | null) {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             ErrorName: this.error.name,
             ErrorMessage: this.error.message,
@@ -275,22 +234,19 @@ export abstract class DotnetAcquisitionError extends IEvent
     }
 }
 
-export class DotnetAcquisitionFinalError extends GenericModalEvent
-{
+export class DotnetAcquisitionFinalError extends GenericModalEvent {
     public readonly type = EventType.DotnetAcquisitionFinalError;
     public readonly eventName = 'DotnetAcquisitionFinalError';
     public readonly mode;
     public readonly installType: DotnetInstallType;
 
-    constructor(public readonly error: Error, public readonly originalEventName: string, public readonly install: DotnetInstall)
-    {
+    constructor(public readonly error: Error, public readonly originalEventName: string, public readonly install: DotnetInstall) {
         super();
         this.mode = install.installMode;
         this.installType = install.isGlobal ? 'global' : 'local';
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             ErrorName: this.error.name,
             ErrorMessage: this.error.message,
@@ -306,17 +262,14 @@ export class DotnetAcquisitionFinalError extends GenericModalEvent
  * This allows us to count all errors and analyze them into categories.
  * The event name for the failure cause is stored in the originalEventName property.
  */
-abstract class DotnetAcquisitionFinalErrorBase extends DotnetAcquisitionError
-{
+abstract class DotnetAcquisitionFinalErrorBase extends DotnetAcquisitionError {
 
-    constructor(public readonly error: Error, public readonly originalEventName: string, public readonly install: DotnetInstall)
-    {
+    constructor(public readonly error: Error, public readonly originalEventName: string, public readonly install: DotnetInstall) {
         super(error, install);
         this.type = EventType.DotnetAcquisitionFinalError;
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             FailureMode: this.originalEventName,
             ErrorName: this.error.name,
@@ -328,33 +281,27 @@ abstract class DotnetAcquisitionFinalErrorBase extends DotnetAcquisitionError
     }
 }
 
-export class DotnetGlobalSDKAcquisitionError extends DotnetAcquisitionFinalErrorBase
-{
+export class DotnetGlobalSDKAcquisitionError extends DotnetAcquisitionFinalErrorBase {
     public eventName = 'DotnetGlobalSDKAcquisitionError';
 }
 
-export class DotnetRuntimeFinalAcquisitionError extends DotnetAcquisitionFinalErrorBase
-{
+export class DotnetRuntimeFinalAcquisitionError extends DotnetAcquisitionFinalErrorBase {
     public eventName = 'DotnetRuntimeFinalAcquisitionError';
 }
 
-export class DotnetASPNetRuntimeFinalAcquisitionError extends DotnetAcquisitionFinalErrorBase
-{
+export class DotnetASPNetRuntimeFinalAcquisitionError extends DotnetAcquisitionFinalErrorBase {
     public eventName = 'DotnetASPNetRuntimeFinalAcquisitionError';
 }
 
-export abstract class DotnetNonAcquisitionError extends IEvent
-{
+export abstract class DotnetNonAcquisitionError extends IEvent {
     public readonly type = EventType.DotnetAcquisitionError;
     public isError = true;
 
-    constructor(public readonly error: Error)
-    {
+    constructor(public readonly error: Error) {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             ErrorName: this.error.name,
             ErrorMessage: this.error.message,
@@ -363,8 +310,7 @@ export abstract class DotnetNonAcquisitionError extends IEvent
     }
 }
 
-export abstract class DotnetInstallExpectedAbort extends IEvent
-{
+export abstract class DotnetInstallExpectedAbort extends IEvent {
     public readonly type = EventType.DotnetInstallExpectedAbort;
     public isError = true;
 
@@ -374,15 +320,12 @@ export abstract class DotnetInstallExpectedAbort extends IEvent
      * @param install For acquisition errors, you MUST include this install id. For commands unrelated to acquiring or managing a specific dotnet version, you
      * have the option to leave this parameter null. If it is NULL during acquisition the extension CANNOT properly manage what it has finished installing or not.
      */
-    constructor(public readonly error: Error, public readonly install: DotnetInstall | null)
-    {
+    constructor(public readonly error: Error, public readonly install: DotnetInstall | null) {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
-        if (this.install)
-        {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+        if (this.install) {
             return {
                 ErrorName: this.error?.name ?? 'GenericError',
                 ErrorMessage: this.error?.message ?? 'ErrorMessage not provided',
@@ -391,8 +334,7 @@ export abstract class DotnetInstallExpectedAbort extends IEvent
                 ...InstallToStrings(this.install) ?? 'No Install Info'
             };
         }
-        else
-        {
+        else {
             return {
                 ErrorName: this.error.name,
                 ErrorMessage: this.error.message,
@@ -403,18 +345,15 @@ export abstract class DotnetInstallExpectedAbort extends IEvent
     }
 }
 
-export class SuppressedAcquisitionError extends IEvent
-{
+export class SuppressedAcquisitionError extends IEvent {
     public eventName = 'SuppressedAcquisitionError';
     public readonly type = EventType.SuppressedAcquisitionError;
 
-    constructor(public readonly error: Error, public readonly supplementalMessage: string)
-    {
+    constructor(public readonly error: Error, public readonly supplementalMessage: string) {
         super();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             SupplementMessage: this.supplementalMessage,
             ErrorName: this.error.name,
@@ -424,77 +363,62 @@ export class SuppressedAcquisitionError extends IEvent
     }
 }
 
-export class DotnetInstallScriptAcquisitionError extends DotnetAcquisitionError
-{
+export class DotnetInstallScriptAcquisitionError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetInstallScriptAcquisitionError';
 }
 
-export class UserManualInstallFailure extends SuppressedAcquisitionError
-{
+export class UserManualInstallFailure extends SuppressedAcquisitionError {
     eventName = 'UserManualInstallFailure';
 }
 
-export class OfflineDetectionLogicTriggered extends SuppressedAcquisitionError
-{
+export class OfflineDetectionLogicTriggered extends SuppressedAcquisitionError {
     eventName = 'OfflineDetectionLogicTriggered';
 }
 
-export class DotnetInstallationValidationMissed extends SuppressedAcquisitionError
-{
+export class DotnetInstallationValidationMissed extends SuppressedAcquisitionError {
     eventName = 'DotnetInstallationValidationMissed';
 }
 
-export class OSXOpenNotAvailableError extends DotnetAcquisitionError
-{
+export class OSXOpenNotAvailableError extends DotnetAcquisitionError {
     public readonly eventName = 'OSXOpenNotAvailableError';
 }
 
-export class WebRequestError extends DotnetAcquisitionError
-{
+export class WebRequestError extends DotnetAcquisitionError {
     public readonly eventName = 'WebRequestError';
 }
 
-export class DiskIsFullError extends DotnetAcquisitionError
-{
+export class DiskIsFullError extends DotnetAcquisitionError {
     public readonly eventName = 'DiskIsFullError';
 }
 
-export class DotnetDownloadFailure extends DotnetAcquisitionError
-{
+export class DotnetDownloadFailure extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetDownloadFailure';
 }
 
-export class DotnetPreinstallDetectionError extends DotnetAcquisitionError
-{
+export class DotnetPreinstallDetectionError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetPreinstallDetectionError';
 }
 
-export class TimeoutSudoProcessSpawnerError extends DotnetAcquisitionError
-{
+export class TimeoutSudoProcessSpawnerError extends DotnetAcquisitionError {
     public readonly eventName = 'TimeoutSudoProcessSpawnerError';
 }
 
-export class TimeoutSudoCommandExecutionError extends DotnetAcquisitionError
-{
+export class TimeoutSudoCommandExecutionError extends DotnetAcquisitionError {
     public readonly eventName = 'TimeoutSudoCommandExecutionError';
 }
 
-export class CommandExecutionNonZeroExitFailure extends DotnetAcquisitionError
-{
+export class CommandExecutionNonZeroExitFailure extends DotnetAcquisitionError {
     public readonly eventName = 'CommandExecutionNonZeroExitFailure';
 }
 
-export class DotnetNotInstallRelatedCommandFailed extends DotnetNonAcquisitionError
-{
+export class DotnetNotInstallRelatedCommandFailed extends DotnetNonAcquisitionError {
     public readonly eventName = 'DotnetNotInstallRelatedCommandFailed';
 
-    constructor(error: Error, public readonly command: string)
-    {
+    constructor(error: Error, public readonly command: string) {
         super(error);
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             ErrorMessage: this.error.message,
             CommandName: this.command,
@@ -504,22 +428,18 @@ export class DotnetNotInstallRelatedCommandFailed extends DotnetNonAcquisitionEr
     }
 }
 
-export class InvalidUninstallRequest extends DotnetNonAcquisitionError
-{
+export class InvalidUninstallRequest extends DotnetNonAcquisitionError {
     public readonly eventName = 'InvalidUninstallRequest';
 }
 
-export class DotnetCommandFailed extends DotnetAcquisitionError
-{
+export class DotnetCommandFailed extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetCommandFailed';
 
-    constructor(error: Error, public readonly command: string, install: DotnetInstall | null)
-    {
+    constructor(error: Error, public readonly command: string, install: DotnetInstall | null) {
         super(error, install);
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             ErrorMessage: this.error.message,
             CommandName: this.command,
@@ -531,56 +451,44 @@ export class DotnetCommandFailed extends DotnetAcquisitionError
     }
 }
 
-export class DotnetInvalidReleasesJSONError extends DotnetAcquisitionError
-{
+export class DotnetInvalidReleasesJSONError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetInvalidReleasesJSONError';
 }
 
-export class DotnetNoInstallerFileExistsError extends DotnetAcquisitionError
-{
+export class DotnetNoInstallerFileExistsError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetNoInstallerFileExistsError';
 }
 
-export class DotnetNoInstallerResponseError extends DotnetInstallExpectedAbort
-{
+export class DotnetNoInstallerResponseError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetNoInstallerResponseError';
 }
 
-export class DotnetUnexpectedInstallerOSError extends DotnetAcquisitionError
-{
+export class DotnetUnexpectedInstallerOSError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetUnexpectedInstallerOSError';
 }
 
-export class DotnetUnexpectedInstallerArchitectureError extends DotnetAcquisitionError
-{
+export class DotnetUnexpectedInstallerArchitectureError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetUnexpectedInstallerArchitectureError';
 }
 
-export class DotnetFeatureBandDoesNotExistError extends DotnetAcquisitionError
-{
+export class DotnetFeatureBandDoesNotExistError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetFeatureBandDoesNotExistError';
 }
 
-export class DotnetInvalidRuntimePatchVersion extends DotnetAcquisitionError
-{
+export class DotnetInvalidRuntimePatchVersion extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetInvalidRuntimePatchVersion';
 }
 
-export class DotnetWSLSecurityError extends DotnetInstallExpectedAbort
-{
+export class DotnetWSLSecurityError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetWSLSecurityError';
 }
 
-
-export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionError
-{
-    constructor(error: Error, public readonly install: DotnetInstall | null)
-    {
+export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionError {
+    constructor(error: Error, public readonly install: DotnetInstall | null) {
         super(error, install);
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return this.install ? {
             ErrorMessage: this.error.message,
             AcquisitionErrorInstallId: this.install.installId ?? 'null',
@@ -598,65 +506,52 @@ export abstract class DotnetAcquisitionVersionError extends DotnetAcquisitionErr
     }
 }
 
-export class DotnetAcquisitionUnexpectedError extends DotnetAcquisitionVersionError
-{
+export class DotnetAcquisitionUnexpectedError extends DotnetAcquisitionVersionError {
     public readonly eventName = 'DotnetAcquisitionUnexpectedError';
 }
 
-export class DotnetAcquisitionInstallError extends DotnetAcquisitionVersionError
-{
+export class DotnetAcquisitionInstallError extends DotnetAcquisitionVersionError {
     public readonly eventName = 'DotnetAcquisitionInstallError';
 }
 
-export class DotnetAcquisitionScriptError extends DotnetAcquisitionVersionError
-{
+export class DotnetAcquisitionScriptError extends DotnetAcquisitionVersionError {
     public readonly eventName = 'DotnetAcquisitionScriptError';
 }
 
-export class DotnetConflictingGlobalWindowsInstallError extends DotnetInstallExpectedAbort
-{
+export class DotnetConflictingGlobalWindowsInstallError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetConflictingGlobalWindowsInstallError';
 }
 
-export class DotnetInstallCancelledByUserError extends DotnetInstallExpectedAbort
-{
+export class DotnetInstallCancelledByUserError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetInstallCancelledByUserError';
 }
 
 
 
-export class DotnetNonZeroInstallerExitCodeError extends DotnetAcquisitionError
-{
+export class DotnetNonZeroInstallerExitCodeError extends DotnetAcquisitionError {
     public readonly eventName = 'DotnetNonZeroInstallerExitCodeError';
 }
 
-export class DotnetOfflineFailure extends DotnetAcquisitionVersionError
-{
+export class DotnetOfflineFailure extends DotnetAcquisitionVersionError {
     public readonly eventName = 'DotnetOfflineFailure';
 }
 
-export class PowershellBadLanguageMode extends DotnetAcquisitionVersionError
-{
+export class PowershellBadLanguageMode extends DotnetAcquisitionVersionError {
     public readonly eventName = 'PowershellBadLanguageMode';
 }
 
-export class PowershellBadExecutionPolicy extends DotnetAcquisitionVersionError
-{
+export class PowershellBadExecutionPolicy extends DotnetAcquisitionVersionError {
     public readonly eventName = 'PowershellBadExecutionPolicy';
 }
-export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError
-{
+export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError {
     public readonly eventName = 'DotnetAcquisitionTimeoutError';
 
-    constructor(error: Error, installId: DotnetInstall | null, public readonly timeoutValue: number)
-    {
+    constructor(error: Error, installId: DotnetInstall | null, public readonly timeoutValue: number) {
         super(error, installId);
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
-        if (this.install)
-        {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+        if (this.install) {
             return {
                 ErrorMessage: this.error.message,
                 TimeoutValue: this.timeoutValue.toString(),
@@ -665,8 +560,7 @@ export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError
                 StackTrace: this.error.stack ? this.error.stack : ''
             };
         }
-        else
-        {
+        else {
             return {
                 ErrorMessage: this.error.message,
                 TimeoutValue: this.timeoutValue.toString(),
@@ -678,35 +572,28 @@ export class DotnetAcquisitionTimeoutError extends DotnetAcquisitionVersionError
 
 }
 
-export class DotnetVersionResolutionError extends DotnetInstallExpectedAbort
-{
+export class DotnetVersionResolutionError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetVersionResolutionError';
 }
 
-export class DotnetConflictingLinuxInstallTypesError extends DotnetInstallExpectedAbort
-{
+export class DotnetConflictingLinuxInstallTypesError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetConflictingLinuxInstallTypesError';
 }
 
-export class DotnetCustomLinuxInstallExistsError extends DotnetInstallExpectedAbort
-{
+export class DotnetCustomLinuxInstallExistsError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetCustomLinuxInstallExistsError';
 }
 
-export class DotnetInstallationValidationError extends DotnetAcquisitionVersionError
-{
+export class DotnetInstallationValidationError extends DotnetAcquisitionVersionError {
     public readonly eventName = 'DotnetInstallationValidationError';
     public readonly fileStructure: string;
-    constructor(error: Error, install: DotnetInstall, public readonly dotnetPath: string)
-    {
+    constructor(error: Error, install: DotnetInstall, public readonly dotnetPath: string) {
         super(error, install);
         this.fileStructure = this.getFileStructure();
     }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
-        if (this.install)
-        {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
+        if (this.install) {
             return {
                 ErrorMessage: this.error.message,
                 AcquisitionErrorInstallId: this.install?.installId ?? 'null',
@@ -717,8 +604,7 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
                 FileStructure: this.fileStructure
             };
         }
-        else
-        {
+        else {
             return {
                 ErrorMessage: this.error.message,
                 AcquisitionErrorInstallId: 'null',
@@ -730,25 +616,20 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
         }
     }
 
-    private getFileStructure(): string
-    {
+    private getFileStructure(): string {
         const folderPath = path.dirname(this.dotnetPath);
-        if (!fs.existsSync(folderPath))
-        {
+        if (!fs.existsSync(folderPath)) {
             return `Dotnet Path (${path.basename(folderPath)}) does not exist`;
         }
         // Get 2 levels worth of content of the folder
         let files = fs.readdirSync(folderPath).map(file => path.join(folderPath, file));
-        for (const file of files)
-        {
-            if (fs.statSync(file).isDirectory())
-            {
+        for (const file of files) {
+            if (fs.statSync(file).isDirectory()) {
                 files = files.concat(fs.readdirSync(file).map(fileName => path.join(file, fileName)));
             }
         }
         const relativeFiles: string[] = [];
-        for (const file of files)
-        {
+        for (const file of files) {
             relativeFiles.push(path.relative(path.dirname(folderPath), file));
         }
 
@@ -756,12 +637,10 @@ export class DotnetInstallationValidationError extends DotnetAcquisitionVersionE
     }
 }
 
-export class DotnetAcquisitionDistroUnknownError extends DotnetInstallExpectedAbort
-{
+export class DotnetAcquisitionDistroUnknownError extends DotnetInstallExpectedAbort {
     public readonly eventName = 'DotnetAcquisitionDistroUnknownError';
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             ErrorMessage: this.error.message,
             ErrorName: this.error.name,
@@ -773,46 +652,38 @@ export class DotnetAcquisitionDistroUnknownError extends DotnetInstallExpectedAb
 }
 
 
-export abstract class DotnetAcquisitionSuccessEvent extends IEvent
-{
+export abstract class DotnetAcquisitionSuccessEvent extends IEvent {
     public readonly type = EventType.DotnetAcquisitionSuccessEvent;
 
-    public getProperties(): { [id: string]: string } | undefined
-    {
+    public getProperties(): { [id: string]: string } | undefined {
         return undefined;
     }
 }
 
-export class DotnetCommandSucceeded extends DotnetAcquisitionSuccessEvent
-{
+export class DotnetCommandSucceeded extends DotnetAcquisitionSuccessEvent {
     public readonly eventName = 'DotnetCommandSucceeded';
 
     constructor(public readonly commandName: string) { super(); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return { CommandName: this.commandName };
     }
 }
 
-export class DotnetUninstallAllStarted extends DotnetAcquisitionSuccessEvent
-{
+export class DotnetUninstallAllStarted extends DotnetAcquisitionSuccessEvent {
     public readonly eventName = 'DotnetUninstallAllStarted';
 }
 
-export class DotnetUninstallAllCompleted extends DotnetAcquisitionSuccessEvent
-{
+export class DotnetUninstallAllCompleted extends DotnetAcquisitionSuccessEvent {
     public readonly eventName = 'DotnetUninstallAllCompleted';
 }
 
-export class DotnetVersionResolutionCompleted extends DotnetAcquisitionSuccessEvent
-{
+export class DotnetVersionResolutionCompleted extends DotnetAcquisitionSuccessEvent {
     public readonly eventName = 'DotnetVersionResolutionCompleted';
 
     constructor(public readonly requestedVersion: string, public readonly resolvedVersion: string) { super(); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             RequestedVersion: this.requestedVersion,
             ResolvedVersion: this.resolvedVersion
@@ -820,123 +691,100 @@ export class DotnetVersionResolutionCompleted extends DotnetAcquisitionSuccessEv
     }
 }
 
-export class DotnetInstallScriptAcquisitionCompleted extends DotnetAcquisitionSuccessEvent
-{
+export class DotnetInstallScriptAcquisitionCompleted extends DotnetAcquisitionSuccessEvent {
     public readonly eventName = 'DotnetInstallScriptAcquisitionCompleted';
 }
 
-export class DotnetExistingPathResolutionCompleted extends DotnetAcquisitionSuccessEvent
-{
+export class DotnetExistingPathResolutionCompleted extends DotnetAcquisitionSuccessEvent {
     public readonly eventName = 'DotnetExistingPathResolutionCompleted';
 
     constructor(public readonly resolvedPath: string) { super(); }
 
-    public getProperties(telemetry = false)
-    {
+    public getProperties(telemetry = false) {
         return telemetry ? undefined : { ConfiguredPath: this.resolvedPath };
     }
 }
 
-export abstract class DotnetAcquisitionMessage extends IEvent
-{
+export abstract class DotnetAcquisitionMessage extends IEvent {
     public type = EventType.DotnetAcquisitionMessage;
 
-    public getProperties(): { [id: string]: string } | undefined
-    {
+    public getProperties(): { [id: string]: string } | undefined {
         return {};
     }
 }
 
-export class DotnetAcquisitionDeletion extends DotnetAcquisitionMessage
-{
+export class DotnetAcquisitionDeletion extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetAcquisitionDeletion';
     constructor(public readonly folderPath: string) { super(); }
 
-    public getProperties(telemetry = false)
-    {
+    public getProperties(telemetry = false) {
         return telemetry ? undefined : { DeletedFolderPath: this.folderPath };
     }
 }
 
-export class DotnetFallbackInstallScriptUsed extends DotnetAcquisitionMessage
-{
+export class DotnetFallbackInstallScriptUsed extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetFallbackInstallScriptUsed';
 }
 
-export abstract class DotnetCustomMessageEvent extends DotnetAcquisitionMessage
-{
+export abstract class DotnetCustomMessageEvent extends DotnetAcquisitionMessage {
     constructor(public readonly eventMessage: string) { super(); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return { Message: this.eventMessage };
     }
 }
 
-export abstract class DotnetVisibleWarningEvent extends DotnetCustomMessageEvent
-{
+export abstract class DotnetVisibleWarningEvent extends DotnetCustomMessageEvent {
     public readonly type = EventType.DotnetVisibleWarning;
 }
 
-export class DotnetFileIntegrityFailureEvent extends DotnetVisibleWarningEvent
-{
+export class DotnetFileIntegrityFailureEvent extends DotnetVisibleWarningEvent {
     public readonly eventName = 'DotnetFileIntegrityFailureEvent';
 }
 
-export class DotnetUnableToCheckPATHArchitecture extends DotnetVisibleWarningEvent
-{
+export class DotnetUnableToCheckPATHArchitecture extends DotnetVisibleWarningEvent {
     public readonly eventName = 'DotnetUnableToCheckPATHArchitecture';
 }
 
-export class UtilizingExistingInstallPromise extends DotnetCustomMessageEvent
-{
+export class UtilizingExistingInstallPromise extends DotnetCustomMessageEvent {
     public readonly eventName = 'UtilizingExistingInstallPromise';
 }
 
-export class FileIsBusy extends DotnetCustomMessageEvent
-{
+export class FileIsBusy extends DotnetCustomMessageEvent {
     public readonly eventName = 'FileIsBusy';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { ...super.getProperties(), ...getDisabledTelemetryOnChance(1) };
     }
 }
 
-export class FileIsNotBusy extends DotnetCustomMessageEvent
-{
+export class FileIsNotBusy extends DotnetCustomMessageEvent {
     public readonly eventName = 'FileIsNotBusy';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { ...super.getProperties(), ...getDisabledTelemetryOnChance(1) };
     }
 }
 
-export class DotnetVersionCategorizedEvent extends DotnetCustomMessageEvent
-{
+export class DotnetVersionCategorizedEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetVersionCategorizedEvent';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DuplicateInstallDetected extends DotnetCustomMessageEvent
-{
+export class DuplicateInstallDetected extends DotnetCustomMessageEvent {
     public readonly eventName = 'DuplicateInstallDetected';
 }
 
-export abstract class WebRequestTimer extends DotnetCustomMessageEvent
-{
+export abstract class WebRequestTimer extends DotnetCustomMessageEvent {
 
     constructor(public readonly eventMessage: string, public readonly durationMs: string,
         public readonly finished: string, public readonly url: string, public readonly status: string
     ) { super(eventMessage); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             Message: this.eventMessage,
             DurationMs: this.durationMs,
@@ -948,14 +796,12 @@ export abstract class WebRequestTimer extends DotnetCustomMessageEvent
     }
 }
 
-export class CommandExecutionTimer extends DotnetCustomMessageEvent
-{
+export class CommandExecutionTimer extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionTimer';
 
     constructor(public readonly eventMessage: string, public readonly durationMs: string, public readonly commandRoot: string, public readonly fullCommandString: string) { super(eventMessage); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             ...super.getProperties(), DurationMs: this.durationMs, CommandRoot: TelemetryUtilities.HashAllPaths(this.fullCommandString),
             HashedFullCommand: TelemetryUtilities.HashData(this.commandRoot)
@@ -963,706 +809,585 @@ export class CommandExecutionTimer extends DotnetCustomMessageEvent
     }
 }
 
-export class WebRequestTime extends WebRequestTimer
-{
+export class WebRequestTime extends WebRequestTimer {
     public readonly eventName = 'WebRequestTime';
 }
 
-export class WebRequestCachedTime extends WebRequestTimer
-{
+export class WebRequestCachedTime extends WebRequestTimer {
     public readonly eventName = 'WebRequestCachedTime';
 }
 
-export class WebRequestTimeUnknown extends WebRequestTimer
-{
+export class WebRequestTimeUnknown extends WebRequestTimer {
     public readonly eventName = 'WebRequestTimeUnknown';
 }
 
-export class EmptyDirectoryToWipe extends DotnetCustomMessageEvent
-{
+export class EmptyDirectoryToWipe extends DotnetCustomMessageEvent {
     public readonly eventName = 'EmptyDirectoryToWipe';
 }
 
-export class ProxyUsed extends DotnetCustomMessageEvent
-{
+export class ProxyUsed extends DotnetCustomMessageEvent {
     public readonly eventName = 'ProxyUsed';
 }
 
-export class FileToWipe extends DotnetCustomMessageEvent
-{
+export class FileToWipe extends DotnetCustomMessageEvent {
     public readonly eventName = 'FileToWipe';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { ...getDisabledTelemetryOnChance(1), ...super.getProperties() };
     }
 }
 
-export class TriedToExitMasterSudoProcess extends DotnetCustomMessageEvent
-{
+export class TriedToExitMasterSudoProcess extends DotnetCustomMessageEvent {
     public readonly eventName = 'TriedToExitMasterSudoProcess';
 }
 
-export class FeatureBandDoesNotExist extends DotnetCustomMessageEvent
-{
+export class FeatureBandDoesNotExist extends DotnetCustomMessageEvent {
     public readonly eventName = 'FeatureBandDoesNotExist';
 }
 
-export class FileDoesNotExist extends DotnetCustomMessageEvent
-{
+export class FileDoesNotExist extends DotnetCustomMessageEvent {
     public readonly eventName = 'FileDoesNotExist';
 }
 
-export class DotnetUninstallStarted extends DotnetCustomMessageEvent
-{
+export class DotnetUninstallStarted extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetUninstallStarted';
     public type = EventType.DotnetUninstallMessage;
 }
 
-export class DotnetUninstallCompleted extends DotnetCustomMessageEvent
-{
+export class DotnetUninstallCompleted extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetUninstallStarted';
     public type = EventType.DotnetUninstallMessage;
 }
 
-export class DotnetUninstallFailed extends DotnetCustomMessageEvent
-{
+export class DotnetUninstallFailed extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetUninstallStarted';
     public type = EventType.DotnetUninstallMessage;
 }
 
 
-export class DotnetUninstallSkipped extends DotnetCustomMessageEvent
-{
+export class DotnetUninstallSkipped extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetUninstallSkipped';
     public type = EventType.DotnetUninstallMessage;
 }
 
-export class NoExtensionIdProvided extends DotnetCustomMessageEvent
-{
+export class NoExtensionIdProvided extends DotnetCustomMessageEvent {
     public readonly eventName = 'NoExtensionIdProvided';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { ...getDisabledTelemetryOnChance(1), ...super.getProperties() };
     }
 }
 
-export class ConvertingLegacyInstallRecord extends DotnetCustomMessageEvent
-{
+export class ConvertingLegacyInstallRecord extends DotnetCustomMessageEvent {
     public readonly eventName = 'ConvertingLegacyInstallRecord';
 }
-export class FoundTrackingVersions extends DotnetCustomMessageEvent
-{
+export class FoundTrackingVersions extends DotnetCustomMessageEvent {
     public readonly eventName = 'FoundTrackingVersions';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class RemovingVersionFromExtensionState extends DotnetCustomMessageEvent
-{
+export class RemovingVersionFromExtensionState extends DotnetCustomMessageEvent {
     public readonly eventName = 'RemovingVersionFromExtensionState';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class RemovingExtensionFromList extends DotnetCustomMessageEvent
-{
+export class RemovingExtensionFromList extends DotnetCustomMessageEvent {
     public readonly eventName = 'RemovingExtensionFromList';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class RemovingOwnerFromList extends DotnetCustomMessageEvent
-{
+export class RemovingOwnerFromList extends DotnetCustomMessageEvent {
     public readonly eventName = 'RemovingOwnerFromList';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class SkipAddingInstallEvent extends DotnetCustomMessageEvent
-{
+export class SkipAddingInstallEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'SkipAddingInstallEvent';
 }
 
-export class AddTrackingVersions extends DotnetCustomMessageEvent
-{
+export class AddTrackingVersions extends DotnetCustomMessageEvent {
     public readonly eventName = 'AddTrackingVersions';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetWSLCheckEvent extends DotnetCustomMessageEvent
-{
+export class DotnetWSLCheckEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetWSLCheckEvent';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetWSLOperationOutputEvent extends DotnetCustomMessageEvent
-{
+export class DotnetWSLOperationOutputEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetWSLOperationOutputEvent';
 }
 
-export class DotnetFindPathCommandInvoked extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathCommandInvoked extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathCommandInvoked';
     constructor(public readonly eventMessage: string, public readonly request: IDotnetFindPathContext) { super(eventMessage); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return { Message: this.eventMessage, Context: JSON.stringify(this.request) };
     };
 }
 
-export class WebCacheClearEvent extends DotnetCustomMessageEvent
-{
+export class WebCacheClearEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'WebCacheClearEvent';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { ...getDisabledTelemetryOnChance(1), ...super.getProperties() };
     }
 }
 
-export class CacheClearEvent extends DotnetCustomMessageEvent
-{
+export class CacheClearEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CacheClearEvent';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { ...getDisabledTelemetryOnChance(1), ...super.getProperties() };
     }
 }
 
-export class CachePutEvent extends DotnetCustomMessageEvent
-{
+export class CachePutEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CachePutEvent';
     constructor(public readonly eventMessage: string, public readonly indexStr: string, public readonly value: string, public readonly ttl: string) { super(eventMessage); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return { Message: this.eventMessage, indexStr: this.indexStr, value: this.value, ttl: this.ttl, ...getDisabledTelemetryOnChance(1) };
     };
 }
 
-export class CacheGetEvent extends DotnetCustomMessageEvent
-{
+export class CacheGetEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CacheGetEvent';
     constructor(public readonly eventMessage: string, public readonly indexStr: string, public readonly value: string) { super(eventMessage); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return { Message: this.eventMessage, indexStr: this.indexStr, value: this.value, ...getDisabledTelemetryOnChance(1) };
     };
 }
 
-export class DotnetFindPathLookupSetting extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathLookupSetting extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathLookupSetting';
 }
 
-export class CacheAliasCreated extends DotnetCustomMessageEvent
-{
+export class CacheAliasCreated extends DotnetCustomMessageEvent {
     public readonly eventName = 'CacheAliasCreated';
-    public getProperties()
-    {
+    public getProperties() {
         return { Message: this.eventMessage, ...getDisabledTelemetryOnChance(1) };
     };
 }
 
-export class DotnetFindPathSettingFound extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathSettingFound extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathSettingFound';
 }
 
-export class DotnetFindPathLookupPATH extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathLookupPATH extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathLookupPATH';
 }
 
-export class DotnetFindPathPATHFound extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathPATHFound extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathPATHFound';
 }
 
-export class DotnetFindPathLookupRealPATH extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathLookupRealPATH extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathLookupRealPATH';
 }
 
-export class DotnetFindPathRealPATHFound extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathRealPATHFound extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
-export class DotnetConditionsValidated extends DotnetCustomMessageEvent
-{
+export class DotnetConditionsValidated extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetConditionsValidated';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { ...getDisabledTelemetryOnChance(1), ...super.getProperties() };
     }
 }
 
-export class DotnetFindPathHostFxrResolutionLookup extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathHostFxrResolutionLookup extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathHostFxrResolutionLookup';
 }
 
-export class DotnetFindPathOnRegistry extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathOnRegistry extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathOnRegistry';
 }
 
-export class DotnetFindPathNoHostOnRegistry extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathNoHostOnRegistry extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathNoHostOnRegistry';
 }
 
-export class SudoDirCreationFailed extends DotnetCustomMessageEvent
-{
+export class SudoDirCreationFailed extends DotnetCustomMessageEvent {
     public readonly eventName = 'SudoDirCreationFailed';
 }
 
-export class SudoDirDeletionFailed extends DotnetCustomMessageEvent
-{
+export class SudoDirDeletionFailed extends DotnetCustomMessageEvent {
     public readonly eventName = 'SudoDirDeletionFailed';
 }
 
-export class DotnetFindPathOnFileSystem extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathOnFileSystem extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathOnFileSystem';
 }
 
-export class DotnetFindPathNoHostOnFileSystem extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathNoHostOnFileSystem extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathNoHostOnFileSystem';
 }
 
-export class DotnetFindPathNoRuntimesOnHost extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathNoRuntimesOnHost extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathNoRuntimesOnHost';
 }
 
-export class DotnetFindPathLookupRootPATH extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathLookupRootPATH extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathLookupRealPATH';
 }
 
-export class DotnetFindPathRootEmulationPATHFound extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathRootEmulationPATHFound extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
-export class DotnetFindPathRootUnderEmulationButNoneSet extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathRootUnderEmulationButNoneSet extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
-export class DotnetFindPathRootPATHFound extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathRootPATHFound extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathRealPATHFound';
 }
 
-export class DotnetFindPathMetCondition extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathMetCondition extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathMetCondition';
 }
 
-export class DotnetFindPathNoPathMetCondition extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathNoPathMetCondition extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathNoPathMetCondition';
 }
 
-export class DotnetFindPathDidNotMeetCondition extends DotnetCustomMessageEvent
-{
+export class DotnetFindPathDidNotMeetCondition extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFindPathDidNotMeetCondition';
 }
 
-export class DotnetTelemetrySettingEvent extends DotnetCustomMessageEvent
-{
+export class DotnetTelemetrySettingEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetTelemetrySettingEvent';
 }
 
+export class MacInstallerFailure extends DotnetCustomMessageEvent {
+    public readonly eventName = 'MacInstallerFailure';
 
-export class DistroSupport extends DotnetCustomMessageEvent
-{
+    constructor(message: string, private readonly status: string, private readonly stdout: string, private readonly stderr: string) {
+        super(message);
+    }
+    public getProperties() {
+        return { Status: this.status, Stdout: this.stdout, StdErr: this.stderr, ...super.getProperties() };
+    }
+}
+
+export class MacInstallerBackupSuccess extends DotnetCustomMessageEvent {
+    public readonly eventName = 'MacInstallerBackupSuccess';
+}
+
+export class MacInstallerBackupFailure extends DotnetCustomMessageEvent {
+    public readonly eventName = 'MacInstallerBackupSuccess';
+}
+
+export class DistroSupport extends DotnetCustomMessageEvent {
     public readonly eventName = 'DistroSupport';
 }
 
-export class FeedInjection extends DotnetCustomMessageEvent
-{
+export class FeedInjection extends DotnetCustomMessageEvent {
     public readonly eventName = 'FeedInjection';
 }
 
-export class FeedInjectionStarted extends DotnetCustomMessageEvent
-{
+export class FeedInjectionStarted extends DotnetCustomMessageEvent {
     type = EventType.FeedInjectionMessage
     public readonly eventName = 'FeedInjectionStarted';
 }
 
-export class FeedInjectionFinished extends DotnetCustomMessageEvent
-{
+export class FeedInjectionFinished extends DotnetCustomMessageEvent {
     type = EventType.FeedInjectionMessage
     public readonly eventName = 'FeedInjectionFinished';
 }
 
-export class DistroPackagesSearch extends DotnetCustomMessageEvent
-{
+export class DistroPackagesSearch extends DotnetCustomMessageEvent {
     public readonly eventName = 'DistroPackagesSearch';
 }
 
-export class FoundDistroVersionDetails extends DotnetCustomMessageEvent
-{
+export class FoundDistroVersionDetails extends DotnetCustomMessageEvent {
     public readonly eventName = 'FoundDistroVersionDetails';
 }
 
-export class DotnetVSCodeExtensionFound extends DotnetCustomMessageEvent
-{
+export class DotnetVSCodeExtensionFound extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetVSCodeExtensionFound';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetVSCodeExtensionHasInstallRequest extends DotnetCustomMessageEvent
-{
+export class DotnetVSCodeExtensionHasInstallRequest extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetVSCodeExtensionHasInstallRequest';
 }
 
-export class DotnetVSCodeExtensionChange extends DotnetCustomMessageEvent
-{
+export class DotnetVSCodeExtensionChange extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetVSCodeExtensionChange';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetCommandNotFoundEvent extends DotnetCustomMessageEvent
-{
+export class DotnetCommandNotFoundEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetCommandNotFoundEvent';
 }
 
-export class DotnetFileIntegrityCheckEvent extends DotnetCustomMessageEvent
-{
+export class DotnetFileIntegrityCheckEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFileIntegrityCheckEvent';
 }
 
-export class GlobalAcquisitionContextMenuOpened extends DotnetCustomMessageEvent
-{
+export class GlobalAcquisitionContextMenuOpened extends DotnetCustomMessageEvent {
     public readonly eventName = 'GlobalAcquisitionContextMenuOpened';
 }
 
-export class UserManualInstallVersionChosen extends DotnetCustomMessageEvent
-{
+export class UserManualInstallVersionChosen extends DotnetCustomMessageEvent {
     public readonly eventName = 'UserManualInstallVersionChosen';
 }
 
-export class UserManualInstallRequested extends DotnetCustomMessageEvent
-{
+export class UserManualInstallRequested extends DotnetCustomMessageEvent {
     public readonly eventName = 'UserManualInstallRequested';
 }
 
-export class UserManualInstallSuccess extends DotnetCustomMessageEvent
-{
+export class UserManualInstallSuccess extends DotnetCustomMessageEvent {
     public readonly eventName = 'UserManualInstallSuccess';
 }
 
-export class CommandExecutionStdOut extends DotnetCustomMessageEvent
-{
+export class CommandExecutionStdOut extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionStdOut';
 }
 
-export class NoMatchingInstallToStopTracking extends DotnetCustomMessageEvent
-{
+export class NoMatchingInstallToStopTracking extends DotnetCustomMessageEvent {
     public readonly eventName = 'NoMatchingInstallToStopTracking';
 }
 
-export class CommandExecutionStdError extends DotnetCustomMessageEvent
-{
+export class CommandExecutionStdError extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionStdError';
 }
 
-export class DotnetGlobalAcquisitionBeginEvent extends DotnetCustomMessageEvent
-{
+export class DotnetGlobalAcquisitionBeginEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetGlobalAcquisitionBeginEvent';
 }
 
-export class DotnetGlobalVersionResolutionCompletionEvent extends DotnetCustomMessageEvent
-{
+export class DotnetGlobalVersionResolutionCompletionEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetGlobalVersionResolutionCompletionEvent';
 }
 
-export class CommandProcessesExecutionFailureNonTerminal extends DotnetCustomMessageEvent
-{
+export class CommandProcessesExecutionFailureNonTerminal extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandProcessesExecutionFailureNonTerminal';
 }
 
-export class CommandProcessorExecutionBegin extends DotnetCustomMessageEvent
-{
+export class CommandProcessorExecutionBegin extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandProcessorExecutionBegin';
 }
 
-export class CommandProcessorExecutionEnd extends DotnetCustomMessageEvent
-{
+export class CommandProcessorExecutionEnd extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandProcessorExecutionEnd';
 }
 
-export class DotnetBeginGlobalInstallerExecution extends DotnetCustomMessageEvent
-{
+export class DotnetBeginGlobalInstallerExecution extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetBeginGlobalInstallerExecution';
 }
 
-export class DotnetCompletedGlobalInstallerExecution extends DotnetCustomMessageEvent
-{
+export class DotnetCompletedGlobalInstallerExecution extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetCompletedGlobalInstallerExecution';
 }
 
-export class DotnetGlobalAcquisitionCompletionEvent extends DotnetCustomMessageEvent
-{
+export class DotnetGlobalAcquisitionCompletionEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetGlobalAcquisitionCompletionEvent';
 }
 
-export class DotnetAlternativeCommandFoundEvent extends DotnetCustomMessageEvent
-{
+export class DotnetAlternativeCommandFoundEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetAlternativeCommandFoundEvent';
 }
 
-export class DotnetCommandFallbackArchitectureEvent extends DotnetCustomMessageEvent
-{
+export class DotnetCommandFallbackArchitectureEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetCommandFallbackArchitectureEvent';
 }
 
-export class DotnetCommandFallbackOSEvent extends DotnetCustomMessageEvent
-{
+export class DotnetCommandFallbackOSEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetCommandFallbackOSEvent';
 }
 
-export class DotnetInstallIdCreatedEvent extends DotnetCustomMessageEvent
-{
+export class DotnetInstallIdCreatedEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetInstallIdCreatedEvent';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetLegacyInstallDetectedEvent extends DotnetCustomMessageEvent
-{
+export class DotnetLegacyInstallDetectedEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetLegacyInstallDetectedEvent';
 }
 
-export class DotnetLegacyInstallRemovalRequestEvent extends DotnetCustomMessageEvent
-{
+export class DotnetLegacyInstallRemovalRequestEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetLegacyInstallRemovalRequestEvent';
 }
 
-export class DotnetFakeSDKEnvironmentVariableTriggered extends DotnetCustomMessageEvent
-{
+export class DotnetFakeSDKEnvironmentVariableTriggered extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetFakeSDKEnvironmentVariableTriggered';
 }
 
-export class CommandExecutionNoStatusCodeWarning extends DotnetCustomMessageEvent
-{
+export class CommandExecutionNoStatusCodeWarning extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionNoStatusCodeWarning';
 }
 
-export class CommandExecutionSignalSentEvent extends DotnetCustomMessageEvent
-{
+export class CommandExecutionSignalSentEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionSignalSentEvent';
 }
 
-export class CommandExecutionStatusEvent extends DotnetCustomMessageEvent
-{
+export class CommandExecutionStatusEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionStatusEvent';
 }
 
-export class CommandExecutionEvent extends DotnetCustomMessageEvent
-{
+export class CommandExecutionEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionEvent';
 }
 
-export class SudoProcAliveCheckBegin extends DotnetCustomMessageEvent
-{
+export class SudoProcAliveCheckBegin extends DotnetCustomMessageEvent {
     public readonly eventName = 'SudoProcAliveCheckBegin';
 }
 
-export class SudoProcAliveCheckEnd extends DotnetCustomMessageEvent
-{
+export class SudoProcAliveCheckEnd extends DotnetCustomMessageEvent {
     public readonly eventName = 'SudoProcAliveCheckEnd';
 }
 
-export class SudoProcCommandExchangeBegin extends DotnetCustomMessageEvent
-{
+export class SudoProcCommandExchangeBegin extends DotnetCustomMessageEvent {
     public readonly eventName = 'SudoProcCommandExchangeBegin';
 }
 
-export class SudoProcCommandExchangePing extends DotnetCustomMessageEvent
-{
+export class SudoProcCommandExchangePing extends DotnetCustomMessageEvent {
     public readonly eventName = 'SudoProcCommandExchangePing';
 }
 
-export class WaitingForDotnetInstallerResponse extends DotnetCustomMessageEvent
-{
+export class WaitingForDotnetInstallerResponse extends DotnetCustomMessageEvent {
     public readonly eventName = 'WaitingForDotnetInstallerResponse';
 }
 
-export class SudoProcCommandExchangeEnd extends DotnetCustomMessageEvent
-{
+export class SudoProcCommandExchangeEnd extends DotnetCustomMessageEvent {
     public readonly eventName = 'SudoProcCommandExchangeEnd';
 }
 
-export class CommandExecutionUserAskDialogueEvent extends DotnetCustomMessageEvent
-{
+export class CommandExecutionUserAskDialogueEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionUserAskDialogueEvent';
 }
 
-export class CommandExecutionUserCompletedDialogueEvent extends DotnetCustomMessageEvent
-{
+export class CommandExecutionUserCompletedDialogueEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionUserCompletedDialogueEvent';
 }
 
-export class CommandExecutionUnderSudoEvent extends DotnetCustomMessageEvent
-{
+export class CommandExecutionUnderSudoEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'CommandExecutionUnderSudoEvent';
-    public getProperties()
-    {
+    public getProperties() {
         return { ...getDisabledTelemetryOnChance(1), ...super.getProperties() };
     }
 }
 
-export class CommandExecutionUserRejectedPasswordRequest extends DotnetInstallExpectedAbort
-{
+export class CommandExecutionUserRejectedPasswordRequest extends DotnetInstallExpectedAbort {
     public readonly eventName = 'CommandExecutionUserRejectedPasswordRequest';
 }
 
-export class CommandExecutionUnknownCommandExecutionAttempt extends DotnetInstallExpectedAbort
-{
+export class CommandExecutionUnknownCommandExecutionAttempt extends DotnetInstallExpectedAbort {
     public readonly eventName = 'CommandExecutionUnknownCommandExecutionAttempt';
 }
 
-export class DotnetVersionParseEvent extends DotnetCustomMessageEvent
-{
+export class DotnetVersionParseEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetVersionParseEvent';
 }
 
-export class DotnetUpgradedEvent extends DotnetCustomMessageEvent
-{
+export class DotnetUpgradedEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetUpgradedEvent';
-    constructor(eventMsg: string)
-    {
+    constructor(eventMsg: string) {
         super(eventMsg);
         this.type = EventType.DotnetUpgradedEvent;
     }
 }
 
-export class DotnetOfflineInstallUsed extends DotnetCustomMessageEvent
-{
+export class DotnetOfflineInstallUsed extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetOfflineInstallUsed';
-    constructor(eventMsg: string)
-    {
+    constructor(eventMsg: string) {
         super(eventMsg);
         this.type = EventType.OfflineInstallUsed;
     }
 }
 
-export class DotnetOfflineWarning extends DotnetCustomMessageEvent
-{
+export class DotnetOfflineWarning extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetOfflineWarning';
-    constructor(eventMsg: string)
-    {
+    constructor(eventMsg: string) {
         super(eventMsg);
         this.type = EventType.OfflineWarning;
     }
 }
 
-export class NetInstallerBeginExecutionEvent extends DotnetCustomMessageEvent
-{
+export class NetInstallerBeginExecutionEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'NetInstallerBeginExecutionEvent';
 }
 
-export class NetInstallerEndExecutionEvent extends DotnetCustomMessageEvent
-{
+export class NetInstallerEndExecutionEvent extends DotnetCustomMessageEvent {
     public readonly eventName = 'NetInstallerEndExecutionEvent';
 }
 
-export class FailedToRunSudoCommand extends DotnetCustomMessageEvent
-{
+export class FailedToRunSudoCommand extends DotnetCustomMessageEvent {
     public readonly eventName = 'FailedToRunSudoCommand';
 }
 
-export class DotnetInstallLinuxChecks extends DotnetCustomMessageEvent
-{
+export class DotnetInstallLinuxChecks extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetInstallLinuxChecks';
 }
 
-export abstract class DotnetFileEvent extends DotnetAcquisitionMessage
-{
+export abstract class DotnetFileEvent extends DotnetAcquisitionMessage {
     constructor(public readonly eventMessage: string, public readonly time: string, public readonly file: string) { super(); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return { Message: this.eventMessage, Time: this.time, File: TelemetryUtilities.HashData(this.file) };
     }
 }
 
-export abstract class DotnetLockEvent extends DotnetFileEvent
-{
+export abstract class DotnetLockEvent extends DotnetFileEvent {
     constructor(public readonly eventMessage: string, public readonly time: string, public readonly lock: string, public readonly file: string) { super(eventMessage, time, file); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return { Message: this.eventMessage, Time: this.time, Lock: this.lock, File: this.file, ...getDisabledTelemetryOnChance(1) };
     }
 }
 
-export class GenericDotnetLockEvent extends DotnetLockEvent
-{
+export class GenericDotnetLockEvent extends DotnetLockEvent {
     public readonly eventName = 'GenericDotnetLockEvent';
 }
 
-export class DotnetFileWriteRequestEvent extends DotnetFileEvent
-{
+export class DotnetFileWriteRequestEvent extends DotnetFileEvent {
     public readonly eventName = 'DotnetFileWriteRequestEvent';
 
-    public getProperties()
-    {
+    public getProperties() {
         return { suppressTelemetry: 'true', ...super.getProperties() };
     }
 }
 
-export class DotnetAcquisitionPartialInstallation extends DotnetAcquisitionMessage
-{
+export class DotnetAcquisitionPartialInstallation extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetAcquisitionPartialInstallation';
     constructor(public readonly install: DotnetInstall) { super(); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             ...InstallToStrings(this.install!),
             PartialInstallationInstallId: this.install.installId
@@ -1670,15 +1395,13 @@ export class DotnetAcquisitionPartialInstallation extends DotnetAcquisitionMessa
     }
 }
 
-export class DotnetAcquisitionInProgress extends IEvent
-{
+export class DotnetAcquisitionInProgress extends IEvent {
     public readonly type = EventType.DotnetAcquisitionInProgress;
 
     public readonly eventName = 'DotnetAcquisitionInProgress';
     constructor(public readonly install: DotnetInstall, public readonly requestingExtensionId: string | null) { super(); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             InProgressInstallationInstallId: this.install.installId,
             ...InstallToStrings(this.install!),
@@ -1687,15 +1410,13 @@ export class DotnetAcquisitionInProgress extends IEvent
     }
 }
 
-export class DotnetAcquisitionAlreadyInstalled extends IEvent
-{
+export class DotnetAcquisitionAlreadyInstalled extends IEvent {
     public readonly eventName = 'DotnetAcquisitionAlreadyInstalled';
     public readonly type = EventType.DotnetAcquisitionAlreadyInstalled;
 
     constructor(public readonly install: DotnetInstall, public readonly requestingExtensionId: string | null) { super(); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             ...InstallToStrings(this.install),
             extensionId: TelemetryUtilities.HashData(this.requestingExtensionId)
@@ -1703,24 +1424,20 @@ export class DotnetAcquisitionAlreadyInstalled extends IEvent
     }
 }
 
-export class DotnetAcquisitionMissingLinuxDependencies extends DotnetAcquisitionMessage
-{
+export class DotnetAcquisitionMissingLinuxDependencies extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetAcquisitionMissingLinuxDependencies';
 }
 
-export class DotnetAcquisitionThoughtInstalledButNot extends DotnetCustomMessageEvent
-{
+export class DotnetAcquisitionThoughtInstalledButNot extends DotnetCustomMessageEvent {
     public readonly eventName = 'DotnetAcquisitionThoughtInstalledButNot';
 }
 
-export class DotnetAcquisitionScriptOutput extends DotnetAcquisitionMessage
-{
+export class DotnetAcquisitionScriptOutput extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetAcquisitionScriptOutput';
     public isError = true;
     constructor(public readonly install: DotnetInstall, public readonly output: string) { super(); }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             AcquisitionInstallId: this.install.installId,
             ...InstallToStrings(this.install!),
@@ -1729,13 +1446,11 @@ export class DotnetAcquisitionScriptOutput extends DotnetAcquisitionMessage
     }
 }
 
-export class DotnetInstallationValidated extends DotnetAcquisitionMessage
-{
+export class DotnetInstallationValidated extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetInstallationValidated';
     constructor(public readonly install: DotnetInstall) { super(); }
 
-    public getProperties(telemetry = false): { [id: string]: string } | undefined
-    {
+    public getProperties(telemetry = false): { [id: string]: string } | undefined {
         return {
             ValidatedInstallId: this.install.installId,
             ...InstallToStrings(this.install!)
@@ -1743,18 +1458,15 @@ export class DotnetInstallationValidated extends DotnetAcquisitionMessage
     }
 }
 
-export class DotnetAcquisitionStatusRequested extends DotnetAcquisitionMessage
-{
+export class DotnetAcquisitionStatusRequested extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetAcquisitionStatusRequested';
 
     constructor(public readonly version: string,
-        public readonly requestingId = '')
-    {
+        public readonly requestingId = '') {
         super();
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             AcquisitionStartVersion: this.version,
             RequestingExtensionId: TelemetryUtilities.HashData(this.requestingId)
@@ -1762,17 +1474,14 @@ export class DotnetAcquisitionStatusRequested extends DotnetAcquisitionMessage
     }
 }
 
-export class DotnetAcquisitionStatusUndefined extends DotnetAcquisitionMessage
-{
+export class DotnetAcquisitionStatusUndefined extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetAcquisitionStatusUndefined';
 
-    constructor(public readonly installId: DotnetInstall)
-    {
+    constructor(public readonly installId: DotnetInstall) {
         super();
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             AcquisitionStatusInstallId: this.installId.installId,
             ...InstallToStrings(this.installId!)
@@ -1780,17 +1489,14 @@ export class DotnetAcquisitionStatusUndefined extends DotnetAcquisitionMessage
     }
 }
 
-export class DotnetAcquisitionStatusResolved extends DotnetAcquisitionMessage
-{
+export class DotnetAcquisitionStatusResolved extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetAcquisitionStatusResolved';
 
-    constructor(public readonly installId: DotnetInstall, public readonly version: string)
-    {
+    constructor(public readonly installId: DotnetInstall, public readonly version: string) {
         super();
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             AcquisitionStatusInstallId: this.installId.installId,
             ...InstallToStrings(this.installId!),
@@ -1799,59 +1505,48 @@ export class DotnetAcquisitionStatusResolved extends DotnetAcquisitionMessage
     }
 }
 
-export class WebRequestSent extends DotnetAcquisitionMessage
-{
+export class WebRequestSent extends DotnetAcquisitionMessage {
     public readonly eventName = 'WebRequestSent';
 
-    constructor(public readonly url: string)
-    {
+    constructor(public readonly url: string) {
         super();
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return { WebRequestUri: this.url };
     }
 }
 
-export class WebRequestUsingAltClient extends DotnetAcquisitionMessage
-{
+export class WebRequestUsingAltClient extends DotnetAcquisitionMessage {
     public readonly eventName = 'WebRequestUsingAltClient';
 
-    constructor(public readonly url: string, public readonly msg: string)
-    {
+    constructor(public readonly url: string, public readonly msg: string) {
         super();
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return { WebRequestUri: this.url, Message: this.msg };
     }
 }
 
 
-export class WebRequestInitiated extends DotnetAcquisitionMessage
-{
+export class WebRequestInitiated extends DotnetAcquisitionMessage {
     public readonly eventName = 'WebRequestInitiated';
 
-    constructor(public readonly url: string)
-    {
+    constructor(public readonly url: string) {
         super();
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return { WebRequestUri: this.url };
     }
 }
 
-export class DotnetPreinstallDetected extends DotnetAcquisitionMessage
-{
+export class DotnetPreinstallDetected extends DotnetAcquisitionMessage {
     public readonly eventName = 'DotnetPreinstallDetected';
     constructor(public readonly installId: DotnetInstall) { super(); }
 
-    public getProperties()
-    {
+    public getProperties() {
         return {
             ...InstallToStrings(this.installId!),
             PreinstalledInstallId: this.installId.installId
@@ -1859,23 +1554,19 @@ export class DotnetPreinstallDetected extends DotnetAcquisitionMessage
     }
 }
 
-export class TestAcquireCalled extends IEvent
-{
+export class TestAcquireCalled extends IEvent {
     public readonly eventName = 'TestAcquireCalled';
     public readonly type = EventType.DotnetAcquisitionTest;
 
-    constructor(public readonly context: IDotnetInstallationContext)
-    {
+    constructor(public readonly context: IDotnetInstallationContext) {
         super();
     }
 
-    public getProperties()
-    {
+    public getProperties() {
         return undefined;
     }
 }
 
-function getDisabledTelemetryOnChance(percentIntToSend: number): { [disableTelemetryId: string]: string }
-{
+function getDisabledTelemetryOnChance(percentIntToSend: number): { [disableTelemetryId: string]: string } {
     return { suppressTelemetry: (!(Math.random() < percentIntToSend / 100)).toString() };
 }

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -666,7 +666,7 @@ export class MockTelemetryReporter implements ITelemetryReporter
 
 export class MockInstallationValidator extends IInstallationValidator
 {
-    public validateDotnetInstall(version: DotnetInstall, dotnetPath: string): boolean
+    public validateDotnetInstall(version: DotnetInstall, dotnetPath: string, validateDirectory?: boolean, failOnErr?: boolean): boolean
     {
         return true;
     }

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -666,9 +666,9 @@ export class MockTelemetryReporter implements ITelemetryReporter
 
 export class MockInstallationValidator extends IInstallationValidator
 {
-    public validateDotnetInstall(version: DotnetInstall, dotnetPath: string): void
+    public validateDotnetInstall(version: DotnetInstall, dotnetPath: string): boolean
     {
-        // Always validate
+        return true;
     }
 }
 

--- a/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
@@ -110,8 +110,8 @@ suite('Windows & Mac Global Installer Tests', function ()
 
         if (os.platform() === 'darwin')
         {
-            assert.isTrue(mockExecutor.attemptedCommand.startsWith('open'), `It ran the right mac command, open. Command found: ${mockExecutor.attemptedCommand}`);
-            assert.isTrue(mockExecutor.attemptedCommand.includes('-W'), 'It used the -W flag');
+            assert.isTrue(mockExecutor.attemptedCommand.startsWith('sudo'), `It ran under sudo. C${mockExecutor.attemptedCommand}`);
+            assert.isTrue(mockExecutor.attemptedCommand.includes('installer'), 'It used the installer command');
             assert.isTrue(mockExecutor.attemptedCommand.includes('"'), 'It put the installer in quotes for username with space in it');
         }
         else if (os.platform() === 'win32')

--- a/vscode-dotnet-runtime-library/yarn.lock
+++ b/vscode-dotnet-runtime-library/yarn.lock
@@ -637,11 +637,6 @@ fs.realpath@^1.0.0:
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.3.3:
-  version "2.3.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/1052 (That story is technically already resolved but this closes it out)

The mac installer currently always requires user input to go through the UI dialog prompt. This gets missed by a large number of users. Worse yet, we use 'open' so we don't parse the user password, but open doesn't allow us to get the exit code of the installer, so we don't know if someone cancelled, closed out the installer, left their pc, or rejected the password prompt, and that gets counted as a failure on our side.

This updates the method to use 'installer' and the sudo prompt to elevate and install. The sudo prompt must be used with caution with gui applications, as the files it touches can become owned by 'root.' Luckily in this case, the installer is meant to be executed with admin privileges.

An alternative is to use osascript -e 'do shell script "..." with administrator privileges' but this doesn't seem to be able to parse properly in this context.

In the event users have issues with 'installer' such as it being disabled by a policy, we fallback to the old method. However, now we collect data in the fallback to allow us to better count the cases when a user leaves/denies the request.