### PR TITLE
Fix Linux Image

### DIFF
--- a/1pr-azure-pipeline.yml
+++ b/1pr-azure-pipeline.yml
@@ -31,7 +31,7 @@ parameters:
     os: windows
     emoji: 🪟
   - name: NetCore-Public
-    demands: ImageOverride -equals 1es-ubuntu-2004-open
+    demands: ImageOverride -equals build.ubuntu.2204.amd64.open
     os: linux
     emoji: 🐧
   - name: Azure Pipelines

--- a/pipeline-templates/build-test.yaml
+++ b/pipeline-templates/build-test.yaml
@@ -33,6 +33,10 @@ jobs:
       displayName: 🔍 Test Windows
   - ${{ if eq(parameters.pool.os, 'linux') }}:
     - bash: |
+        sudo apt-get update
+        sudo apt-get install -y libgbm1 xvfb libnss3 libatk-bridge2.0-0 libatk1.0-0 libgtk-3-0 libgbm-dev libxkbcommon-x11-0 libdrm2 libx11-xcb1 libasound2
+      displayName: 📦 Install VS Code dependencies
+    - bash: |
         /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
         echo ">>> Started xvfb"
       displayName: 🎮 Start xvfb

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockEnvironmentVariableCollection.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockEnvironmentVariableCollection.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 export class MockEnvironmentVariableCollection implements vscode.EnvironmentVariableCollection {
 
     public persistent =  true;
+    public description: string | vscode.MarkdownString | undefined = undefined;
     public variables: {[variable: string]: string} = {};
 
     public append(variable: string, value: string): void {

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -21,7 +21,7 @@ const standardTimeoutTime = 100000;
 const mockVersion = '8.0.103';
 const acquisitionContext = getMockAcquisitionContext('sdk', mockVersion);
 const mockExecutor = new MockCommandExecutor(acquisitionContext, getMockUtilityContext());
-const pair: DistroVersionPair = { distro: UBUNTU_DISTRO_INFO_KEY, version: '24.04' };
+const pair: DistroVersionPair = { distro: UBUNTU_DISTRO_INFO_KEY, version: '22.04' };
 const provider: GenericDistroSDKProvider = new GenericDistroSDKProvider(pair, acquisitionContext, getMockUtilityContext(), mockExecutor);
 const shouldRun = os.platform() === 'linux';
 const installType: DotnetInstallMode = 'sdk';

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -147,11 +147,7 @@ export async function getLinuxSupportedDotnetSDKVersion(context: IAcquisitionWor
     {
         if (distroInfo.version < '22.04')
         {
-            return '9.0.100';
-        }
-        if (distroInfo.version < '22.06')
-        {
-            return '9.0.100';
+            return '7.0.100';
         }
         if (distroInfo.version < '24.04')
         {


### PR DESCRIPTION
We need to migrate to the new Linux image in CI so we can run tests on Linux again. https://github.com/dotnet/vscode-dotnet-runtime/pull/2557 This PR initially had the changes but it should really be an isolated fix - was intending to put it there to improve PR merge velocity.

The new linux image doesn't support some linux versions and is missing some vscode dependencies, which is also resolved in this PR.