### PR TITLE
Don't include bl file in the .VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,6 +5,7 @@ node_modules/**
 dist/test/**
 src/**
 *.vsix
+*.binlog
 packages/
 msbuild/**
 global.json


### PR DESCRIPTION
This file is large and shouldn't be part of the build - it should only be in the artifacts directory.