### PR TITLE
Report cancelled SDK uninstalls accurately

### DIFF
--- a/vscode-dotnet-runtime-extension/src/ErrorMessageUtilities.ts
+++ b/vscode-dotnet-runtime-extension/src/ErrorMessageUtilities.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+
+/**
+ * Heuristically detects whether an error/installer message indicates the user cancelled or declined an
+ * elevation/credential prompt. Kept private to this module: the more robust check in CommandExecutor's
+ * parseVSCodeSudoExecError is preferred everywhere else, and this heuristic does not consider exit code 126.
+ * "did not grant permission" comes from @vscode/sudo-prompt when the UAC dialog is dismissed on Windows.
+ */
+function isUserCancellationMessage(message: string): boolean
+{
+    return /cancel|user rejected|user denied|password request|did not grant permission/i.test(message);
+}
+
+/**
+ * Builds the message thrown for a failed `dotnet.uninstall` so the LLM-tool layer (and other callers) can
+ * surface the real installer failure reason instead of a generic "another install may be in progress".
+ */
+export function buildUninstallFailureMessage(version: string, result: string): string
+{
+    const normalized = result.trim();
+    const asNumber = Number(normalized);
+    const detail = normalized !== '' && Number.isInteger(asNumber) ? `code ${normalized}` : normalized;
+    return isUserCancellationMessage(normalized)
+        ? `Uninstall of .NET ${version} was cancelled — the admin/elevation prompt was dismissed. Retry and accept the prompt to continue. (${detail})`
+        : `Uninstall of .NET ${version} did not succeed (${detail}). The uninstaller may be blocked by another install in progress, or require manual removal.`;
+}

--- a/vscode-dotnet-runtime-extension/src/ErrorMessageUtilities.ts
+++ b/vscode-dotnet-runtime-extension/src/ErrorMessageUtilities.ts
@@ -22,8 +22,9 @@ export function buildUninstallFailureMessage(version: string, result: string): s
 {
     const normalized = result.trim();
     const asNumber = Number(normalized);
-    const detail = normalized !== '' && Number.isInteger(asNumber) ? `code ${normalized}` : normalized;
+    const detailText = normalized !== '' && Number.isInteger(asNumber) ? `code ${normalized}` : normalized;
+    const detailSuffix = detailText ? ` (${detailText})` : '';
     return isUserCancellationMessage(normalized)
-        ? `Uninstall of .NET ${version} was cancelled. The elevation prompt was dismissed. Retry and accept the prompt to continue. (${detail})`
-        : `Uninstall of .NET ${version} did not succeed (${detail}). The uninstaller may be blocked by another install in progress or require manual removal.`;
+        ? `Uninstall of .NET ${version} was cancelled. A permission/elevation prompt was dismissed or rejected. Retry and accept the prompt to continue.${detailSuffix}`
+        : `Uninstall of .NET ${version} did not succeed${detailSuffix}. The uninstaller may be blocked by another install in progress or require manual removal.`;
 }

--- a/vscode-dotnet-runtime-extension/src/ErrorMessageUtilities.ts
+++ b/vscode-dotnet-runtime-extension/src/ErrorMessageUtilities.ts
@@ -24,6 +24,6 @@ export function buildUninstallFailureMessage(version: string, result: string): s
     const asNumber = Number(normalized);
     const detail = normalized !== '' && Number.isInteger(asNumber) ? `code ${normalized}` : normalized;
     return isUserCancellationMessage(normalized)
-        ? `Uninstall of .NET ${version} was cancelled — the admin/elevation prompt was dismissed. Retry and accept the prompt to continue. (${detail})`
+        ? `Uninstall of .NET ${version} was cancelled. The elevation prompt was dismissed. Retry and accept the prompt to continue. (${detail})`
         : `Uninstall of .NET ${version} did not succeed (${detail}). The uninstaller may be blocked by another install in progress, or require manual removal.`;
 }

--- a/vscode-dotnet-runtime-extension/src/ErrorMessageUtilities.ts
+++ b/vscode-dotnet-runtime-extension/src/ErrorMessageUtilities.ts
@@ -25,5 +25,5 @@ export function buildUninstallFailureMessage(version: string, result: string): s
     const detail = normalized !== '' && Number.isInteger(asNumber) ? `code ${normalized}` : normalized;
     return isUserCancellationMessage(normalized)
         ? `Uninstall of .NET ${version} was cancelled. The elevation prompt was dismissed. Retry and accept the prompt to continue. (${detail})`
-        : `Uninstall of .NET ${version} did not succeed (${detail}). The uninstaller may be blocked by another install in progress, or require manual removal.`;
+        : `Uninstall of .NET ${version} did not succeed (${detail}). The uninstaller may be blocked by another install in progress or require manual removal.`;
 }

--- a/vscode-dotnet-runtime-extension/src/ErrorMessageUtilities.ts
+++ b/vscode-dotnet-runtime-extension/src/ErrorMessageUtilities.ts
@@ -9,7 +9,7 @@
  * parseVSCodeSudoExecError is preferred everywhere else, and this heuristic does not consider exit code 126.
  * "did not grant permission" comes from @vscode/sudo-prompt when the UAC dialog is dismissed on Windows.
  */
-function isUserCancellationMessage(message: string): boolean
+export function isUserCancellationMessage(message: string): boolean
 {
     return /cancel|user rejected|user denied|password request|did not grant permission/i.test(message);
 }

--- a/vscode-dotnet-runtime-extension/src/LanguageModelTools.ts
+++ b/vscode-dotnet-runtime-extension/src/LanguageModelTools.ts
@@ -39,6 +39,7 @@ import
         SuppressedAcquisitionError
     } from 'vscode-dotnet-runtime-library';
 import { settingsInfoContent } from './SettingsInfoContent';
+import { isUserCancellationMessage } from './ErrorMessageUtilities';
 
 /**
  * Tool name constants matching those in package.json
@@ -98,17 +99,6 @@ function textResult(text: string): vscode.LanguageModelToolResult
     return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(text)]);
 }
 
-/**
- * Heuristically detects whether an error/installer message indicates the user cancelled or declined an
- * elevation/credential prompt, so install and uninstall can surface a consistent "retry and accept prompts" hint.
- * Kept private to this module: it does not consider exit code 126, so callers outside the LM tool path should
- * prefer the more robust check in CommandExecutor.parseVSCodeSudoExecError instead.
- * "did not grant permission" comes from @vscode/sudo-prompt when the UAC dialog is dismissed on Windows.
- */
-function isUserCancellationMessage(message: string): boolean
-{
-    return /cancel|user rejected|user denied|password request|did not grant permission/i.test(message);
-}
 
 /**
  * Builds the minimal IAcquisitionWorkerContext that the stateless VersionUtilities parsing helpers require.

--- a/vscode-dotnet-runtime-extension/src/LanguageModelTools.ts
+++ b/vscode-dotnet-runtime-extension/src/LanguageModelTools.ts
@@ -101,19 +101,13 @@ function textResult(text: string): vscode.LanguageModelToolResult
 /**
  * Heuristically detects whether an error/installer message indicates the user cancelled or declined an
  * elevation/credential prompt, so install and uninstall can surface a consistent "retry and accept prompts" hint.
+ * Kept private to this module: it does not consider exit code 126, so callers outside the LM tool path should
+ * prefer the more robust check in CommandExecutor.parseVSCodeSudoExecError instead.
  * "did not grant permission" comes from @vscode/sudo-prompt when the UAC dialog is dismissed on Windows.
  */
-export function isUserCancellationMessage(message: string): boolean
+function isUserCancellationMessage(message: string): boolean
 {
     return /cancel|user rejected|user denied|password request|did not grant permission/i.test(message);
-}
-
-export function buildUninstallFailureMessage(version: string, result: string): string
-{
-    const detail = /^-?\d+$/.test(result) ? `code ${result}` : result;
-    return isUserCancellationMessage(result)
-        ? `Uninstall of .NET ${version} was cancelled — the admin/elevation prompt was dismissed. Retry and accept the prompt to continue. (${detail})`
-        : `Uninstall of .NET ${version} did not succeed (${detail}). The uninstaller may be blocked by another install in progress, or require manual removal.`;
 }
 
 /**

--- a/vscode-dotnet-runtime-extension/src/LanguageModelTools.ts
+++ b/vscode-dotnet-runtime-extension/src/LanguageModelTools.ts
@@ -101,10 +101,11 @@ function textResult(text: string): vscode.LanguageModelToolResult
 /**
  * Heuristically detects whether an error/installer message indicates the user cancelled or declined an
  * elevation/credential prompt, so install and uninstall can surface a consistent "retry and accept prompts" hint.
+ * "did not grant permission" comes from @vscode/sudo-prompt when the UAC dialog is dismissed on Windows.
  */
-function isUserCancellationMessage(message: string): boolean
+export function isUserCancellationMessage(message: string): boolean
 {
-    return /cancel|user rejected|user denied|password request/i.test(message);
+    return /cancel|user rejected|user denied|password request|did not grant permission/i.test(message);
 }
 
 /**

--- a/vscode-dotnet-runtime-extension/src/LanguageModelTools.ts
+++ b/vscode-dotnet-runtime-extension/src/LanguageModelTools.ts
@@ -108,6 +108,14 @@ export function isUserCancellationMessage(message: string): boolean
     return /cancel|user rejected|user denied|password request|did not grant permission/i.test(message);
 }
 
+export function buildUninstallFailureMessage(version: string, result: string): string
+{
+    const detail = /^-?\d+$/.test(result) ? `code ${result}` : result;
+    return isUserCancellationMessage(result)
+        ? `Uninstall of .NET ${version} was cancelled — the admin/elevation prompt was dismissed. Retry and accept the prompt to continue. (${detail})`
+        : `Uninstall of .NET ${version} did not succeed (${detail}). The uninstaller may be blocked by another install in progress, or require manual removal.`;
+}
+
 /**
  * Builds the minimal IAcquisitionWorkerContext that the stateless VersionUtilities parsing helpers require.
  * Those helpers only read `acquisitionContext` (and only when constructing error events for malformed input,

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -92,7 +92,8 @@ import
 import { InstallTrackerSingleton } from 'vscode-dotnet-runtime-library/dist/Acquisition/InstallTrackerSingleton';
 import { EventStreamTaggingDecorator } from 'vscode-dotnet-runtime-library/dist/EventStream/EventStreamTaggingDecorator';
 import { dotnetCoreAcquisitionExtensionId } from './DotnetCoreAcquisitionId';
-import { buildUninstallFailureMessage, registerLanguageModelTools } from './LanguageModelTools';
+import { buildUninstallFailureMessage } from './ErrorMessageUtilities';
+import { registerLanguageModelTools } from './LanguageModelTools';
 import open = require('open');
 
 const packageJson = require('../package.json');

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -92,7 +92,7 @@ import
 import { InstallTrackerSingleton } from 'vscode-dotnet-runtime-library/dist/Acquisition/InstallTrackerSingleton';
 import { EventStreamTaggingDecorator } from 'vscode-dotnet-runtime-library/dist/EventStream/EventStreamTaggingDecorator';
 import { dotnetCoreAcquisitionExtensionId } from './DotnetCoreAcquisitionId';
-import { registerLanguageModelTools } from './LanguageModelTools';
+import { isUserCancellationMessage, registerLanguageModelTools } from './LanguageModelTools';
 import open = require('open');
 
 const packageJson = require('../package.json');
@@ -863,7 +863,16 @@ ${JSON.stringify(commandContext)}`));
                 // rethrown consistently when rethrowError is requested (e.g. for the LLM tools).
                 if (result !== '0' && result !== '')
                 {
-                    throw new Error(`Uninstall of .NET ${commandContext.version} did not succeed (code ${result}). The uninstaller may have been cancelled, blocked by another install in progress, or require manual removal.`);
+                    // uninstallGlobal may now return a human-readable failure reason from the elevation provider
+                    // (e.g. "User did not grant permission.") instead of only a numeric exit code. Avoid the
+                    // misleading "(code <reason>)" wrapping in that case, and tailor the message when the reason
+                    // indicates the user dismissed the admin/credential prompt.
+                    const looksNumeric = /^-?\d+$/.test(result);
+                    const detail = looksNumeric ? `code ${result}` : result;
+                    const message = isUserCancellationMessage(result)
+                        ? `Uninstall of .NET ${commandContext.version} was cancelled — the admin/elevation prompt was dismissed. Retry and accept the prompt to continue. (${detail})`
+                        : `Uninstall of .NET ${commandContext.version} did not succeed (${detail}). The uninstaller may be blocked by another install in progress, or require manual removal.`;
+                    throw new Error(message);
                 }
             }
         }, getIssueContext(existingPathConfigWorker)(commandContext?.errorConfiguration, 'uninstall'), commandContext?.requestingExtensionId, workerContext, commandContext?.rethrowError);

--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -92,7 +92,7 @@ import
 import { InstallTrackerSingleton } from 'vscode-dotnet-runtime-library/dist/Acquisition/InstallTrackerSingleton';
 import { EventStreamTaggingDecorator } from 'vscode-dotnet-runtime-library/dist/EventStream/EventStreamTaggingDecorator';
 import { dotnetCoreAcquisitionExtensionId } from './DotnetCoreAcquisitionId';
-import { isUserCancellationMessage, registerLanguageModelTools } from './LanguageModelTools';
+import { buildUninstallFailureMessage, registerLanguageModelTools } from './LanguageModelTools';
 import open = require('open');
 
 const packageJson = require('../package.json');
@@ -863,16 +863,7 @@ ${JSON.stringify(commandContext)}`));
                 // rethrown consistently when rethrowError is requested (e.g. for the LLM tools).
                 if (result !== '0' && result !== '')
                 {
-                    // uninstallGlobal may now return a human-readable failure reason from the elevation provider
-                    // (e.g. "User did not grant permission.") instead of only a numeric exit code. Avoid the
-                    // misleading "(code <reason>)" wrapping in that case, and tailor the message when the reason
-                    // indicates the user dismissed the admin/credential prompt.
-                    const looksNumeric = /^-?\d+$/.test(result);
-                    const detail = looksNumeric ? `code ${result}` : result;
-                    const message = isUserCancellationMessage(result)
-                        ? `Uninstall of .NET ${commandContext.version} was cancelled — the admin/elevation prompt was dismissed. Retry and accept the prompt to continue. (${detail})`
-                        : `Uninstall of .NET ${commandContext.version} did not succeed (${detail}). The uninstaller may be blocked by another install in progress, or require manual removal.`;
-                    throw new Error(message);
+                    throw new Error(buildUninstallFailureMessage(commandContext.version, result));
                 }
             }
         }, getIssueContext(existingPathConfigWorker)(commandContext?.errorConfiguration, 'uninstall'), commandContext?.requestingExtensionId, workerContext, commandContext?.rethrowError);

--- a/vscode-dotnet-runtime-extension/src/test/functional/LanguageModelTools.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/LanguageModelTools.test.ts
@@ -17,7 +17,7 @@ import
     MockWindowDisplayWorker
 } from 'vscode-dotnet-runtime-library';
 import * as extension from '../../extension';
-import { buildAvailableInstallsSearchContext, computeLinuxPatchMismatchNote, highestPatchInSameFeatureBand, isFullySpecifiedSdkVersion, resolveSdkVersionForInstall, ToolNames } from '../../LanguageModelTools';
+import { buildAvailableInstallsSearchContext, buildUninstallFailureMessage, computeLinuxPatchMismatchNote, highestPatchInSameFeatureBand, isFullySpecifiedSdkVersion, resolveSdkVersionForInstall, ToolNames } from '../../LanguageModelTools';
 
 const assert: any = chai.assert;
 const standardTimeoutTime = 30000;
@@ -876,6 +876,17 @@ suite('LanguageModelTools Tests', function ()
                 textContent.includes('output channel');
 
             assert.isTrue(hasActionableGuidance, 'Error messages should provide actionable guidance');
+        }).timeout(standardTimeoutTime);
+
+        test('Reports a dismissed elevation prompt as a cancelled uninstall', () =>
+        {
+            const message = buildUninstallFailureMessage('9.0.314', 'User did not grant permission.');
+
+            assert.include(message, 'was cancelled');
+            assert.include(message, 'Retry and accept the prompt');
+            assert.include(message, 'User did not grant permission.');
+            assert.notInclude(message, 'Another install may be in progress');
+            assert.notInclude(message, 'code User did not grant permission.');
         }).timeout(standardTimeoutTime);
     });
 

--- a/vscode-dotnet-runtime-extension/src/test/functional/LanguageModelTools.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/LanguageModelTools.test.ts
@@ -17,7 +17,8 @@ import
     MockWindowDisplayWorker
 } from 'vscode-dotnet-runtime-library';
 import * as extension from '../../extension';
-import { buildAvailableInstallsSearchContext, buildUninstallFailureMessage, computeLinuxPatchMismatchNote, highestPatchInSameFeatureBand, isFullySpecifiedSdkVersion, resolveSdkVersionForInstall, ToolNames } from '../../LanguageModelTools';
+import { buildUninstallFailureMessage } from '../../ErrorMessageUtilities';
+import { buildAvailableInstallsSearchContext, computeLinuxPatchMismatchNote, highestPatchInSameFeatureBand, isFullySpecifiedSdkVersion, resolveSdkVersionForInstall, ToolNames } from '../../LanguageModelTools';
 
 const assert: any = chai.assert;
 const standardTimeoutTime = 30000;

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -621,34 +621,37 @@ Other dependents remain.`));
 
                 try
                 {
-                    context.eventStream.post(new DotnetUninstallStarted(`Attempting to remove .NET ${install.installId}.`));
                     await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).untrackInstalledVersion(context, install, force);
 
                     // Note: it's ok not to check live dependents here (though we could) since this will require UAC and extensions do not depend on us to auto-manage admin installs
-                    if (force || await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).installHasNoRegisteredDependentsBesidesId(install, context.installDirectoryProvider, false, context.acquisitionContext.requestingExtensionId ?? ''))
+                    if (!force && !(await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).installHasNoRegisteredDependentsBesidesId(install, context.installDirectoryProvider, false, context.acquisitionContext.requestingExtensionId ?? '')))
                     {
-                        const installingVersion = await globalInstallerResolver.getFullySpecifiedVersion();
-                        const installer: IGlobalInstaller = os.platform() === 'linux' ?
-                            new LinuxGlobalInstaller(context, this.utilityContext, installingVersion) :
-                            new WinMacGlobalInstaller(context, this.utilityContext, installingVersion, await globalInstallerResolver.getInstallerUrl(), await globalInstallerResolver.getInstallerHash());
+                        context.eventStream.post(new DotnetUninstallSkipped(`Removed reference of ${JSON.stringify(install)}, but did not uninstall .NET ${install.installId}.
+Other dependents remain.`));
+                        return '0';
+                    }
 
-                        systemInstallPath = await installer.getExpectedGlobalSDKPath(installingVersion, install.architecture);
-                        uninstallResult = await installer.uninstallSDK(install);
-                        LocalMemoryCacheSingleton.getInstance().invalidateEntriesContaining('dotnet', context);
-                        await new CommandExecutor(context, this.utilityContext).endSudoProcessMaster(context.eventStream);
-                        if (uninstallResult === '0')
-                        {
-                            await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).reportSuccessfulUninstall(context, install, force);
-                            context.eventStream.post(new DotnetUninstallCompleted(`Uninstalled .NET ${install.installId}.`));
-                            return '0';
-                        }
+                    context.eventStream.post(new DotnetUninstallStarted(`Attempting to remove .NET ${install.installId}.`));
+                    const installingVersion = await globalInstallerResolver.getFullySpecifiedVersion();
+                    const installer: IGlobalInstaller = os.platform() === 'linux' ?
+                        new LinuxGlobalInstaller(context, this.utilityContext, installingVersion) :
+                        new WinMacGlobalInstaller(context, this.utilityContext, installingVersion, await globalInstallerResolver.getInstallerUrl(), await globalInstallerResolver.getInstallerHash());
+
+                    systemInstallPath = await installer.getExpectedGlobalSDKPath(installingVersion, install.architecture);
+                    uninstallResult = await installer.uninstallSDK(install);
+                    LocalMemoryCacheSingleton.getInstance().invalidateEntriesContaining('dotnet', context);
+                    await new CommandExecutor(context, this.utilityContext).endSudoProcessMaster(context.eventStream);
+                    if (uninstallResult === '0')
+                    {
+                        await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).reportSuccessfulUninstall(context, install, force);
+                        context.eventStream.post(new DotnetUninstallCompleted(`Uninstalled .NET ${install.installId}.`));
+                        return '0';
                     }
 
                     // When command execution is non-terminal, the status may contain a useful error from the elevation
                     // provider (for example, "User did not grant permission.") instead of only a numeric exit code.
                     const failureReason = uninstallResult.trim();
-                    const failureDetails = failureReason ? ` ${failureReason}` : '';
-                    context.eventStream.post(new DotnetUninstallFailed(`Failed to uninstall .NET ${install.installId}.${failureDetails}`));
+                    context.eventStream.post(new DotnetUninstallFailed(`Failed to uninstall .NET ${install.installId}.${failureReason ? ` ${failureReason}` : ''}`));
                     return failureReason || '1';
                 }
                 catch (error: any)

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -617,6 +617,7 @@ Other dependents remain.`));
                 }
 
                 let systemInstallPath = '';
+                let uninstallResult = '';
 
                 try
                 {
@@ -632,18 +633,23 @@ Other dependents remain.`));
                             new WinMacGlobalInstaller(context, this.utilityContext, installingVersion, await globalInstallerResolver.getInstallerUrl(), await globalInstallerResolver.getInstallerHash());
 
                         systemInstallPath = await installer.getExpectedGlobalSDKPath(installingVersion, install.architecture);
-                        const ok = await installer.uninstallSDK(install);
+                        uninstallResult = await installer.uninstallSDK(install);
                         LocalMemoryCacheSingleton.getInstance().invalidateEntriesContaining('dotnet', context);
                         await new CommandExecutor(context, this.utilityContext).endSudoProcessMaster(context.eventStream);
-                        if (ok === '0')
+                        if (uninstallResult === '0')
                         {
                             await InstallTrackerSingleton.getInstance(context.eventStream, context.extensionState).reportSuccessfulUninstall(context, install, force);
                             context.eventStream.post(new DotnetUninstallCompleted(`Uninstalled .NET ${install.installId}.`));
                             return '0';
                         }
                     }
-                    context.eventStream.post(new DotnetUninstallFailed(`Failed to uninstall .NET ${install.installId}. Another install may be in progress? Uninstall manually or delete the folder.`));
-                    return '117778'; // arbitrary error code to indicate uninstall failed without error.
+
+                    // When command execution is non-terminal, the status may contain a useful error from the elevation
+                    // provider (for example, "User did not grant permission.") instead of only a numeric exit code.
+                    const failureReason = uninstallResult.trim();
+                    const failureDetails = failureReason ? ` ${failureReason}` : '';
+                    context.eventStream.post(new DotnetUninstallFailed(`Failed to uninstall .NET ${install.installId}.${failureDetails}`));
+                    return failureReason || '1';
                 }
                 catch (error: any)
                 {

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -16,6 +16,7 @@ import
     DotnetInstallCancelledByUserError,
     DotnetNoInstallerResponseError,
     DotnetUnexpectedInstallerOSError,
+    DotnetUninstallCancelledByUserError,
     EventBasedError,
     EventCancellationError,
     MacInstallerBackupFailure,
@@ -185,6 +186,8 @@ This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/is
         const validInstallerStatusCodes = ['0', '1641', '3010']; // Ok, Pending Reboot, + Reboot Starting Now
         const noPermissionStatusCodes = ['1', '5', '1260', '2147942405'];
 
+        this.throwIfUserCancelled(installerResult, install, 'install');
+
         if (validInstallerStatusCodes.includes(installerResult))
         {
             if (this.cleanupInstallFiles)
@@ -192,14 +195,6 @@ This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/is
                 await this.file.wipeDirectory(path.dirname(installerFile), this.acquisitionContext.eventStream);
             }
             return '0'; // These statuses are a success, we don't want to throw.
-        }
-        else if (installerResult === '1602')
-        {
-            // Special code for when user cancels the install
-            const err = new DotnetInstallCancelledByUserError(new EventCancellationError('DotnetInstallCancelledByUserError',
-                `The install of .NET was cancelled by the user. Aborting.`), install);
-            this.acquisitionContext.eventStream.post(err);
-            throw err.error;
         }
         else if (noPermissionStatusCodes.includes(installerResult) && allowRetry)
         {
@@ -209,6 +204,26 @@ This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/is
         else
         {
             return installerResult;
+        }
+    }
+
+    /**
+     * Throws a user-cancellation error when the (un)installer reports exit code 1602 (user cancelled),
+     * e.g. by dismissing the elevation prompt. Install and uninstall raise distinct event types so
+     * telemetry can tell them apart; both extend DotnetInstallExpectedAbort, so all observers treat them
+     * identically and there is no behavioral difference from the previous install-only handling.
+     */
+    private throwIfUserCancelled(status: string, install: DotnetInstall, operation: 'install' | 'uninstall'): void
+    {
+        if (status === '1602')
+        {
+            const eventName = operation === 'install' ? 'DotnetInstallCancelledByUserError' : 'DotnetUninstallCancelledByUserError';
+            const cancellation = new EventCancellationError(eventName, `The ${operation} of .NET was cancelled by the user. Aborting.`);
+            const err = operation === 'install'
+                ? new DotnetInstallCancelledByUserError(cancellation, install)
+                : new DotnetUninstallCancelledByUserError(cancellation, install);
+            this.acquisitionContext.eventStream.post(err);
+            throw err.error;
         }
     }
 
@@ -230,6 +245,8 @@ This report should be made at https://github.com/dotnet/vscode-dotnet-runtime/is
             const uninstallArgs = ['/uninstall', '/passive', '/norestart'];
             const commandResult = await this.commandRunner.execute(CommandExecutor.makeCommand(command, uninstallArgs), { timeout: this.acquisitionContext.timeoutSeconds * 1000 }, false);
             this.handleTimeout(commandResult);
+
+            this.throwIfUserCancelled(commandResult.status, installation, 'uninstall');
 
             return commandResult.status;
         }

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -647,7 +647,10 @@ export class DotnetInstallCancelledByUserError extends DotnetInstallExpectedAbor
     public readonly eventName = 'DotnetInstallCancelledByUserError';
 }
 
-
+export class DotnetUninstallCancelledByUserError extends DotnetInstallExpectedAbort
+{
+    public readonly eventName = 'DotnetUninstallCancelledByUserError';
+}
 
 export class DotnetNonZeroInstallerExitCodeError extends DotnetAcquisitionError
 {

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -8,10 +8,14 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { DotnetCoreAcquisitionWorker } from '../../Acquisition/DotnetCoreAcquisitionWorker';
+import { GetDotnetInstallInfo } from '../../Acquisition/DotnetInstall';
 import { DotnetInstallMode } from '../../Acquisition/DotnetInstallMode';
+import { GlobalInstallerResolver } from '../../Acquisition/GlobalInstallerResolver';
 import { IAcquisitionInvoker } from '../../Acquisition/IAcquisitionInvoker';
 import { IAcquisitionWorkerContext } from '../../Acquisition/IAcquisitionWorkerContext';
 import { InstallRecord } from '../../Acquisition/InstallRecord';
+import { LinuxGlobalInstaller } from '../../Acquisition/LinuxGlobalInstaller';
+import { WinMacGlobalInstaller } from '../../Acquisition/WinMacGlobalInstaller';
 import { IEventStream } from '../../EventStream/EventStream';
 import
 {
@@ -22,6 +26,7 @@ import
     DotnetLockEvent,
     DotnetUninstallAllCompleted,
     DotnetUninstallAllStarted,
+    DotnetUninstallFailed,
     TestAcquireCalled
 } from '../../EventStream/EventStreamEvents';
 import { EventType } from '../../EventStream/EventType';
@@ -334,6 +339,60 @@ ${eventStream.events.map(event => event.eventName).join(', ')}`);
     test('Acquire SDK and UninstallAll', async () =>
     {
         await acquireAndUninstallAll('6.0', 'sdk', 'local');
+    }).timeout(expectedTimeoutTime);
+
+    test('Global uninstall failure surfaces the installer error', async () =>
+    {
+        const version = '9.0.314';
+        const failureReason = 'User did not grant permission.';
+        const eventStream = new MockEventStream();
+        const context = getMockAcquisitionContext('sdk', version, expectedTimeoutTime, eventStream);
+        context.acquisitionContext.installType = 'global';
+        context.acquisitionContext.requestingExtensionId = 'test.extension';
+        const worker = getMockAcquisitionWorker(context);
+        const install = GetDotnetInstallInfo(version, 'sdk', 'global', os.arch());
+        const resolver = {
+            getFullySpecifiedVersion: async () => version,
+            getInstallerUrl: async () => 'https://example.invalid/dotnet-sdk.exe',
+            getInstallerHash: async () => ''
+        } as GlobalInstallerResolver;
+        const originalLinuxGetExpectedGlobalSDKPath = LinuxGlobalInstaller.prototype.getExpectedGlobalSDKPath;
+        const originalLinuxUninstallSDK = LinuxGlobalInstaller.prototype.uninstallSDK;
+        const originalGetExpectedGlobalSDKPath = WinMacGlobalInstaller.prototype.getExpectedGlobalSDKPath;
+        const originalUninstallSDK = WinMacGlobalInstaller.prototype.uninstallSDK;
+        const originalDisableMutex = process.env.VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX;
+
+        process.env.VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX = 'true';
+        LinuxGlobalInstaller.prototype.getExpectedGlobalSDKPath = async () => `/usr/share/dotnet/sdk/${version}`;
+        LinuxGlobalInstaller.prototype.uninstallSDK = async () => failureReason;
+        WinMacGlobalInstaller.prototype.getExpectedGlobalSDKPath = async () => `C:\\Program Files\\dotnet\\sdk\\${version}`;
+        WinMacGlobalInstaller.prototype.uninstallSDK = async () => failureReason;
+
+        try
+        {
+            const result = await worker.uninstallGlobal(context, install, resolver, true);
+            const failureEvent = eventStream.events.find(event => event instanceof DotnetUninstallFailed) as DotnetUninstallFailed;
+
+            assert.equal(result, failureReason);
+            assert.exists(failureEvent);
+            assert.include(failureEvent.eventMessage, failureReason);
+            assert.notInclude(failureEvent.eventMessage, 'Another install may be in progress');
+        }
+        finally
+        {
+            LinuxGlobalInstaller.prototype.getExpectedGlobalSDKPath = originalLinuxGetExpectedGlobalSDKPath;
+            LinuxGlobalInstaller.prototype.uninstallSDK = originalLinuxUninstallSDK;
+            WinMacGlobalInstaller.prototype.getExpectedGlobalSDKPath = originalGetExpectedGlobalSDKPath;
+            WinMacGlobalInstaller.prototype.uninstallSDK = originalUninstallSDK;
+            if (originalDisableMutex === undefined)
+            {
+                delete process.env.VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX;
+            }
+            else
+            {
+                process.env.VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX = originalDisableMutex;
+            }
+        }
     }).timeout(expectedTimeoutTime);
 
     test('Correctly Removes Legacy (No-Architecture) Installs', async () =>

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetCoreAcquisitionWorker.test.ts
@@ -356,17 +356,23 @@ ${eventStream.events.map(event => event.eventName).join(', ')}`);
             getInstallerUrl: async () => 'https://example.invalid/dotnet-sdk.exe',
             getInstallerHash: async () => ''
         } as GlobalInstallerResolver;
-        const originalLinuxGetExpectedGlobalSDKPath = LinuxGlobalInstaller.prototype.getExpectedGlobalSDKPath;
-        const originalLinuxUninstallSDK = LinuxGlobalInstaller.prototype.uninstallSDK;
-        const originalGetExpectedGlobalSDKPath = WinMacGlobalInstaller.prototype.getExpectedGlobalSDKPath;
-        const originalUninstallSDK = WinMacGlobalInstaller.prototype.uninstallSDK;
-        const originalDisableMutex = process.env.VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX;
 
-        process.env.VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX = 'true';
-        LinuxGlobalInstaller.prototype.getExpectedGlobalSDKPath = async () => `/usr/share/dotnet/sdk/${version}`;
-        LinuxGlobalInstaller.prototype.uninstallSDK = async () => failureReason;
-        WinMacGlobalInstaller.prototype.getExpectedGlobalSDKPath = async () => `C:\\Program Files\\dotnet\\sdk\\${version}`;
-        WinMacGlobalInstaller.prototype.uninstallSDK = async () => failureReason;
+        const installerPrototypes: Array<{ prototype: { getExpectedGlobalSDKPath: any; uninstallSDK: any }; expectedSdkPath: string }> = [
+            { prototype: LinuxGlobalInstaller.prototype, expectedSdkPath: `/usr/share/dotnet/sdk/${version}` },
+            { prototype: WinMacGlobalInstaller.prototype, expectedSdkPath: `C:\\Program Files\\dotnet\\sdk\\${version}` }
+        ];
+        const restorers = installerPrototypes.map(({ prototype, expectedSdkPath }) =>
+        {
+            const originalGetPath = prototype.getExpectedGlobalSDKPath;
+            const originalUninstall = prototype.uninstallSDK;
+            prototype.getExpectedGlobalSDKPath = async () => expectedSdkPath;
+            prototype.uninstallSDK = async () => failureReason;
+            return () =>
+            {
+                prototype.getExpectedGlobalSDKPath = originalGetPath;
+                prototype.uninstallSDK = originalUninstall;
+            };
+        });
 
         try
         {
@@ -380,18 +386,7 @@ ${eventStream.events.map(event => event.eventName).join(', ')}`);
         }
         finally
         {
-            LinuxGlobalInstaller.prototype.getExpectedGlobalSDKPath = originalLinuxGetExpectedGlobalSDKPath;
-            LinuxGlobalInstaller.prototype.uninstallSDK = originalLinuxUninstallSDK;
-            WinMacGlobalInstaller.prototype.getExpectedGlobalSDKPath = originalGetExpectedGlobalSDKPath;
-            WinMacGlobalInstaller.prototype.uninstallSDK = originalUninstallSDK;
-            if (originalDisableMutex === undefined)
-            {
-                delete process.env.VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX;
-            }
-            else
-            {
-                process.env.VSCODE_DOTNET_RUNTIME_DISABLE_MUTEX = originalDisableMutex;
-            }
+            restorers.forEach(restore => restore());
         }
     }).timeout(expectedTimeoutTime);
 

--- a/vscode-dotnet-runtime-library/yarn.lock
+++ b/vscode-dotnet-runtime-library/yarn.lock
@@ -621,6 +621,11 @@ fs.realpath@^1.0.0:
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fsevents@^2.3.3:
+  version "2.3.3"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.2.tgz"

--- a/vscode-dotnet-runtime-library/yarn.lock
+++ b/vscode-dotnet-runtime-library/yarn.lock
@@ -621,11 +621,6 @@ fs.realpath@^1.0.0:
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.3.3:
-  version "2.3.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
## Summary

- preserve the failure reason returned by the global SDK uninstaller
- recognize the `@vscode/sudo-prompt` UAC dismissal message as user cancellation
- report a dismissed elevation prompt as a cancelled uninstall instead of suggesting that another install may be in progress
- add regression coverage for the library failure propagation and the final language-model-facing message

## Root cause

When the Windows UAC prompt was dismissed, `@vscode/sudo-prompt` returned
`User did not grant permission.`. The global uninstall worker discarded that
status and replaced it with an arbitrary error code and a fixed
`Another install may be in progress` message.

## User impact

Copilot and other callers now receive an accurate cancellation message with
guidance to retry and accept the elevation prompt. Other uninstall failures
continue to use the existing generic guidance.

## Validation

- `npm test` in `vscode-dotnet-runtime-library`: 255 passing, 7 pending
- `npm run test:lm-tools` in `vscode-dotnet-runtime-extension`: 68 passing

Fixes #2698
