### PR TITLE
Improve NodeIPCMutex Handler Edge Scenarios

### DIFF
--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -633,99 +633,101 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
      */
     const dotnetFindPathRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.findPath}`, async (commandContext: IDotnetFindPathContext): Promise<IDotnetAcquireResult | undefined> =>
     {
-        globalEventStream.post(new DotnetFindPathCommandInvoked(`The find path command was invoked.`, commandContext));
-
-        if (!commandContext.acquireContext.mode || !commandContext.acquireContext.requestingExtensionId || !commandContext.acquireContext.version || !commandContext.acquireContext.architecture)
+        const findPathResult = await callWithErrorHandling<Promise<IDotnetAcquireResult | undefined>>(async () =>
         {
-            throw new EventCancellationError('BadContextualFindPathError', `The find path request was missing required information: a mode, version, architecture, and requestingExtensionId.`);
-        }
-        const requestedArchitecture = commandContext.acquireContext.architecture;
+            globalEventStream.post(new DotnetFindPathCommandInvoked(`The find path command was invoked.`, commandContext));
 
-        globalEventStream.post(new DotnetFindPathLookupSetting(`Looking up vscode setting.`));
-        const workerContext = getAcquisitionWorkerContext(commandContext.acquireContext.mode, commandContext.acquireContext);
-        const existingPath = await resolveExistingPathIfExists(existingPathConfigWorker, commandContext.acquireContext, workerContext, utilContext, commandContext.versionSpecRequirement);
-
-        // The setting is not intended to be used as the SDK, only the runtime for extensions to run on. Ex: PowerShell policy doesn't allow us to install the runtime, let users set the path manually.
-        if (existingPath && commandContext.acquireContext.mode !== 'sdk')
-        {
-            // We don't need to validate the existing path as it gets validated + tracked in the lookup logic already.
-            globalEventStream.post(new DotnetFindPathSettingFound(`Found vscode setting.`));
-            void loggingObserver.flush();
-            return existingPath;
-        }
-
-        const validator = new DotnetConditionValidator(workerContext, utilContext);
-        const finder = new DotnetHostPathFinder(workerContext, utilContext);
-
-        const dotnetOnShellSpawn = (await finder.findDotnetFastFromListOnly(requestedArchitecture)) ?? '';
-        if (dotnetOnShellSpawn)
-        {
-            const validatedShellSpawn = await getPathIfValid(dotnetOnShellSpawn, validator, commandContext);
-            if (validatedShellSpawn)
+            if (!commandContext.acquireContext.mode || !commandContext.acquireContext.requestingExtensionId || !commandContext.acquireContext.version || !commandContext.acquireContext.architecture)
             {
-                void loggingObserver.flush();
-                return { dotnetPath: validatedShellSpawn };
+                throw new EventCancellationError('BadContextualFindPathError', `The find path request was missing required information: a mode, version, architecture, and requestingExtensionId.`);
             }
-        }
+            const requestedArchitecture = commandContext.acquireContext.architecture;
 
-        const dotnetsOnPATH = await finder.findRawPathEnvironmentSetting(true, requestedArchitecture);
-        for (const dotnetPath of dotnetsOnPATH ?? [])
-        {
-            const validatedPATH = await getPathIfValid(dotnetPath, validator, commandContext);
-            if (validatedPATH)
+            globalEventStream.post(new DotnetFindPathLookupSetting(`Looking up vscode setting.`));
+            const workerContext = getAcquisitionWorkerContext(commandContext.acquireContext.mode, commandContext.acquireContext);
+            const existingPath = await resolveExistingPathIfExists(existingPathConfigWorker, commandContext.acquireContext, workerContext, utilContext, commandContext.versionSpecRequirement);
+
+            // The setting is not intended to be used as the SDK, only the runtime for extensions to run on. Ex: PowerShell policy doesn't allow us to install the runtime, let users set the path manually.
+            if (existingPath && commandContext.acquireContext.mode !== 'sdk')
             {
+                // We don't need to validate the existing path as it gets validated + tracked in the lookup logic already.
+                globalEventStream.post(new DotnetFindPathSettingFound(`Found vscode setting.`));
                 void loggingObserver.flush();
-                return { dotnetPath: validatedPATH };
+                return existingPath;
             }
-        }
 
-        const dotnetsOnRealPATH = await finder.findRealPathEnvironmentSetting(true, requestedArchitecture);
-        for (const dotnetPath of dotnetsOnRealPATH ?? [])
-        {
-            const validatedRealPATH = await getPathIfValid(dotnetPath, validator, commandContext);
-            if (validatedRealPATH)
+            const validator = new DotnetConditionValidator(workerContext, utilContext);
+            const finder = new DotnetHostPathFinder(workerContext, utilContext);
+
+            const dotnetOnShellSpawn = (await finder.findDotnetFastFromListOnly(requestedArchitecture)) ?? '';
+            if (dotnetOnShellSpawn)
             {
-                void loggingObserver.flush();
-                return { dotnetPath: validatedRealPATH };
-            }
-        }
-
-        const dotnetOnROOT = await finder.findDotnetRootPath(commandContext.acquireContext.architecture);
-        const validatedRoot = await getPathIfValid(dotnetOnROOT, validator, commandContext);
-        if (validatedRoot)
-        {
-            void loggingObserver.flush();
-            return { dotnetPath: validatedRoot };
-        }
-
-        if (commandContext.acquireContext.mode !== 'sdk' && !commandContext.disableLocalLookup)
-        {
-            const extensionManagedRuntimeRecordPaths = await finder.findExtensionManagedRuntimes();
-            const filteredExtensionManagedRuntimeRecordPaths = validator.filterValidPaths(extensionManagedRuntimeRecordPaths, commandContext);
-            for (const dotnetPath of filteredExtensionManagedRuntimeRecordPaths ?? [])
-            {
-                const validatedExistingManagedPath = await getPathIfValid(dotnetPath.path, validator, commandContext);
-                if (validatedExistingManagedPath)
+                const validatedShellSpawn = await getPathIfValid(dotnetOnShellSpawn, validator, commandContext);
+                if (validatedShellSpawn)
                 {
                     void loggingObserver.flush();
-                    return { dotnetPath: dotnetPath.path };
+                    return { dotnetPath: validatedShellSpawn };
                 }
             }
-        }
 
-        const dotnetOnHostfxrRecord = await finder.findHostInstallPaths(commandContext.acquireContext.architecture);
-        for (const dotnetPath of dotnetOnHostfxrRecord ?? [])
-        {
-            const validatedHostfxr = await getPathIfValid(dotnetPath, validator, commandContext);
-            if (validatedHostfxr && process.env.DOTNET_INSTALL_TOOL_SKIP_HOSTFXR !== 'true')
+            const dotnetsOnPATH = await finder.findRawPathEnvironmentSetting(true, requestedArchitecture);
+            for (const dotnetPath of dotnetsOnPATH ?? [])
+            {
+                const validatedPATH = await getPathIfValid(dotnetPath, validator, commandContext);
+                if (validatedPATH)
+                {
+                    void loggingObserver.flush();
+                    return { dotnetPath: validatedPATH };
+                }
+            }
+
+            const dotnetsOnRealPATH = await finder.findRealPathEnvironmentSetting(true, requestedArchitecture);
+            for (const dotnetPath of dotnetsOnRealPATH ?? [])
+            {
+                const validatedRealPATH = await getPathIfValid(dotnetPath, validator, commandContext);
+                if (validatedRealPATH)
+                {
+                    void loggingObserver.flush();
+                    return { dotnetPath: validatedRealPATH };
+                }
+            }
+
+            const dotnetOnROOT = await finder.findDotnetRootPath(commandContext.acquireContext.architecture);
+            const validatedRoot = await getPathIfValid(dotnetOnROOT, validator, commandContext);
+            if (validatedRoot)
             {
                 void loggingObserver.flush();
-                return { dotnetPath: validatedHostfxr };
+                return { dotnetPath: validatedRoot };
             }
-        }
 
-        void loggingObserver.flush();
-        globalEventStream.post(new DotnetFindPathNoPathMetCondition(`Could not find a single host path that met the conditions.
+            if (commandContext.acquireContext.mode !== 'sdk' && !commandContext.disableLocalLookup)
+            {
+                const extensionManagedRuntimeRecordPaths = await finder.findExtensionManagedRuntimes();
+                const filteredExtensionManagedRuntimeRecordPaths = validator.filterValidPaths(extensionManagedRuntimeRecordPaths, commandContext);
+                for (const dotnetPath of filteredExtensionManagedRuntimeRecordPaths ?? [])
+                {
+                    const validatedExistingManagedPath = await getPathIfValid(dotnetPath.path, validator, commandContext);
+                    if (validatedExistingManagedPath)
+                    {
+                        void loggingObserver.flush();
+                        return { dotnetPath: dotnetPath.path };
+                    }
+                }
+            }
+
+            const dotnetOnHostfxrRecord = await finder.findHostInstallPaths(commandContext.acquireContext.architecture);
+            for (const dotnetPath of dotnetOnHostfxrRecord ?? [])
+            {
+                const validatedHostfxr = await getPathIfValid(dotnetPath, validator, commandContext);
+                if (validatedHostfxr && process.env.DOTNET_INSTALL_TOOL_SKIP_HOSTFXR !== 'true')
+                {
+                    void loggingObserver.flush();
+                    return { dotnetPath: validatedHostfxr };
+                }
+            }
+
+            void loggingObserver.flush();
+            globalEventStream.post(new DotnetFindPathNoPathMetCondition(`Could not find a single host path that met the conditions.
 existingPath : ${existingPath?.dotnetPath}
 onPath : ${JSON.stringify(dotnetsOnPATH)}
 onRealPath : ${JSON.stringify(dotnetsOnRealPATH)}
@@ -734,7 +736,10 @@ onHostfxrRecord : ${JSON.stringify(dotnetOnHostfxrRecord)}
 
 Requirement:
 ${JSON.stringify(commandContext)}`));
-        return undefined;
+            return undefined;
+        }, getIssueContext(existingPathConfigWorker)(commandContext?.acquireContext?.errorConfiguration, commandKeys.findPath));
+
+        return findPathResult;
     });
 
     async function getPathIfValid(path: string | undefined, validator: IDotnetConditionValidator, commandContext: IDotnetFindPathContext): Promise<string | undefined>

--- a/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/InstallTrackerSingleton.ts
@@ -31,7 +31,7 @@ import { EventStreamNodeIPCMutexLoggerWrapper } from '../Utils/EventStreamNodeIP
 import { getAssumedInstallInfo } from '../Utils/InstallIdUtilities';
 import { NodeIPCMutex } from '../Utils/NodeIPCMutex';
 import { deserializeMapOfSets, serializeMapOfSets } from '../Utils/SerializationHelpers';
-import { executeWithLock, getDotnetExecutable } from '../Utils/TypescriptUtilities';
+import { acquireWithManualReleaseOrDisabled, executeWithLock, getDotnetExecutable } from '../Utils/TypescriptUtilities';
 import
 {
     DotnetInstall,
@@ -78,10 +78,13 @@ export class InstallTrackerSingleton
      */
     protected acquirePermanentSessionMutex(): void
     {
-        const logger = new EventStreamNodeIPCMutexLoggerWrapper(this.eventStream, InstallTrackerSingleton.sessionId);
-        const mutex = new NodeIPCMutex(InstallTrackerSingleton.sessionId, logger, '');
-
-        mutex.acquireWithManualRelease(InstallTrackerSingleton.sessionId, InstallTrackerSingleton.SESSION_MUTEX_PING_DURATION, InstallTrackerSingleton.SESSION_MUTEX_ACQUIRE_TIMEOUT_MS).catch((error) =>
+        acquireWithManualReleaseOrDisabled(
+            this.eventStream,
+            InstallTrackerSingleton.sessionId,
+            InstallTrackerSingleton.sessionId,
+            InstallTrackerSingleton.SESSION_MUTEX_PING_DURATION,
+            InstallTrackerSingleton.SESSION_MUTEX_ACQUIRE_TIMEOUT_MS
+        ).catch((error) =>
         {
             this.eventStream.post(new SessionMutexAcquisitionFailed(`Failed to acquire permanent mutex for session ${InstallTrackerSingleton.sessionId}: ${error}`));
         }).then((resolved) =>

--- a/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
@@ -3,7 +3,7 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
 import * as fs from 'fs';
-import * as open from 'open';
+import open = require('open');
 import { DotnetCoreAcquisitionWorker } from '../Acquisition/DotnetCoreAcquisitionWorker';
 import { GetDotnetInstallInfo } from '../Acquisition/DotnetInstall';
 import { IAcquisitionWorkerContext } from '../Acquisition/IAcquisitionWorkerContext';

--- a/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/FileUtilities.ts
@@ -341,7 +341,9 @@ export class FileUtilities extends IFileUtilities
             try
             {
                 const commandResult = await executor.execute(CommandExecutor.makeCommand('id', ['-u']), { dotnetInstallToolCacheTtlMs: SYSTEM_INFORMATION_CACHE_DURATION_MS }, false);
-                return commandResult.status === '0';
+                // `id -u` exits 0 regardless of uid; its stdout is the effective uid. Root is uid 0.
+                // Require both the command to have succeeded AND the uid stdout to be '0'.
+                return commandResult.status === '0' && commandResult.stdout.trim() === '0';
             }
             catch (error: any)
             {

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -263,10 +263,12 @@ export class NodeIPCMutex
                 return true; // We can acquire the lock, and delete the file handle.
             }
 
-            // Expected errors:
-            // - ENOENT: The file descriptor doesn't exist, which means the process holding it has died.
-            //   Technically stale, but the only action would be to delete it, and it already is deleted.
-            // - EACCES / EPERM: We can't access the socket due- might be a OS policy like SELinux but haven't tested, might be changing user accounts
+            // Expected errors (non-stale):
+            // - ENOENT: The socket file doesn't exist. Technically stale, but the only action
+            //   would be to delete it, and it already is deleted.
+            // - EACCES / EPERM: We can't access the socket. Possible causes include a restrictive
+            //   parent directory, socket file owned by another user, or an OS policy denial. Not
+            //   evidence of staleness, so we cannot safely delete the file.
 
             this.logger.log(`Action: ${actionId} Unable to acquire lock: ${JSON.stringify(error ?? '')}.`);
             return false; // We don't know what happened, but we can't acquire the lock.
@@ -279,7 +281,7 @@ export class NodeIPCMutex
         {
             const socket = createConnection(this.lockPath, () =>
             {
-              try
+                try
                 {
                     socket.removeListener('error', reject); // Ignore other errors : we were able to connect, that's all that matters.
                     this.logger.log(`Action: ${actionId} Connected to existing lock.`);

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -2,7 +2,7 @@
 *  Licensed to the .NET Foundation under one or more agreements.
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
-import { rm } from 'fs/promises';
+import { rm, stat } from 'fs/promises';
 import { createConnection, createServer, Server } from 'net';
 import * as os from 'os';
 import * as path from 'path';
@@ -147,7 +147,8 @@ export class NodeIPCMutex
 
                     if (retries >= maxRetryCountToEndAtRoughlyTimeoutTime)
                     {
-                        throw new Error(`Action: ${actionId} Failed to acquire lock ${this.lockPath} after ${retries} retries out of ${maxRetryCountToEndAtRoughlyTimeoutTime} total available attempts. Last error: ${errorCode}.\n${this.supplementalErrorInfo}`);
+                        const diagnostic = await this.crossUidDiagnostic(actionId);
+                        throw new Error(`Action: ${actionId} Failed to acquire lock ${this.lockPath} after ${retries} retries out of ${maxRetryCountToEndAtRoughlyTimeoutTime} total available attempts. Last error: ${errorCode}.${diagnostic}\n${this.supplementalErrorInfo}`);
                     }
 
                     if (await this.isLockStale(actionId))
@@ -327,6 +328,53 @@ export class NodeIPCMutex
     {
         // Could implement exponential back-off here if we wanted to.
         return new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+
+    /**
+     * When we give up acquiring the lock, add a diagnostic hint if the socket on disk is owned
+     * by a different uid than the current process. This is a common silent cause of permanent
+     * lock contention: a process that ran under `sudo` created a root-owned socket, crashed
+     * without unlinking it, and now non-elevated processes cannot connect (EACCES) nor unlink
+     * (EPERM on sticky-bit /tmp). `fs.stat` works cross-uid because it only requires read/search
+     * on the parent directory, not on the socket file itself. Unix only; Windows named pipes
+     * do not have POSIX uid ownership.
+     *
+     * This is a best-effort diagnostic: any failure here (missing socket, unreadable parent dir,
+     * unexpected platform, stat ENOTSUP on exotic filesystems) must not mask the original
+     * acquisition failure. Errors are logged at debug level and swallowed.
+     */
+    private async crossUidDiagnostic(actionId: string): Promise<string>
+    {
+        if (os.platform() === 'win32')
+        {
+            // Named pipes on Windows have no POSIX uid ownership.
+            return '';
+        }
+
+        const selfUid = process.getuid!();
+
+        try
+        {
+            const st = await stat(this.lockPath);
+            if (st.uid !== selfUid)
+            {
+                return ` Socket at ${this.lockPath} is owned by uid=${st.uid}, current uid=${selfUid}. A previous process (likely run under sudo) may have left a stale socket that cannot be cleaned up automatically. Remove it manually with: sudo rm ${this.lockPath}`;
+            }
+        }
+        catch (err: any)
+        {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            const code = err?.code ?? 'UNKNOWN';
+            // ENOENT: socket was unlinked between acquisition failure and diagnostic; benign.
+            // EACCES / EPERM: parent directory denies search; we can't classify, fall through silently.
+            // Anything else: still not worth failing over; log so it's visible if someone investigates.
+            if (code !== 'ENOENT')
+            {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                this.logger.log(`Action: ${actionId} crossUidDiagnostic stat failed: ${code} (${String(err?.message ?? '')})`);
+            }
+        }
+        return '';
     }
 }
 

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -358,7 +358,7 @@ export class NodeIPCMutex
             const st = await stat(this.lockPath);
             if (st.uid !== selfUid)
             {
-                return ` Socket at ${this.lockPath} is owned by uid=${st.uid}, current uid=${selfUid}. A previous process (likely run under sudo) may have left a stale socket that cannot be cleaned up automatically. Remove it manually with: sudo rm ${this.lockPath}`;
+                return ` Socket at ${this.lockPath} is owned by uid=${st.uid}, current uid=${selfUid}. Another process running under a different user may still be holding this lock, or a previous process (likely run under sudo) may have left a stale socket that cannot be cleaned up automatically. If no other processes are using this lock and you believe the socket is stale, you may need to remove it manually with elevated permissions, for example: sudo rm ${this.lockPath}`;
             }
         }
         catch (err: any)

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -112,8 +112,14 @@ export class NodeIPCMutex
             }
             catch (error: any)
             {
+                // These are the retryable error codes from server.listen():
+                // - EADDRINUSE: Another process or async task in this process is currently listening on the socket path. The lock is held.
+                // - EEXIST: The socket file already exists on disk (stale leftover from a dead process on some OS/filesystem combos).
+                // - EACCES: Permission denied creating/binding the socket — e.g. /run/user/<uid>/ permissions changed, or stale socket owned by another session.
+                // - EPERM: Operation not permitted — similar to EACCES but from kernel-level policy (SELinux, AppArmor, or elevated-permission mismatch).
+                //   VS Code's main process also handles EPERM alongside EACCES: https://github.com/microsoft/vscode/blob/main/src/vs/code/electron-main/main.ts
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                if (error?.code === 'EADDRINUSE' || error?.code === 'EEXIST' || error?.code === 'EACCESS')
+                if (error?.code === 'EADDRINUSE' || error?.code === 'EEXIST' || error?.code === 'EACCES' || error?.code === 'EPERM')
                 {
                     if (retries >= maxRetryCountToEndAtRoughlyTimeoutTime)
                     {
@@ -227,9 +233,9 @@ export class NodeIPCMutex
         catch (error: any) // Handle synchronous errors from the socket connection.
         {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            if (error?.code === 'ECONNREFUSED') // The process is dead - it may have been pkilled and did not drop the file handle.
+            if (error?.code === 'ECONNREFUSED' || error?.code === 'ECONNRESET') // The process is dead - it may have been pkilled and did not drop the file handle, or died mid-handshake.
             {
-                this.logger.log(`Action: ${actionId} found Lock is stale, as ECONNREFUSED detected.`);
+                this.logger.log(`Action: ${actionId} found Lock is stale, as ${error?.code} detected.`);
                 return true; // We can acquire the lock, and delete the file handle.
             }
 
@@ -237,7 +243,7 @@ export class NodeIPCMutex
             // - ENOENT: The file descriptor doesn't exist, which means the process holding it has died.
             // -> Technically, this means it's stale, but the only action to do if it's stale is delete it, but it already is deleted.
 
-            // - EPERM / EACCESS: The file descriptor exists, but we don't have permission to access it. This is expected if the process holding it is still alive and running it under elevated permissions (chmod failed)
+            // - EPERM / EACCES: The file descriptor exists, but we don't have permission to access it. This is expected if the process holding it is still alive and running it under elevated permissions (chmod failed)
             // - EPIPE: This might be possible, but I haven't seen it happen yet.
             this.logger.log(`Action: ${actionId} Unable to acquire lock: ${JSON.stringify(error ?? '')}.`);
             return false; // We don't know what happened, but we can't acquire the lock.

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -134,9 +134,10 @@ export class NodeIPCMutex
                 //   stale XDG_RUNTIME_DIR after a uid mismatch / session teardown, or parent directory not writable
                 // - EPERM: Operation not permitted — similar to EACCES but from kernel-level policy (SELinux, AppArmor, or elevated-permission mismatch).
                 //   VS Code's main process also handles EPERM alongside EACCES: https://github.com/microsoft/vscode/blob/main/src/vs/code/electron-main/main.ts
+                // - EROFS: Read-only file system — e.g. macOS Signed System Volume where "/" is mounted read-only.
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 const errorCode = error?.code;
-                if (errorCode === 'EADDRINUSE' || errorCode === 'EEXIST' || errorCode === 'EACCES' || errorCode === 'EPERM')
+                if (errorCode === 'EADDRINUSE' || errorCode === 'EEXIST' || errorCode === 'EACCES' || errorCode === 'EPERM' || errorCode === 'EROFS')
                 {
                     // Log the errno on every retry. This is essential for diagnosing field issues
                     // where the raw libuv trace gives no actionable signal. Keep the payload small

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -55,8 +55,8 @@ export class NodeIPCMutex
      * @remarks Resolves the directory to hold the IPC handle in. Extracted as a protected method so tests
      * can override it to use a directory they fully control (e.g. for simulating permission errors).
      *
-     * On Unix, A file descriptor in /temp/ is a good option to hold this sock.
-     * In Linux, The user or system may set XDG_RUNTIME_DIR to set our applications temporary directory, so use this instead of /temp/
+     * On Unix, A file descriptor in /tmp/ is a good option to hold this sock.
+     * In Linux, The user or system may set XDG_RUNTIME_DIR to set our applications temporary directory, so use this instead of /tmp/
      * On Unix, Access to /tmp/ may be restricted, but all processes must use the same directory, so we can't condition to use another dir based on the permissions for it.
      *
      * CAVEAT: XDG_RUNTIME_DIR (typically /run/user/<uid>/) is set by pam_systemd during login sessions.

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -358,7 +358,9 @@ export class NodeIPCMutex
             const st = await stat(this.lockPath);
             if (st.uid !== selfUid)
             {
-                return ` Socket at ${this.lockPath} is owned by uid=${st.uid}, current uid=${selfUid}. Another process running under a different user may still be holding this lock, or a previous process (likely run under sudo) may have left a stale socket that cannot be cleaned up automatically. If no other processes are using this lock and you believe the socket is stale, you may need to remove it manually with elevated permissions, for example: sudo rm ${this.lockPath}`;
+                return ` Socket at ${this.lockPath} is owned by uid=${st.uid}, current uid=${selfUid}.
+Another process running under a different user may still be holding this lock, or a previous process (likely run under sudo) may have left a stale socket that cannot be cleaned up automatically.
+If no other processes are using this lock and you believe the socket is stale, you may need to remove it manually with elevated permissions, for example: sudo rm ${this.lockPath}`;
             }
         }
         catch (err: any)

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -242,6 +242,7 @@ export class NodeIPCMutex
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             if (error?.code === 'ECONNREFUSED' || error?.code === 'ECONNRESET') // The process is dead - it may have been pkilled and did not drop the file handle, or died mid-handshake.
             {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 this.logger.log(`Action: ${actionId} found Lock is stale, as ${error?.code} detected.`);
                 return true; // We can acquire the lock, and delete the file handle.
             }

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -59,6 +59,13 @@ export class NodeIPCMutex
         // In Linux, The user or system may set XDG_RUNTIME_DIR to set our applications temporary directory, so use this instead of /temp/
         // On Unix, Access to /tmp/ may be restricted, but all processes must use the same directory, so we can't condition to use another dir based on the permissions for it.
 
+        // CAVEAT: XDG_RUNTIME_DIR (typically /run/user/<uid>/) is set by pam_systemd during login sessions.
+        // It is NOT set when SSH is configured without PAM (UsePAM no), when using su/sudo -u, inside containers
+        // without systemd, in cron jobs, or in CI/CD environments. If one VS Code process has XDG_RUNTIME_DIR
+        // set and another doesn't, they will create sockets in different directories (/run/user/<uid>/ vs /tmp/),
+        // silently breaking cross-process mutex isolation. VS Code's own IPC code has the same limitation:
+        // https://github.com/microsoft/vscode/blob/main/src/vs/base/parts/ipc/node/ipc.net.ts
+
         // On Windows, '\\\\.\\pipe\\` is a Special File System to get a Named Pipe (File Descriptors won't work)
         // https://nodejs.org/docs/latest/api/net.html#ipc-support:~:text=On%20Windows%2C%20the,owning%20process%20exits.
 

--- a/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/NodeIPCMutex.ts
@@ -34,7 +34,7 @@ export class INodeIPCMutexLogger
  */
 export class NodeIPCMutex
 {
-    private readonly lockPath: string;
+    protected readonly lockPath: string;
     private readonly supplementalErrorInfo: string;
     private server?: Server;
     private hasCleanedUpBefore = false;
@@ -51,26 +51,34 @@ export class NodeIPCMutex
         this.lockPath = this.getIPCHandlePath(lockId);
     }
 
+    /**
+     * @remarks Resolves the directory to hold the IPC handle in. Extracted as a protected method so tests
+     * can override it to use a directory they fully control (e.g. for simulating permission errors).
+     *
+     * On Unix, A file descriptor in /temp/ is a good option to hold this sock.
+     * In Linux, The user or system may set XDG_RUNTIME_DIR to set our applications temporary directory, so use this instead of /temp/
+     * On Unix, Access to /tmp/ may be restricted, but all processes must use the same directory, so we can't condition to use another dir based on the permissions for it.
+     *
+     * CAVEAT: XDG_RUNTIME_DIR (typically /run/user/<uid>/) is set by pam_systemd during login sessions.
+     * It is NOT set when SSH is configured without PAM (UsePAM no), when using su/sudo -u, inside containers
+     * without systemd, in cron jobs, or in CI/CD environments. If one VS Code process has XDG_RUNTIME_DIR
+     * set and another doesn't, they will create sockets in different directories (/run/user/<uid>/ vs /tmp/),
+     * silently breaking cross-process mutex isolation. VS Code's own IPC code has the same limitation:
+     * https://github.com/microsoft/vscode/blob/main/src/vs/base/parts/ipc/node/ipc.net.ts
+     *
+     * On Windows, '\\\\.\\pipe\\` is a Special File System to get a Named Pipe (File Descriptors won't work)
+     * https://nodejs.org/docs/latest/api/net.html#ipc-support:~:text=On%20Windows%2C%20the,owning%20process%20exits.
+     */
+    protected getIPCDirectory(): string
+    {
+        return os.platform() === 'win32' ? `\\\\.\\pipe\\` :
+            os.platform() === 'linux' && process.env.XDG_RUNTIME_DIR ? process.env.XDG_RUNTIME_DIR as string : os.tmpdir();
+    }
+
     private getIPCHandlePath(id: string): string
     {
         const lengthLimit = os.platform() === 'win32' ? 256 : 104; // Mac 10.9 and FreeBSD have their own length limit.
-
-        // On Unix, A file descriptor in /temp/ is a good option to hold this sock.
-        // In Linux, The user or system may set XDG_RUNTIME_DIR to set our applications temporary directory, so use this instead of /temp/
-        // On Unix, Access to /tmp/ may be restricted, but all processes must use the same directory, so we can't condition to use another dir based on the permissions for it.
-
-        // CAVEAT: XDG_RUNTIME_DIR (typically /run/user/<uid>/) is set by pam_systemd during login sessions.
-        // It is NOT set when SSH is configured without PAM (UsePAM no), when using su/sudo -u, inside containers
-        // without systemd, in cron jobs, or in CI/CD environments. If one VS Code process has XDG_RUNTIME_DIR
-        // set and another doesn't, they will create sockets in different directories (/run/user/<uid>/ vs /tmp/),
-        // silently breaking cross-process mutex isolation. VS Code's own IPC code has the same limitation:
-        // https://github.com/microsoft/vscode/blob/main/src/vs/base/parts/ipc/node/ipc.net.ts
-
-        // On Windows, '\\\\.\\pipe\\` is a Special File System to get a Named Pipe (File Descriptors won't work)
-        // https://nodejs.org/docs/latest/api/net.html#ipc-support:~:text=On%20Windows%2C%20the,owning%20process%20exits.
-
-        const ipcPathDir = os.platform() === 'win32' ? `\\\\.\\pipe\\` :
-            os.platform() === 'linux' && process.env.XDG_RUNTIME_DIR ? process.env.XDG_RUNTIME_DIR as string : os.tmpdir();
+        const ipcPathDir = this.getIPCDirectory();
 
         if (id.length > (lengthLimit - ipcPathDir.length))
         {
@@ -122,15 +130,23 @@ export class NodeIPCMutex
                 // These are the retryable error codes from server.listen():
                 // - EADDRINUSE: Another process or async task in this process is currently listening on the socket path. The lock is held.
                 // - EEXIST: The socket file already exists on disk (stale leftover from a dead process on some OS/filesystem combos).
-                // - EACCES: Permission denied creating/binding the socket — e.g. /run/user/<uid>/ permissions changed, or stale socket owned by another session.
+                // - EACCES: Permission denied creating/binding the socket — e.g. /run/user/<uid>/ permissions changed,
+                //   stale XDG_RUNTIME_DIR after a uid mismatch / session teardown, or parent directory not writable
                 // - EPERM: Operation not permitted — similar to EACCES but from kernel-level policy (SELinux, AppArmor, or elevated-permission mismatch).
                 //   VS Code's main process also handles EPERM alongside EACCES: https://github.com/microsoft/vscode/blob/main/src/vs/code/electron-main/main.ts
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                if (error?.code === 'EADDRINUSE' || error?.code === 'EEXIST' || error?.code === 'EACCES' || error?.code === 'EPERM')
+                const errorCode = error?.code;
+                if (errorCode === 'EADDRINUSE' || errorCode === 'EEXIST' || errorCode === 'EACCES' || errorCode === 'EPERM')
                 {
+                    // Log the errno on every retry. This is essential for diagnosing field issues
+                    // where the raw libuv trace gives no actionable signal. Keep the payload small
+                    // to avoid flooding logs.
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                    this.logger.log(`Action: ${actionId} Lock acquire retryable error: ${errorCode} (${String(error?.message ?? '')}) retry ${retries + 1}/${maxRetryCountToEndAtRoughlyTimeoutTime}`);
+
                     if (retries >= maxRetryCountToEndAtRoughlyTimeoutTime)
                     {
-                        throw new Error(`Action: ${actionId} Failed to acquire lock ${this.lockPath} after ${retries} retries out of ${maxRetryCountToEndAtRoughlyTimeoutTime} total available attempts.\n${this.supplementalErrorInfo}`);
+                        throw new Error(`Action: ${actionId} Failed to acquire lock ${this.lockPath} after ${retries} retries out of ${maxRetryCountToEndAtRoughlyTimeoutTime} total available attempts. Last error: ${errorCode}.\n${this.supplementalErrorInfo}`);
                     }
 
                     if (await this.isLockStale(actionId))
@@ -249,10 +265,9 @@ export class NodeIPCMutex
 
             // Expected errors:
             // - ENOENT: The file descriptor doesn't exist, which means the process holding it has died.
-            // -> Technically, this means it's stale, but the only action to do if it's stale is delete it, but it already is deleted.
+            //   Technically stale, but the only action would be to delete it, and it already is deleted.
+            // - EACCES / EPERM: We can't access the socket due- might be a OS policy like SELinux but haven't tested, might be changing user accounts
 
-            // - EPERM / EACCES: The file descriptor exists, but we don't have permission to access it. This is expected if the process holding it is still alive and running it under elevated permissions (chmod failed)
-            // - EPIPE: This might be possible, but I haven't seen it happen yet.
             this.logger.log(`Action: ${actionId} Unable to acquire lock: ${JSON.stringify(error ?? '')}.`);
             return false; // We don't know what happened, but we can't acquire the lock.
         }
@@ -264,7 +279,7 @@ export class NodeIPCMutex
         {
             const socket = createConnection(this.lockPath, () =>
             {
-                try
+              try
                 {
                     socket.removeListener('error', reject); // Ignore other errors : we were able to connect, that's all that matters.
                     this.logger.log(`Action: ${actionId} Connected to existing lock.`);

--- a/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/TypescriptUtilities.ts
@@ -90,6 +90,29 @@ Report this issue to our vscode-dotnet-runtime GitHub for help.`
     }
 }
 
+/**
+ * Acquires a mutex with manual release semantics, but respects VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX.
+ * When the env var is set, returns a no-op releaser immediately.
+ */
+export async function acquireWithManualReleaseOrDisabled(
+    eventStream: IEventStream,
+    lockId: string,
+    actionId: string,
+    retryDelayMs: number,
+    timeoutTimeMs: number,
+    lockFailureErrorMessage = ''
+): Promise<(() => void) | undefined>
+{
+    if (process.env.VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX === 'true')
+    {
+        return () => { /* no-op: mutex disabled */ };
+    }
+
+    const logger = new EventStreamNodeIPCMutexLoggerWrapper(eventStream, lockId);
+    const mutex = new NodeIPCMutex(lockId, logger, lockFailureErrorMessage);
+    return mutex.acquireWithManualRelease(actionId, retryDelayMs, timeoutTimeMs);
+}
+
 const possiblyUsefulUpperCaseEnvVars = new Set<string>([ // This is a local variable instead of in the function so it doesn't get recreated every time the function is called. I looked at compiled JS and didn't see it get optimized.
     'COMMONPROGRAMFILES',
     'COMMONPROGRAMFILES(x86)',
@@ -135,6 +158,9 @@ const possiblyUsefulUpperCaseEnvVars = new Set<string>([ // This is a local vari
     'DOTNET_ROLL_FORWARD',
     'DOTNET_ROLL_FORWARD_TO_PRERELEASE',
     'DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX',
+    'VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX',
+    'XDG_RUNTIME_DIR',
+    'TMPDIR',
 ]);
 
 /*

--- a/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
+++ b/vscode-dotnet-runtime-library/src/test/mocks/MockObjects.ts
@@ -35,11 +35,46 @@ import { ICommandExecutor } from '../../Utils/ICommandExecutor';
 import { IFileUtilities } from '../../Utils/IFileUtilities';
 import { IUtilityContext } from '../../Utils/IUtilityContext';
 import { IVSCodeEnvironment } from '../../Utils/IVSCodeEnvironment';
+import { INodeIPCMutexLogger, NodeIPCMutex } from '../../Utils/NodeIPCMutex';
 import { getDotnetExecutable } from '../../Utils/TypescriptUtilities';
 import { WebRequestWorkerSingleton } from '../../Utils/WebRequestWorkerSingleton';
 import { getMockUtilityContext } from '../unit/TestUtility';
 
 const testDefaultTimeoutTimeMs = 60000;
+
+/**
+ * A NodeIPCMutex that lets tests override the IPC directory so they can use a directory they fully
+ * own and can chmod freely (or an unwritable one like "/") to produce REAL bind/listen errors from
+ * the kernel — no synthetic error injection.
+ */
+export class MockNodeIPCMutex extends NodeIPCMutex
+{
+    private readonly customDirectory?: string;
+
+    constructor(lockId: string, logger: INodeIPCMutexLogger, customDirectory?: string, lockFailureErrorMessage?: string)
+    {
+        // Temporarily stash the directory so the parent ctor (which resolves the lock path before any
+        // subclass field is set) can read it via our overridden getIPCDirectory().
+        // We cannot set `this.customDirectory` before `super()` in TypeScript, so route through a module-level holder.
+        MockNodeIPCMutex.pendingDirectory = customDirectory;
+        super(lockId, logger, lockFailureErrorMessage);
+        this.customDirectory = customDirectory;
+        MockNodeIPCMutex.pendingDirectory = undefined;
+    }
+
+    private static pendingDirectory: string | undefined;
+
+    protected override getIPCDirectory(): string
+    {
+        const dir = this.customDirectory ?? MockNodeIPCMutex.pendingDirectory;
+        return dir ?? super.getIPCDirectory();
+    }
+
+    public getLockPathForTest(): string
+    {
+        return this.lockPath;
+    }
+}
 
 export class MockExtensionContext implements IExtensionState
 {

--- a/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
@@ -8,9 +8,10 @@ import * as fs from 'fs';
 import { createServer } from 'net';
 import * as os from 'os';
 import * as path from 'path';
+import { FileUtilities } from '../../Utils/FileUtilities';
 import { executeWithLock } from '../../Utils/TypescriptUtilities';
 import { MockEventStream, MockNodeIPCMutex } from '../mocks/MockObjects';
-import { acquiredText, INodeIPCTestLogger, printWithLock, releasedText, wait } from './TestUtility';
+import { acquiredText, getMockAcquisitionContext, getMockUtilityContext, INodeIPCTestLogger, printWithLock, releasedText, wait } from './TestUtility';
 const assert = chai.assert;
 
 const taskAText = 'Task A';
@@ -264,16 +265,14 @@ suite('NodeIPCMutex Unit Tests', function ()
         if (os.platform() === 'win32')
         {
             this.skip();
-            return;
         }
 
         const code = await probeListenErrnoOnUnwritableParent();
 
-        if (code === 'LISTEN_SUCCEEDED')
+        if (code === 'LISTEN_SUCCEEDED' && await new FileUtilities().isElevated(getMockAcquisitionContext('runtime', ''), getMockUtilityContext()))
         {
-            // Happens when running as root: DAC is bypassed. Skip rather than falsely pass downstream.
+            // Happens when running as root: Skip rather than falsely pass downstream.
             this.skip();
-            return;
         }
 
         assert.strictEqual(code, 'EACCES',
@@ -290,14 +289,6 @@ suite('NodeIPCMutex Unit Tests', function ()
         if (os.platform() === 'win32')
         {
             this.skip();
-            return;
-        }
-
-        const probeCode = await probeListenErrnoOnUnwritableParent();
-        if (probeCode !== 'EACCES')
-        {
-            this.skip();
-            return;
         }
 
         const logger = new INodeIPCTestLogger();
@@ -345,14 +336,6 @@ suite('NodeIPCMutex Unit Tests', function ()
         if (os.platform() === 'win32')
         {
             this.skip();
-            return;
-        }
-
-        const probeCode = await probeListenErrnoOnUnwritableParent();
-        if (probeCode !== 'EACCES')
-        {
-            this.skip();
-            return;
         }
 
         const logger = new INodeIPCTestLogger();
@@ -405,10 +388,14 @@ suite('NodeIPCMutex Unit Tests', function ()
      */
     test('It does not crash immediately when server.listen throws real EACCES (root directory primitive)', async function ()
     {
-        if (os.platform() === 'win32' || (typeof process.getuid === 'function' && process.getuid() === 0))
+        if (os.platform() === 'win32')
         {
             this.skip();
-            return;
+        }
+        // Skip when running elevated: root can bind in '/' and would leak a socket file there.
+        if (await new FileUtilities().isElevated(getMockAcquisitionContext('runtime', ''), getMockUtilityContext()))
+        {
+            this.skip();
         }
 
         const logger = new INodeIPCTestLogger();

--- a/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
@@ -425,4 +425,61 @@ suite('NodeIPCMutex Unit Tests', function ()
         assert(logger.logs.some(l => l.includes('EACCES') || l.includes('EROFS')),
             `${logger.logs}\nExpected EACCES or EROFS in the retry-loop logs.`);
     }).timeout(testTimeoutMs);
+
+    /**
+     * When acquisition times out and the socket on disk is owned by a different uid than the
+     * current process, the final error must include a diagnostic pointing at the cross-uid
+     * ownership mismatch (the real-world cause: a prior `sudo` run left a root-owned socket).
+     *
+     * We cannot chown a file to another uid without root, so we stub `process.getuid` to return
+     * a value different from the file's real owner. A held mutex (via acquireWithManualRelease)
+     * provides a live listening socket so connect succeeds -> isLockStale returns false ->
+     * the second mutex retries until timeout -> the final-error path runs the diagnostic.
+     */
+    test('Final error includes cross-uid diagnostic when socket is owned by a different uid', async function ()
+    {
+        if (os.platform() === 'win32')
+        {
+            this.skip();
+        }
+
+        const holderLogger = new INodeIPCTestLogger();
+        const contenderLogger = new INodeIPCTestLogger();
+        const myLock = `${randomLockPrefix}-XU`;
+        const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeipc-crossuid-'));
+
+        const holder = new MockNodeIPCMutex(myLock, holderLogger, testDir);
+        const contender = new MockNodeIPCMutex(myLock, contenderLogger, testDir);
+        const sockPath = holder.getLockPathForTest();
+
+        const realGetuid = process.getuid!.bind(process);
+        const realUid = realGetuid();
+
+        const release = await holder.acquireWithManualRelease(`${myLock}-holder`, 50, 2000);
+        process.getuid = () => realUid + 1; // pretend we are a different uid
+
+        let caught: any;
+        try
+        {
+            await contender.acquire(async () => 'done', 50, 300, `${myLock}-crossuid-test`);
+        }
+        catch (err)
+        {
+            caught = err;
+        }
+        finally
+        {
+            process.getuid = realGetuid;
+            release();
+            try { fs.unlinkSync(sockPath); } catch { /* best effort */ }
+            try { fs.rmdirSync(testDir); } catch { /* best effort */ }
+        }
+
+        assert(caught, `${contenderLogger.logs}\nThe mutex should have timed out.`);
+        const msg = String(caught?.message ?? '');
+        assert(msg.includes('Failed to acquire lock'), `Expected graceful timeout, got: ${msg}`);
+        assert(msg.includes(`owned by uid=${realUid}`), `Expected diagnostic to name the real owner uid. Got: ${msg}`);
+        assert(msg.includes(`current uid=${realUid + 1}`), `Expected diagnostic to name the current (stubbed) uid. Got: ${msg}`);
+        assert(msg.includes('sudo rm'), `Expected remediation hint. Got: ${msg}`);
+    }).timeout(testTimeoutMs);
 });

--- a/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
@@ -5,11 +5,11 @@
 import * as chai from 'chai';
 import { fork } from 'child_process';
 import * as fs from 'fs';
+import { createServer } from 'net';
 import * as os from 'os';
 import * as path from 'path';
 import { executeWithLock } from '../../Utils/TypescriptUtilities';
-import { NodeIPCMutex } from '../../Utils/NodeIPCMutex';
-import { MockEventStream } from '../mocks/MockObjects';
+import { MockEventStream, MockNodeIPCMutex } from '../mocks/MockObjects';
 import { acquiredText, INodeIPCTestLogger, printWithLock, releasedText, wait } from './TestUtility';
 const assert = chai.assert;
 
@@ -29,6 +29,58 @@ const randomLockPrefix = randomTextPrefixes.join(''); // If the code is wrong an
 suite('NodeIPCMutex Unit Tests', function ()
 {
     this.retries(0);
+
+    /**
+     * Probes the real-world scenario where the parent directory of the socket path is not writable
+     * by the current process: `server.listen()` throws EACCES because bind() cannot create the
+     * socket inode in an unwritable directory.
+     *
+     * This is what actually happens with `/run/user/<uid>/vscd-*.sock` when:
+     *   - The process's effective uid differs from the owner of /run/user/<uid>/ (sudo/su, container
+     *     uid mismatch, WSL uid mapping).
+     *   - The logind session was torn down but XDG_RUNTIME_DIR is still inherited.
+     *   - Any other cause of a stale/inaccessible XDG_RUNTIME_DIR.
+     *
+     * See the caveat documented in NodeIPCMutex.getIPCDirectory().
+     *
+     * Empirically verified on Linux (Node 20+): chmod 0500 on the parent dir produces `EACCES`
+     * from server.listen() (exactly matching observed user crash logs) and `ENOENT` from
+     * createConnection (since no file was ever created).
+     */
+    async function probeListenErrnoOnUnwritableParent(): Promise<string>
+    {
+        const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeipc-parent-'));
+        const probePath = path.join(probeDir, 'probe.sock');
+
+        // Read+execute but NOT write on the parent directory -> bind() can resolve the path but
+        // cannot create a new inode -> EACCES.
+        fs.chmodSync(probeDir, 0o500);
+
+        try
+        {
+            return await new Promise<string>((resolve) =>
+            {
+                const server = createServer();
+                server.once('error', (err: NodeJS.ErrnoException) => resolve(err.code ?? 'UNEXPECTED'));
+                server.once('listening', () =>
+                {
+                    server.close();
+                    resolve('LISTEN_SUCCEEDED');
+                });
+                try { server.listen(probePath); }
+                catch (err: any)
+                {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                    resolve((err?.code as string) ?? 'UNEXPECTED');
+                }
+            });
+        }
+        finally
+        {
+            try { fs.chmodSync(probeDir, 0o755); } catch { /* best effort */ }
+            try { fs.rmdirSync(probeDir); } catch { /* best effort */ }
+        }
+    }
 
     function firstComesBeforeSecond(arr: string[], first: string, second: string): boolean
     {
@@ -215,73 +267,15 @@ suite('NodeIPCMutex Unit Tests', function ()
     }).timeout(testTimeoutMs);
 
     /**
-     * EACCES recovery test (Linux/macOS only).
+     * Preflight: independently confirm that chmod 0500 on the parent directory causes
+     * `server.listen()` to emit EACCES. This reproduces the real-world failure mode observed in
+     * user crash logs, where `listen EACCES: permission denied /run/user/<uid>/vscd-*.sock` bubbled
+     * up from a logind-managed XDG_RUNTIME_DIR that the current process could no longer write to.
      *
-     * Creates a .sock file at the lock path, then chmod 000 it so that server.listen() will get EACCES.
-     * The mutex should detect this as a retryable error, call isLockStale → connectToExistingLock (which also gets EACCES),
-     * then call cleanupStaleLock (rm with force:true bypasses permissions on the directory level),
-     * and eventually acquire the lock successfully.
-     *
-     * This test verifies the fix for the EACCESS→EACCES typo bug that previously caused an unrecoverable crash.
+     * If this probe ever stops producing EACCES, the assumptions behind the listen-EACCES-handling
+     * test below are invalid.
      */
-    test('It recovers from EACCES on a stale socket file', async function ()
-    {
-        if (os.platform() === 'win32')
-        {
-            this.skip(); // Named pipes on Windows don't use file permissions; EACCES doesn't apply.
-            return;
-        }
-
-        const logger = new INodeIPCTestLogger();
-        const myLock = `${randomLockPrefix}-EA`;
-        const mutex = new NodeIPCMutex(myLock, logger);
-
-        // Derive the socket path the same way the mutex does internally
-        const ipcPathDir = os.platform() === 'linux' && process.env.XDG_RUNTIME_DIR
-            ? process.env.XDG_RUNTIME_DIR
-            : os.tmpdir();
-        const sockPath = path.join(ipcPathDir, `vscd-${myLock}.sock`);
-
-        // Create a file at the socket path and make it inaccessible
-        fs.writeFileSync(sockPath, '');
-        fs.chmodSync(sockPath, 0o000);
-
-        try
-        {
-            let acquired = false;
-
-            // The mutex should retry on EACCES, detect the stale lock, clean it up, and acquire.
-            // Give it enough time/retries to do so.
-            await mutex.acquire(async () =>
-            {
-                acquired = true;
-                return 'done';
-            }, 50, 5000 * delayFactor, `${myLock}-eacces-test`);
-
-            assert(acquired, `${logger.logs}\nThe mutex should have acquired the lock after recovering from EACCES.`);
-            assert(logger.logs.some(l => l.includes('Lock acquired')), `${logger.logs}\nExpected a 'Lock acquired' log entry.`);
-        }
-        finally
-        {
-            // Clean up: restore permissions and remove if it still exists
-            try { fs.chmodSync(sockPath, 0o644); } catch { /* may already be removed */ }
-            try { fs.unlinkSync(sockPath); } catch { /* may already be removed */ }
-        }
-    }).timeout(testTimeoutMs);
-
-    /**
-     * EPERM recovery test (Linux/macOS only).
-     *
-     * Similar to the EACCES test but simulates EPERM by creating a socket file in a directory
-     * where the sticky bit and ownership would cause EPERM on bind.
-     * In practice, on most Linux systems chmod 000 on a socket file produces EACCES from server.listen(),
-     * so this test verifies that even if the code path encounters EPERM (e.g. from SELinux/AppArmor),
-     * it is treated as retryable and recovers the same way.
-     *
-     * We test this by verifying the mutex handles a stale inaccessible socket the same way regardless
-     * of whether the specific errno is EACCES or EPERM — the recovery path is identical.
-     */
-    test('It recovers from EPERM-like conditions on a stale socket file', async function ()
+    test('Preflight: unwritable parent directory causes server.listen() to emit EACCES', async function ()
     {
         if (os.platform() === 'win32')
         {
@@ -289,39 +283,159 @@ suite('NodeIPCMutex Unit Tests', function ()
             return;
         }
 
+        const code = await probeListenErrnoOnUnwritableParent();
+
+        if (code === 'LISTEN_SUCCEEDED')
+        {
+            // Happens when running as root: DAC is bypassed. Skip rather than falsely pass downstream.
+            this.skip();
+            return;
+        }
+
+        assert.strictEqual(code, 'EACCES',
+            `Expected server.listen() on a path in an unwritable parent directory to emit EACCES, ` +
+            `but got '${code}'. This invalidates the unwritable-parent-directory test's assumption. ` +
+            `User-reported crash logs showed EACCES from this code path in real deployments.`);
+    }).timeout(testTimeoutMs);
+
+    /**
+     * Real-world unwritable-XDG_RUNTIME_DIR scenario test (Linux/macOS only).
+     *
+     * Reproduces the crash observed in user logs:
+     *   Error: listen EACCES: permission denied /run/user/<uid>/vscd-installedLk.sock
+     *
+     * Root cause in the field: `XDG_RUNTIME_DIR` points at a directory the current process cannot
+     * write to (stale session, uid mismatch from sudo/su, container/WSL uid mapping, logind
+     * teardown while VS Code process still running). bind() cannot create the socket inode there,
+     * so the kernel returns EACCES on `server.listen()`.
+     *
+     * Before the fix, the mutex rethrew immediately because of the EACCESS->EACCES typo in the
+     * retryable set, producing the ugly libuv stack trace visible in user logs.
+     *
+     * After the fix, the mutex catches EACCES, classifies it as retryable, tries isLockStale (which
+     * also fails due to the unwritable directory), and tries cleanupStaleLock (which also fails).
+     * Unable to recover — because the environment itself is broken — the mutex times out and throws
+     * a meaningful "Failed to acquire lock after N retries" error instead of the raw libuv trace.
+     *
+     * This test verifies the new behavior: no immediate crash with libuv internals; instead a
+     * graceful, retry-bounded timeout with an actionable error message.
+     */
+    test('It does not crash immediately when server.listen throws EACCES (unwritable parent directory)', async function ()
+    {
+        if (os.platform() === 'win32')
+        {
+            this.skip();
+            return;
+        }
+
+        const probeCode = await probeListenErrnoOnUnwritableParent();
+        if (probeCode !== 'EACCES')
+        {
+            this.skip();
+            return;
+        }
+
         const logger = new INodeIPCTestLogger();
-        const myLock = `${randomLockPrefix}-EP`;
-        const mutex = new NodeIPCMutex(myLock, logger);
+        const myLock = `${randomLockPrefix}-UP`;
 
-        const ipcPathDir = os.platform() === 'linux' && process.env.XDG_RUNTIME_DIR
-            ? process.env.XDG_RUNTIME_DIR
-            : os.tmpdir();
-        const sockPath = path.join(ipcPathDir, `vscd-${myLock}.sock`);
+        // Build a read+execute-only parent directory. bind() in server.listen() will fail with
+        // EACCES because it cannot create the socket inode.
+        const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeipc-unwritable-'));
+        fs.chmodSync(testDir, 0o500);
 
-        // Create a stale socket file and remove all permissions
-        fs.writeFileSync(sockPath, '');
-        fs.chmodSync(sockPath, 0o000);
+        const mutex = new MockNodeIPCMutex(myLock, logger, testDir);
 
+        let caught: any;
+        let acquired = false;
         try
         {
-            let acquired = false;
-
+            // Give it a short budget: we EXPECT the mutex to eventually time out gracefully, since
+            // the environment is genuinely broken — no real recovery is possible.
             await mutex.acquire(async () =>
             {
                 acquired = true;
                 return 'done';
-            }, 50, 5000 * delayFactor, `${myLock}-eperm-test`);
-
-            assert(acquired, `${logger.logs}\nThe mutex should have acquired the lock after recovering from permission errors.`);
-
-            // Verify the stale lock detection + cleanup path was exercised
-            assert(logger.logs.some(l => l.includes('Stale lock') || l.includes('Cleaning up stale lock')),
-                `${logger.logs}\nExpected stale lock detection/cleanup log entries.`);
+            }, 50, 500, `${myLock}-unwritable-parent-test`);
+        }
+        catch (err)
+        {
+            caught = err;
         }
         finally
         {
-            try { fs.chmodSync(sockPath, 0o644); } catch { /* may already be removed */ }
-            try { fs.unlinkSync(sockPath); } catch { /* may already be removed */ }
+            try { fs.chmodSync(testDir, 0o755); } catch { /* best effort */ }
+            try { fs.rmdirSync(testDir); } catch { /* best effort */ }
         }
+
+        assert(!acquired, `The mutex should NOT have acquired the lock in a permanently-broken environment.`);
+        assert(caught, `${logger.logs}\nThe mutex should have thrown a meaningful timeout error after retries were exhausted.`);
+        // The message must be the graceful timeout, NOT the raw libuv "listen EACCES" stack trace.
+        // This is the crux of the user-visible improvement.
+        const msg = String(caught?.message ?? '');
+        assert(msg.includes('Failed to acquire lock'),
+            `Expected the final error to be the graceful "Failed to acquire lock after N retries" ` +
+            `message, but got: ${msg}\nLogs: ${logger.logs}`);
+        assert(!msg.startsWith('listen EACCES'),
+            `The mutex should NOT surface the raw libuv "listen EACCES" error to callers — ` +
+            `that was the bug. Got: ${msg}`);
+        // The EACCES must have been observed in the logs during retries. This is the direct proof
+        // that the retryable-set fix engaged: pre-fix, EACCES was rethrown immediately and never
+        // reached the "Unable to acquire lock" logging path in isLockStale's fallthrough branch.
+        assert(logger.logs.some(l => l.includes('EACCES')),
+            `${logger.logs}\nExpected EACCES to appear in the retry-loop logs, proving the ` +
+            `retryable-code fix engaged. If this fails, the EACCES was swallowed silently or the ` +
+            `retry loop never ran.`);
+    }).timeout(testTimeoutMs);
+
+    /**
+     * Independent real-EACCES test using the filesystem root "/".
+     *
+     * On Unix, `server.listen('/vscd-probe.sock')` as a non-root user produces EACCES from bind()
+     * because the process lacks write permission on "/". No chmod setup, no mkdtemp, no cleanup is
+     * needed: the kernel rejects the bind before any inode is created.
+     *
+     * This is a second independent witness for the same code path as the unwritable-parent test.
+     * If one test regresses (e.g. a future refactor changes how chmod is handled, or Node changes
+     * errno mapping), the other remains as a check.
+     *
+     * Skipped under root (bind would succeed and leak a socket file in /) and on Windows.
+     */
+    test('It does not crash immediately when server.listen throws real EACCES (root directory primitive)', async function ()
+    {
+        if (os.platform() === 'win32' || (typeof process.getuid === 'function' && process.getuid() === 0))
+        {
+            this.skip();
+            return;
+        }
+
+        const logger = new INodeIPCTestLogger();
+        const myLock = `${randomLockPrefix}-RD`;
+        // Override the IPC directory to "/" — bind into "/" fails with EACCES for non-root.
+        const mutex = new MockNodeIPCMutex(myLock, logger, '/');
+
+        let caught: any;
+        let acquired = false;
+        try
+        {
+            await mutex.acquire(async () =>
+            {
+                acquired = true;
+                return 'done';
+            }, 50, 400, `${myLock}-rootdir-test`);
+        }
+        catch (err)
+        {
+            caught = err;
+        }
+
+        assert(!acquired, `The mutex should NOT acquire a lock when "/" is unwritable.`);
+        assert(caught, `${logger.logs}\nThe mutex should time out gracefully, not hang.`);
+        const msg = String(caught?.message ?? '');
+        assert(msg.includes('Failed to acquire lock'),
+            `Expected graceful "Failed to acquire lock" timeout, got: ${msg}\nLogs: ${logger.logs}`);
+        assert(!msg.startsWith('listen EACCES'),
+            `Raw libuv EACCES must not be surfaced to callers. Got: ${msg}`);
+        assert(logger.logs.some(l => l.includes('EACCES')),
+            `${logger.logs}\nExpected EACCES in the retry-loop logs.`);
     }).timeout(testTimeoutMs);
 });

--- a/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
@@ -382,9 +382,9 @@ suite('NodeIPCMutex Unit Tests', function ()
     }).timeout(testTimeoutMs);
 
     /**
-     * Independent real-EACCES witness using filesystem root "/". A non-root process cannot bind
-     * in "/", so `server.listen()` emits EACCES with no chmod/mkdtemp setup required.
-     * Skipped under root and on Windows.
+     * Independent real-EACCES/EROFS witness using filesystem root "/". A non-root process cannot
+     * bind in "/", so `server.listen()` emits EACCES or EROFS (macOS read-only system volume)
+     * with no chmod/mkdtemp setup required. Skipped under root and on Windows.
      */
     test('It does not crash immediately when server.listen throws real EACCES (root directory primitive)', async function ()
     {
@@ -421,8 +421,8 @@ suite('NodeIPCMutex Unit Tests', function ()
         assert(caught, `${logger.logs}\nThe mutex should time out, not hang.`);
         const msg = String(caught?.message ?? '');
         assert(msg.includes('Failed to acquire lock'), `Expected graceful timeout, got: ${msg}`);
-        assert(!msg.startsWith('listen EACCES'), `Raw libuv EACCES should not be surfaced. Got: ${msg}`);
-        assert(logger.logs.some(l => l.includes('EACCES')),
-            `${logger.logs}\nExpected EACCES in the retry-loop logs.`);
+        assert(!msg.startsWith('listen EACCES') && !msg.startsWith('listen EROFS'), `Raw libuv error should not be surfaced. Got: ${msg}`);
+        assert(logger.logs.some(l => l.includes('EACCES') || l.includes('EROFS')),
+            `${logger.logs}\nExpected EACCES or EROFS in the retry-loop logs.`);
     }).timeout(testTimeoutMs);
 });

--- a/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
@@ -4,8 +4,11 @@
 *--------------------------------------------------------------------------------------------*/
 import * as chai from 'chai';
 import { fork } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { executeWithLock } from '../../Utils/TypescriptUtilities';
+import { NodeIPCMutex } from '../../Utils/NodeIPCMutex';
 import { MockEventStream } from '../mocks/MockObjects';
 import { acquiredText, INodeIPCTestLogger, printWithLock, releasedText, wait } from './TestUtility';
 const assert = chai.assert;
@@ -208,6 +211,117 @@ suite('NodeIPCMutex Unit Tests', function ()
         finally
         {
             delete process.env.VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX;
+        }
+    }).timeout(testTimeoutMs);
+
+    /**
+     * EACCES recovery test (Linux/macOS only).
+     *
+     * Creates a .sock file at the lock path, then chmod 000 it so that server.listen() will get EACCES.
+     * The mutex should detect this as a retryable error, call isLockStale → connectToExistingLock (which also gets EACCES),
+     * then call cleanupStaleLock (rm with force:true bypasses permissions on the directory level),
+     * and eventually acquire the lock successfully.
+     *
+     * This test verifies the fix for the EACCESS→EACCES typo bug that previously caused an unrecoverable crash.
+     */
+    test('It recovers from EACCES on a stale socket file', async function ()
+    {
+        if (os.platform() === 'win32')
+        {
+            this.skip(); // Named pipes on Windows don't use file permissions; EACCES doesn't apply.
+            return;
+        }
+
+        const logger = new INodeIPCTestLogger();
+        const myLock = `${randomLockPrefix}-EA`;
+        const mutex = new NodeIPCMutex(myLock, logger);
+
+        // Derive the socket path the same way the mutex does internally
+        const ipcPathDir = os.platform() === 'linux' && process.env.XDG_RUNTIME_DIR
+            ? process.env.XDG_RUNTIME_DIR
+            : os.tmpdir();
+        const sockPath = path.join(ipcPathDir, `vscd-${myLock}.sock`);
+
+        // Create a file at the socket path and make it inaccessible
+        fs.writeFileSync(sockPath, '');
+        fs.chmodSync(sockPath, 0o000);
+
+        try
+        {
+            let acquired = false;
+
+            // The mutex should retry on EACCES, detect the stale lock, clean it up, and acquire.
+            // Give it enough time/retries to do so.
+            await mutex.acquire(async () =>
+            {
+                acquired = true;
+                return 'done';
+            }, 50, 5000 * delayFactor, `${myLock}-eacces-test`);
+
+            assert(acquired, `${logger.logs}\nThe mutex should have acquired the lock after recovering from EACCES.`);
+            assert(logger.logs.some(l => l.includes('Lock acquired')), `${logger.logs}\nExpected a 'Lock acquired' log entry.`);
+        }
+        finally
+        {
+            // Clean up: restore permissions and remove if it still exists
+            try { fs.chmodSync(sockPath, 0o644); } catch { /* may already be removed */ }
+            try { fs.unlinkSync(sockPath); } catch { /* may already be removed */ }
+        }
+    }).timeout(testTimeoutMs);
+
+    /**
+     * EPERM recovery test (Linux/macOS only).
+     *
+     * Similar to the EACCES test but simulates EPERM by creating a socket file in a directory
+     * where the sticky bit and ownership would cause EPERM on bind.
+     * In practice, on most Linux systems chmod 000 on a socket file produces EACCES from server.listen(),
+     * so this test verifies that even if the code path encounters EPERM (e.g. from SELinux/AppArmor),
+     * it is treated as retryable and recovers the same way.
+     *
+     * We test this by verifying the mutex handles a stale inaccessible socket the same way regardless
+     * of whether the specific errno is EACCES or EPERM — the recovery path is identical.
+     */
+    test('It recovers from EPERM-like conditions on a stale socket file', async function ()
+    {
+        if (os.platform() === 'win32')
+        {
+            this.skip();
+            return;
+        }
+
+        const logger = new INodeIPCTestLogger();
+        const myLock = `${randomLockPrefix}-EP`;
+        const mutex = new NodeIPCMutex(myLock, logger);
+
+        const ipcPathDir = os.platform() === 'linux' && process.env.XDG_RUNTIME_DIR
+            ? process.env.XDG_RUNTIME_DIR
+            : os.tmpdir();
+        const sockPath = path.join(ipcPathDir, `vscd-${myLock}.sock`);
+
+        // Create a stale socket file and remove all permissions
+        fs.writeFileSync(sockPath, '');
+        fs.chmodSync(sockPath, 0o000);
+
+        try
+        {
+            let acquired = false;
+
+            await mutex.acquire(async () =>
+            {
+                acquired = true;
+                return 'done';
+            }, 50, 5000 * delayFactor, `${myLock}-eperm-test`);
+
+            assert(acquired, `${logger.logs}\nThe mutex should have acquired the lock after recovering from permission errors.`);
+
+            // Verify the stale lock detection + cleanup path was exercised
+            assert(logger.logs.some(l => l.includes('Stale lock') || l.includes('Cleaning up stale lock')),
+                `${logger.logs}\nExpected stale lock detection/cleanup log entries.`);
+        }
+        finally
+        {
+            try { fs.chmodSync(sockPath, 0o644); } catch { /* may already be removed */ }
+            try { fs.unlinkSync(sockPath); } catch { /* may already be removed */ }
         }
     }).timeout(testTimeoutMs);
 });

--- a/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/NodeIPCMutex.test.ts
@@ -31,21 +31,9 @@ suite('NodeIPCMutex Unit Tests', function ()
     this.retries(0);
 
     /**
-     * Probes the real-world scenario where the parent directory of the socket path is not writable
-     * by the current process: `server.listen()` throws EACCES because bind() cannot create the
-     * socket inode in an unwritable directory.
-     *
-     * This is what actually happens with `/run/user/<uid>/vscd-*.sock` when:
-     *   - The process's effective uid differs from the owner of /run/user/<uid>/ (sudo/su, container
-     *     uid mismatch, WSL uid mapping).
-     *   - The logind session was torn down but XDG_RUNTIME_DIR is still inherited.
-     *   - Any other cause of a stale/inaccessible XDG_RUNTIME_DIR.
-     *
-     * See the caveat documented in NodeIPCMutex.getIPCDirectory().
-     *
-     * Empirically verified on Linux (Node 20+): chmod 0500 on the parent dir produces `EACCES`
-     * from server.listen() (exactly matching observed user crash logs) and `ENOENT` from
-     * createConnection (since no file was ever created).
+     * Probes the real kernel behavior of server.listen() when the parent directory of the socket
+     * path is not writable: bind() cannot create the socket inode, so the kernel emits EACCES.
+     * Returns the errno code string, or 'LISTEN_SUCCEEDED' if listen somehow succeeded (e.g. root).
      */
     async function probeListenErrnoOnUnwritableParent(): Promise<string>
     {
@@ -268,12 +256,8 @@ suite('NodeIPCMutex Unit Tests', function ()
 
     /**
      * Preflight: independently confirm that chmod 0500 on the parent directory causes
-     * `server.listen()` to emit EACCES. This reproduces the real-world failure mode observed in
-     * user crash logs, where `listen EACCES: permission denied /run/user/<uid>/vscd-*.sock` bubbled
-     * up from a logind-managed XDG_RUNTIME_DIR that the current process could no longer write to.
-     *
-     * If this probe ever stops producing EACCES, the assumptions behind the listen-EACCES-handling
-     * test below are invalid.
+     * `server.listen()` to emit EACCES. If this probe stops producing EACCES, the assumptions
+     * behind the listen-EACCES tests below are invalid.
      */
     test('Preflight: unwritable parent directory causes server.listen() to emit EACCES', async function ()
     {
@@ -293,32 +277,13 @@ suite('NodeIPCMutex Unit Tests', function ()
         }
 
         assert.strictEqual(code, 'EACCES',
-            `Expected server.listen() on a path in an unwritable parent directory to emit EACCES, ` +
-            `but got '${code}'. This invalidates the unwritable-parent-directory test's assumption. ` +
-            `User-reported crash logs showed EACCES from this code path in real deployments.`);
+            `Expected EACCES from server.listen() on a path in an unwritable parent directory, but got '${code}'.`);
     }).timeout(testTimeoutMs);
 
     /**
-     * Real-world unwritable-XDG_RUNTIME_DIR scenario test (Linux/macOS only).
-     *
-     * Reproduces the crash observed in user logs:
-     *   Error: listen EACCES: permission denied /run/user/<uid>/vscd-installedLk.sock
-     *
-     * Root cause in the field: `XDG_RUNTIME_DIR` points at a directory the current process cannot
-     * write to (stale session, uid mismatch from sudo/su, container/WSL uid mapping, logind
-     * teardown while VS Code process still running). bind() cannot create the socket inode there,
-     * so the kernel returns EACCES on `server.listen()`.
-     *
-     * Before the fix, the mutex rethrew immediately because of the EACCESS->EACCES typo in the
-     * retryable set, producing the ugly libuv stack trace visible in user logs.
-     *
-     * After the fix, the mutex catches EACCES, classifies it as retryable, tries isLockStale (which
-     * also fails due to the unwritable directory), and tries cleanupStaleLock (which also fails).
-     * Unable to recover — because the environment itself is broken — the mutex times out and throws
-     * a meaningful "Failed to acquire lock after N retries" error instead of the raw libuv trace.
-     *
-     * This test verifies the new behavior: no immediate crash with libuv internals; instead a
-     * graceful, retry-bounded timeout with an actionable error message.
+     * When server.listen() raises EACCES because the parent directory is unwritable, the mutex
+     * must not surface the raw libuv error. It should classify EACCES as retryable and eventually
+     * time out with a graceful error.
      */
     test('It does not crash immediately when server.listen throws EACCES (unwritable parent directory)', async function ()
     {
@@ -337,9 +302,6 @@ suite('NodeIPCMutex Unit Tests', function ()
 
         const logger = new INodeIPCTestLogger();
         const myLock = `${randomLockPrefix}-UP`;
-
-        // Build a read+execute-only parent directory. bind() in server.listen() will fail with
-        // EACCES because it cannot create the socket inode.
         const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeipc-unwritable-'));
         fs.chmodSync(testDir, 0o500);
 
@@ -349,8 +311,6 @@ suite('NodeIPCMutex Unit Tests', function ()
         let acquired = false;
         try
         {
-            // Give it a short budget: we EXPECT the mutex to eventually time out gracefully, since
-            // the environment is genuinely broken — no real recovery is possible.
             await mutex.acquire(async () =>
             {
                 acquired = true;
@@ -367,38 +327,81 @@ suite('NodeIPCMutex Unit Tests', function ()
             try { fs.rmdirSync(testDir); } catch { /* best effort */ }
         }
 
-        assert(!acquired, `The mutex should NOT have acquired the lock in a permanently-broken environment.`);
-        assert(caught, `${logger.logs}\nThe mutex should have thrown a meaningful timeout error after retries were exhausted.`);
-        // The message must be the graceful timeout, NOT the raw libuv "listen EACCES" stack trace.
-        // This is the crux of the user-visible improvement.
+        assert(!acquired, `The mutex should not acquire the lock while the parent directory is unwritable.`);
+        assert(caught, `${logger.logs}\nThe mutex should have thrown a timeout error.`);
         const msg = String(caught?.message ?? '');
-        assert(msg.includes('Failed to acquire lock'),
-            `Expected the final error to be the graceful "Failed to acquire lock after N retries" ` +
-            `message, but got: ${msg}\nLogs: ${logger.logs}`);
-        assert(!msg.startsWith('listen EACCES'),
-            `The mutex should NOT surface the raw libuv "listen EACCES" error to callers — ` +
-            `that was the bug. Got: ${msg}`);
-        // The EACCES must have been observed in the logs during retries. This is the direct proof
-        // that the retryable-set fix engaged: pre-fix, EACCES was rethrown immediately and never
-        // reached the "Unable to acquire lock" logging path in isLockStale's fallthrough branch.
+        assert(msg.includes('Failed to acquire lock'), `Expected graceful timeout error, got: ${msg}`);
+        assert(!msg.startsWith('listen EACCES'), `Raw libuv EACCES should not be surfaced. Got: ${msg}`);
         assert(logger.logs.some(l => l.includes('EACCES')),
-            `${logger.logs}\nExpected EACCES to appear in the retry-loop logs, proving the ` +
-            `retryable-code fix engaged. If this fails, the EACCES was swallowed silently or the ` +
-            `retry loop never ran.`);
+            `${logger.logs}\nExpected EACCES in the retry-loop logs.`);
     }).timeout(testTimeoutMs);
 
     /**
-     * Independent real-EACCES test using the filesystem root "/".
-     *
-     * On Unix, `server.listen('/vscd-probe.sock')` as a non-root user produces EACCES from bind()
-     * because the process lacks write permission on "/". No chmod setup, no mkdtemp, no cleanup is
-     * needed: the kernel rejects the bind before any inode is created.
-     *
-     * This is a second independent witness for the same code path as the unwritable-parent test.
-     * If one test regresses (e.g. a future refactor changes how chmod is handled, or Node changes
-     * errno mapping), the other remains as a check.
-     *
-     * Skipped under root (bind would succeed and leak a socket file in /) and on Windows.
+     * Recovery test: start with an unwritable parent directory (real EACCES from listen), then
+     * mid-retry restore write permissions. The mutex must recover and acquire the lock.
+     */
+    test('It recovers when a previously unwritable parent directory becomes writable mid-retry', async function ()
+    {
+        if (os.platform() === 'win32')
+        {
+            this.skip();
+            return;
+        }
+
+        const probeCode = await probeListenErrnoOnUnwritableParent();
+        if (probeCode !== 'EACCES')
+        {
+            this.skip();
+            return;
+        }
+
+        const logger = new INodeIPCTestLogger();
+        const myLock = `${randomLockPrefix}-RC`;
+        const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeipc-recover-'));
+        fs.chmodSync(testDir, 0o500);
+
+        const mutex = new MockNodeIPCMutex(myLock, logger, testDir);
+        const sockPath = mutex.getLockPathForTest();
+
+        // Unbreak the environment after a few retries have definitely occurred.
+        const unbreakAfterMs = 300;
+        const restore = setTimeout(() =>
+        {
+            try { fs.chmodSync(testDir, 0o755); } catch { /* best effort */ }
+        }, unbreakAfterMs);
+
+        let acquired = false;
+        let caught: any;
+        try
+        {
+            await mutex.acquire(async () =>
+            {
+                acquired = true;
+                return 'done';
+            }, 50, 3000, `${myLock}-recover-test`);
+        }
+        catch (err)
+        {
+            caught = err;
+        }
+        finally
+        {
+            clearTimeout(restore);
+            try { fs.chmodSync(testDir, 0o755); } catch { /* best effort */ }
+            try { fs.unlinkSync(sockPath); } catch { /* best effort */ }
+            try { fs.rmdirSync(testDir); } catch { /* best effort */ }
+        }
+
+        assert(!caught, `${logger.logs}\nThe mutex should have recovered once the directory became writable. Error: ${String(caught?.message ?? '')}`);
+        assert(acquired, `${logger.logs}\nThe mutex should have acquired the lock after recovery.`);
+        assert(logger.logs.some(l => l.includes('EACCES')),
+            `${logger.logs}\nExpected EACCES in the retry-loop logs before recovery.`);
+    }).timeout(testTimeoutMs);
+
+    /**
+     * Independent real-EACCES witness using filesystem root "/". A non-root process cannot bind
+     * in "/", so `server.listen()` emits EACCES with no chmod/mkdtemp setup required.
+     * Skipped under root and on Windows.
      */
     test('It does not crash immediately when server.listen throws real EACCES (root directory primitive)', async function ()
     {
@@ -410,7 +413,6 @@ suite('NodeIPCMutex Unit Tests', function ()
 
         const logger = new INodeIPCTestLogger();
         const myLock = `${randomLockPrefix}-RD`;
-        // Override the IPC directory to "/" — bind into "/" fails with EACCES for non-root.
         const mutex = new MockNodeIPCMutex(myLock, logger, '/');
 
         let caught: any;
@@ -428,13 +430,11 @@ suite('NodeIPCMutex Unit Tests', function ()
             caught = err;
         }
 
-        assert(!acquired, `The mutex should NOT acquire a lock when "/" is unwritable.`);
-        assert(caught, `${logger.logs}\nThe mutex should time out gracefully, not hang.`);
+        assert(!acquired, `The mutex should not acquire a lock when "/" is unwritable.`);
+        assert(caught, `${logger.logs}\nThe mutex should time out, not hang.`);
         const msg = String(caught?.message ?? '');
-        assert(msg.includes('Failed to acquire lock'),
-            `Expected graceful "Failed to acquire lock" timeout, got: ${msg}\nLogs: ${logger.logs}`);
-        assert(!msg.startsWith('listen EACCES'),
-            `Raw libuv EACCES must not be surfaced to callers. Got: ${msg}`);
+        assert(msg.includes('Failed to acquire lock'), `Expected graceful timeout, got: ${msg}`);
+        assert(!msg.startsWith('listen EACCES'), `Raw libuv EACCES should not be surfaced. Got: ${msg}`);
         assert(logger.logs.some(l => l.includes('EACCES')),
             `${logger.logs}\nExpected EACCES in the retry-loop logs.`);
     }).timeout(testTimeoutMs);


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/2658

This fixes the EACCES typo (trying to acquire mutex on unix when another process holds the mutex and may have different permissions than the current process), adds handling for EPERM (similar case) and ECONNRESET (when pipe holding process dies in the middle of the 'handshake'), EROFS (trying to acquire mutex on root on Mac) as well as makes sure the mutex disabling environment variable is respected across all callers.

:star: I recommend hiding whitespace diff when reviewing if using GH. 

Adds remarks in the code about caveats with XDG_RUNTIME_DIR https://github.com/dotnet/vscode-dotnet-runtime/issues/2659 