### PR TITLE
fix: prevent lsof 100% CPU hang on Linux

### DIFF
--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -244,6 +244,16 @@ export class FileUtilities extends IFileUtilities
 
     public static async fileIsOpen(filePath: string, eventStream?: IEventStream): Promise<boolean>
     {
+        try
+        {
+            await fs.promises.access(filePath, fs.constants.F_OK);
+        }
+        catch
+        {
+            eventStream?.post(new FileIsNotBusy(`The file ${filePath} does not exist, so it is not busy.`));
+            return false;
+        }
+
         let fileHandle: fs.promises.FileHandle | null = null;
         if (os.platform() === 'win32')
         {
@@ -270,12 +280,6 @@ export class FileUtilities extends IFileUtilities
         }
         else
         {
-            if (!fs.existsSync(filePath))
-            {
-                eventStream?.post(new FileIsNotBusy(`The file ${filePath} does not exist, so it is not busy.`));
-                return false;
-            }
-
             try
             {
                 // 10s timeout: targeted lsof queries complete in <1s on normal systems.

--- a/vscode-dotnet-runtime-library/src/test/unit/FileUtilities.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/FileUtilities.test.ts
@@ -17,8 +17,8 @@ suite('FileUtilities Unit Tests', function ()
     {
         test('returns false for a non-existent file path', async function ()
         {
-            // Non-existent files hit the fs.existsSync guard and return false
-            // immediately without spawning lsof.
+            // Non-existent files hit the async fs.promises.access guard
+            // and return false without spawning lsof or opening a handle.
             const result = await FileUtilities.fileIsOpen('/tmp/dotnet-test-nonexistent-file-abc123xyz');
             assert.isFalse(result, 'fileIsOpen should return false for a file that does not exist');
         });
@@ -53,8 +53,8 @@ suite('FileUtilities Unit Tests', function ()
             {
                 this.skip();
             }
-            // On Windows, fileIsOpen uses fs.promises.open which throws ENOENT
-            // for non-existent files, caught by the finally block.
+            // On Windows, non-existent files are now caught by the
+            // platform-agnostic fs.promises.access guard at the top.
             const result = await FileUtilities.fileIsOpen('C:\\nonexistent\\dotnet-test-abc123.exe');
             assert.isFalse(result, 'fileIsOpen should return false for a non-existent file on Windows');
         });


### PR DESCRIPTION
## Summary

- Add `-n` flag to `lsof` to prevent reverse DNS lookups that cause indefinite CPU hangs
- Add 10-second timeout to `exec()` so stuck `lsof` processes are killed automatically
- **On timeout, assume file is busy** (safe default — prevents deleting in-use runtimes)
- Add file-existence guard to skip `lsof` for non-existent paths
- Fix incorrect `FileIsBusy` event posted when lsof output is empty (should be `FileIsNotBusy`)
- Fix `EACCES` error code typo (`EACCESS` → `EACCES`)

## Problem

`FileUtilities.fileIsOpen()` spawns `lsof <path>` on Linux/macOS without the `-n` flag. Without `-n`, `lsof` performs reverse DNS lookups for every network file descriptor, which can hang indefinitely on systems with slow or unreachable DNS. Combined with no `timeout` on the `exec()` call, this causes `lsof` processes to consume 100% CPU and never terminate.

The extension's cleanup loop respawns these processes, compounding the problem. On affected systems, 3+ `lsof` processes each consume 100% of a CPU core.

Observed on Kali Linux 6.11.2 (x86_64) with extension v3.0.0. Also reported on macOS.

## Root Cause

```typescript
// Before (hangs indefinitely):
promisify(exec)(`lsof ${filePath}`)

// After (completes reliably):
promisify(exec)(`lsof -n ${filePath}`, { timeout: 10000 })
```

The `-n` flag is the same fix VS Code core applied to their terminal `lsof` calls in microsoft/vscode#78438.

### Timeout value (10 seconds)

Targeted `lsof -n` queries complete in <1s on normal systems. The 10-second timeout is a safety net for heavily loaded systems (300+ processes) where `/proc/*/fd` scanning is slow. This aligns with production precedent (e.g. performa-satellite uses 10s for full lsof parsing).

### Timeout safety

When the timeout fires, `lsof` is killed and we **cannot determine** if the file is busy. The safe choice is to **assume busy** (`return true`) so `wipeDirectory()` skips the deletion. This prevents deleting in-use .NET runtimes on heavily loaded systems where `lsof` is slow. The worst case is an unused runtime stays on disk until the next cleanup cycle — far safer than deleting an active runtime.

```typescript
if (rejected?.killed || rejected?.signal)
{
    eventStream?.post(new FileIsBusy(`... presumed busy because lsof timed out`));
    return Promise.resolve(true);  // safe: don't delete
}
```

### Secondary fixes

- **Line 286 event bug:** Posted `FileIsBusy` when lsof output was empty (file is NOT busy). Fixed to post `FileIsNotBusy`.
- **EACCES typo:** Checked for `'EACCESS'` (extra S) which never matches Node.js error code `'EACCES'`. The permissions handler was dead code.

## Test Plan

- [x] New unit tests in `FileUtilities.test.ts` covering:
  - Non-existent file returns false (guard)
  - Existing file not in use returns false
  - File held open by another process returns true (skips on slow systems)
  - Function completes within 15 seconds (10s timeout + overhead)
  - Correct event type posted when file is not busy
- [x] All existing unit tests pass (zero regressions: 199 passing, 7 pre-existing failures unchanged)
- [x] Manual verification: no `lsof` processes stuck at 100% CPU after fix

## Impact Assessment

| Change | Risk | Rationale |
|--------|------|-----------|
| `-n` flag | None | Suppresses DNS lookups only. Output format identical. |
| `timeout: 10000` | None | If lsof hangs >10s, killed. Returns `true` (presumed busy). Safe: skips deletion. |
| Timeout → assume busy | None | Conservative default. Worst case: unused runtime stays on disk. Prevents data loss. |
| File existence guard | None | Non-existent files already returned `false` via ENOENT rejection. |
| `FileIsNotBusy` event | None | Only affects telemetry. Return value was already correct. |
| `EACCES` typo | Low | Enables the intended EACCES handler (was dead code). |
