### PR TITLE
Fix PME Signing 

### DIFF
--- a/pipeline-templates/list-file-structure.yaml
+++ b/pipeline-templates/list-file-structure.yaml
@@ -16,7 +16,6 @@ steps:
         Write-Host "====================== FILE STRUCTURE OVERVIEW ======================"
         Write-Host ""
 
-        # Function to create a tree-like structure
         function Show-DirectoryTree {
           param(
             [string]$Path,
@@ -99,7 +98,6 @@ steps:
           Write-Host ""
         }
 
-        # Process the current path
         Show-DirectoryTree -Path "${{ pathConfig.path }}" -Title "${{ pathConfig.title }}"
 
       displayName: '${{ parameters.displayName }} - ${{ pathConfig.title }}'

--- a/pipeline-templates/list-file-structure.yaml
+++ b/pipeline-templates/list-file-structure.yaml
@@ -1,0 +1,105 @@
+parameters:
+  - name: paths
+    type: object
+    default:
+      - path: $(System.DefaultWorkingDirectory)
+        title: "🏠 SYSTEM DEFAULT WORKING DIRECTORY"
+      - path: $(Build.ArtifactStagingDirectory)
+        title: "🎯 BUILD ARTIFACT STAGING DIRECTORY"
+  - name: displayName
+    type: string
+    default: '📋 List All Files Recursively'
+
+steps:
+  - ${{ each pathConfig in parameters.paths }}:
+    - pwsh: |
+        Write-Host "====================== FILE STRUCTURE OVERVIEW ======================"
+        Write-Host ""
+
+        # Function to create a tree-like structure
+        function Show-DirectoryTree {
+          param(
+            [string]$Path,
+            [string]$Title
+          )
+
+          Write-Host "$Title" -ForegroundColor Cyan
+          Write-Host "Path: $Path" -ForegroundColor Yellow
+          Write-Host ""
+
+          if (Test-Path $Path) {
+            try {
+              $items = Get-ChildItem -Path $Path -Recurse -ErrorAction SilentlyContinue | Sort-Object FullName
+              $totalFiles = ($items | Where-Object { -not $_.PSIsContainer }).Count
+              $totalDirs = ($items | Where-Object { $_.PSIsContainer }).Count
+
+              Write-Host "📊 Summary: $totalDirs directories, $totalFiles files" -ForegroundColor Green
+              Write-Host ""
+
+              if ($items.Count -eq 0) {
+                Write-Host "📭 Directory is empty" -ForegroundColor Gray
+                Write-Host ""
+                return
+              }
+
+              # Group by directory for better structure
+              $directories = $items | Where-Object { $_.PSIsContainer } | Sort-Object FullName
+              $files = $items | Where-Object { -not $_.PSIsContainer } | Sort-Object FullName
+
+              # Show directory structure first
+              if ($directories.Count -gt 0) {
+                Write-Host "📁 Directory Structure:" -ForegroundColor Magenta
+                foreach ($dir in $directories) {
+                  $relativePath = $dir.FullName.Replace($Path, "").TrimStart('\', '/')
+                  if ($relativePath) {
+                    $depth = ($relativePath.Split([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) | Where-Object { $_ -ne "" }).Count
+                    $indent = "  " * $depth + "├── "
+                    Write-Host "$indent$($dir.Name)/" -ForegroundColor Blue
+                  }
+                }
+                Write-Host ""
+              }
+
+              # Show files grouped by directory
+              if ($files.Count -gt 0) {
+                Write-Host "📄 Files:" -ForegroundColor Magenta
+                $filesByDir = $files | Group-Object { Split-Path $_.FullName -Parent } | Sort-Object Name
+
+                foreach ($group in $filesByDir) {
+                  $relativeDirPath = $group.Name.Replace($Path, "").TrimStart('\', '/')
+                  if ($relativeDirPath -eq "") {
+                    Write-Host "  📂 Root:" -ForegroundColor Yellow
+                  } else {
+                    Write-Host "  📂 ${relativeDirPath}:" -ForegroundColor Yellow
+                  }
+
+                  foreach ($file in ($group.Group | Sort-Object Name)) {
+                    try {
+                      $size = if ($file.Length -lt 1KB) { "$($file.Length) B" }
+                             elseif ($file.Length -lt 1MB) { "{0:N1} KB" -f ($file.Length / 1KB) }
+                             else { "{0:N1} MB" -f ($file.Length / 1MB) }
+
+                      Write-Host "    ├── $($file.Name) ($size)" -ForegroundColor White
+                    }
+                    catch {
+                      Write-Host "    ├── $($file.Name) (size unknown)" -ForegroundColor Gray
+                    }
+                  }
+                  Write-Host ""
+                }
+              }
+            }
+            catch {
+              Write-Host "❌ Error accessing directory: $($_.Exception.Message)" -ForegroundColor Red
+            }
+          } else {
+            Write-Host "❌ Directory does not exist: $Path" -ForegroundColor Red
+          }
+          Write-Host "=================================================================" -ForegroundColor Cyan
+          Write-Host ""
+        }
+
+        # Process the current path
+        Show-DirectoryTree -Path "${{ pathConfig.path }}" -Title "${{ pathConfig.title }}"
+
+      displayName: '${{ parameters.displayName }} - ${{ pathConfig.title }}'

--- a/pipeline-templates/package-vsix.yaml
+++ b/pipeline-templates/package-vsix.yaml
@@ -70,7 +70,7 @@ jobs:
     displayName: 🖊️ Sign VSIXes
     env:
       SignType: ${{ parameters.SignType }}
-  - ${{ if eq(parameters.useOneEngineeringPool, 'true') }}:
+  - ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
     - pwsh: |
         Function Spawn-Tool($command, $commandArgs, $retryCount=0) {
           Write-Host "$pwd >"

--- a/pipeline-templates/package-vsix.yaml
+++ b/pipeline-templates/package-vsix.yaml
@@ -69,47 +69,47 @@ jobs:
     displayName: 🖊️ Sign VSIXes
     env:
       SignType: ${{ parameters.SignType }}
-  - pwsh: |
-      Function Spawn-Tool($command, $commandArgs, $retryCount=0) {
-        Write-Host "$pwd >"
-        for (; $retryCount -ge 0; $retryCount--) {
-          Write-Host "##[command]$command $commandArgs"
-          $output = Invoke-Expression "$command $commandArgs" # Do not use @commandArgs because it quotes '-Target', breaking the script.
-          if ($LASTEXITCODE -eq 0) { break }
-          Write-Host "Task failed with exit code $LASTEXITCODE. $retryCount retries left."
+  - ${{ if eq(parameters.useOneEngineeringPool, 'true') }}:
+    - pwsh: |
+        Function Spawn-Tool($command, $commandArgs, $retryCount=0) {
+          Write-Host "$pwd >"
+          for (; $retryCount -ge 0; $retryCount--) {
+            Write-Host "##[command]$command $commandArgs"
+            $output = Invoke-Expression "$command $commandArgs" # Do not use @commandArgs because it quotes '-Target', breaking the script.
+            if ($LASTEXITCODE -eq 0) { break }
+            Write-Host "Task failed with exit code $LASTEXITCODE. $retryCount retries left."
+          }
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          return $output
         }
-        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-        return $output
-      }
+        $anyFailed = $false
+        $vsixes = Get-ChildItem -Path ../packages -Filter *.vsix -Recurse
+        foreach ($vsix in $vsixes) {
+          $baseName = "$($vsix.DirectoryName)\$($vsix.BaseName)"
+          $manifestFile = $baseName + ".manifest"
+          $signatureFile = $baseName + ".signature.p7s"
 
-      $anyFailed = $false
-      $vsixes = Get-ChildItem -Path ../packages -Filter *.vsix -Recurse
-      foreach ($vsix in $vsixes) {
-        $baseName = "$($vsix.DirectoryName)\$($vsix.BaseName)"
-        $manifestFile = $baseName + ".manifest"
-        $signatureFile = $baseName + ".signature.p7s"
+          $vsceVerifyArgs = '@vscode/vsce','verify-signature','--packagePath',$vsix,'--manifestPath',$manifestFile,'--signaturePath',$signatureFile
+          $output = Spawn-Tool 'npx' $vsceVerifyArgs
 
-        $vsceVerifyArgs = '@vscode/vsce','verify-signature','--packagePath',$vsix,'--manifestPath',$manifestFile,'--signaturePath',$signatureFile
-        $output = Spawn-Tool 'npx' $vsceVerifyArgs
-
-        # This is a brittle check but the command does not return a non-zero exit code for failed validation.
-        # Opened https://github.com/microsoft/vscode-vsce/issues/1192 to track this.
-        if ($output.Contains('Signature verification result: Success')) {
-          Write-Host "Signature verification succeeded for $vsix"
-        } else {
-          Write-Host ($output | Out-String)
-          Write-Host "##[error]Signature verification failed for $vsix"
-          $anyFailed = $true
+          # This is a brittle check but the command does not return a non-zero exit code for failed validation.
+          # Opened https://github.com/microsoft/vscode-vsce/issues/1192 to track this.
+          if ($output.Contains('Signature verification result: Success')) {
+            Write-Host "Signature verification succeeded for $vsix"
+          } else {
+            Write-Host ($output | Out-String)
+            Write-Host "##[error]Signature verification failed for $vsix"
+            $anyFailed = $true
+          }
         }
-      }
 
-      if ($anyFailed) {
-          exit 1
-      }
-    displayName: 🔑 Verify VSIX Signature Files
-    workingDirectory: $(dir-name)
-    condition: and( succeeded(), eq('$(SignType)', 'Real'))
+        if ($anyFailed) {
+            exit 1
+        }
+      displayName: 🔑 Verify VSIX Signature Files
+      workingDirectory: $(dir-name)
   - task: CmdLine@2
     displayName: 🤌 Rename Signed VSIX
     inputs:

--- a/pipeline-templates/package-vsix.yaml
+++ b/pipeline-templates/package-vsix.yaml
@@ -65,6 +65,7 @@ jobs:
     workingDirectory: $(dir-name)
     env:
       SignType: ${{ parameters.SignType }}
+  - template: list-file-structure.yaml
   - script: dotnet build msbuild/signVsix -v:normal
     displayName: 🖊️ Sign VSIXes
     env:

--- a/pipeline-templates/prepare-signing.yaml
+++ b/pipeline-templates/prepare-signing.yaml
@@ -14,8 +14,9 @@ steps:
       signType: ${{ parameters.SignType }}
       zipSources: false
       feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-      signWithProd: true
-      ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
+      ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
+        signWithProd: true
+        ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
     env:
       SignType: ${{ parameters.SignType }}
       TeamName: DotNetCore

--- a/pipeline-templates/prepare-signing.yaml
+++ b/pipeline-templates/prepare-signing.yaml
@@ -14,9 +14,8 @@ steps:
       signType: ${{ parameters.SignType }}
       zipSources: false
       feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-      ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
-        signWithProd: true
-        ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
+      signWithProd: true
+      ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
     env:
       SignType: ${{ parameters.SignType }}
       TeamName: DotNetCore

--- a/pipeline-templates/prepare-signing.yaml
+++ b/pipeline-templates/prepare-signing.yaml
@@ -15,6 +15,7 @@ steps:
       zipSources: false
       feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
       ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
+        signWithProd: true
         ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
     env:
       SignType: ${{ parameters.SignType }}

--- a/pipeline-templates/prepare-signing.yaml
+++ b/pipeline-templates/prepare-signing.yaml
@@ -14,7 +14,6 @@ steps:
       signType: ${{ parameters.SignType }}
       zipSources: false
       feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-      azureSubscription: 'MicroBuild Signing Task (DevDiv)'
       ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
         ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
     env:

--- a/pipeline-templates/publish.yaml
+++ b/pipeline-templates/publish.yaml
@@ -27,6 +27,7 @@ jobs:
       inputs:
         path: '$(System.ArtifactsDirectory)'
     - template: install-node.yaml
+    - template: list-file-structure.yaml
     - bash: |
         VERSION=`node -p "require('./package.json').version"`
         npm version $VERSION --allow-same-version


### PR DESCRIPTION
This adds to the requirements of PME signing. 

With this PR, https://github.com/dotnet/vscode-dotnet-runtime/pull/2401, some things were missing/incorrect:
- `signWithProd` was not enabled
- azureSubscription is not needed.
- The wrong Service Connection was used (Unix instead of Win)
- Signature verification was not conditioned to be per only official builds
- The AzDo Env did not have permission for the Service Connection

This PR also adds a step which prints the file structure which makes it easier to see where the sign file drops are when they get ingested.