### PR TITLE
improve sorting of installed versions when uninstalling dotnet version

### DIFF
--- a/vscode-dotnet-runtime-extension/src/extension.ts
+++ b/vscode-dotnet-runtime-extension/src/extension.ts
@@ -575,27 +575,35 @@ export function activate(vsCodeContext: vscode.ExtensionContext, extensionContex
 
     const dotnetUninstallPublicRegistration = vscode.commands.registerCommand(`${commandPrefix}.${commandKeys.uninstallPublic}`, async () =>
     {
+        const compareVersions = (x: InstallRecord, y: InstallRecord): number =>
+        {
+            const xParts = x.dotnetInstall.version.split('.').map(part => Number(part.split('-')[0]));
+            const yParts = y.dotnetInstall.version.split('.').map(part => Number(part.split('-')[0]));
+            const length = Math.max(xParts.length, yParts.length);
+            for (let index = 0; index < length; index++)
+            {
+                const difference = (xParts[index] ?? 0) - (yParts[index] ?? 0);
+                if (difference !== 0)
+                {
+                    return difference;
+                }
+            }
+            return 0;
+        };
+
         const existingInstalls: InstallRecord[] = await InstallTrackerSingleton.getInstance(globalEventStream, vsCodeContext.globalState).getExistingInstalls(directoryProviderFactory(
             'runtime', vsCodeContext.globalStoragePath));
 
-        const menuItems = existingInstalls?.sort(
-            function (x: InstallRecord, y: InstallRecord): number
-            {
-                if (x.dotnetInstall.installMode === y.dotnetInstall.installMode)
-                {
-                    return x.dotnetInstall.version.localeCompare(y.dotnetInstall.version);
-                }
-                return x.dotnetInstall.installMode.localeCompare(y.dotnetInstall.installMode);
-            })?.map(install =>
-            {
-                return {
-                    label: `.NET ${(install.dotnetInstall.installMode === 'sdk' ? 'SDK' : install.dotnetInstall.installMode === 'runtime' ? 'Runtime' : 'ASP.NET Core Runtime')} ${install.dotnetInstall.version}`,
-                    description: `${install.dotnetInstall.architecture ?? ''} | ${install.dotnetInstall.isGlobal ? 'machine-wide' : 'vscode-local'}`,
-                    detail: install.installingExtensions.some(x => x !== null) ? `Used by ${install.installingExtensions.join(', ')}` : ``,
-                    iconPath: install.dotnetInstall.isGlobal ? new vscode.ThemeIcon('shield') : new vscode.ThemeIcon('trash'),
-                    internalId: install.dotnetInstall.installId
-                }
-            });
+        const menuItems = existingInstalls?.sort(compareVersions)?.map(install =>
+        {
+            return {
+                label: `.NET ${(install.dotnetInstall.installMode === 'sdk' ? 'SDK' : install.dotnetInstall.installMode === 'runtime' ? 'Runtime' : 'ASP.NET Core Runtime')} ${install.dotnetInstall.version}`,
+                description: `${install.dotnetInstall.architecture ?? ''} | ${install.dotnetInstall.isGlobal ? 'machine-wide' : 'vscode-local'}`,
+                detail: install.installingExtensions.some(x => x !== null) ? `Used by ${install.installingExtensions.join(', ')}` : ``,
+                iconPath: install.dotnetInstall.isGlobal ? new vscode.ThemeIcon('shield') : new vscode.ThemeIcon('trash'),
+                internalId: install.dotnetInstall.installId
+            }
+        });
 
         if ((menuItems?.length ?? 0) < 1)
         {


### PR DESCRIPTION
When the command "Uninstall .NET" is selected, the displayed versions are not sorted based on the version numbers.
#2642 

## Root Cause

`localeCompare` was used which did not sort the numbers correctly.

## Changes

Added a new `compareVersion` function which splits the version into integers and compares each index.

```ts
const compareVersions = (x: InstallRecord, y: InstallRecord): number =>
        {
            const xParts = x.dotnetInstall.version.split('.').map(part => Number(part.split('-')[0]));
            const yParts = y.dotnetInstall.version.split('.').map(part => Number(part.split('-')[0]));
            const length = Math.max(xParts.length, yParts.length);
            for (let index = 0; index < length; index++)
            {
                const difference = (xParts[index] ?? 0) - (yParts[index] ?? 0);
                if (difference !== 0)
                {
                    return difference;
                }
            }
            return 0;
        };
```

I also thought about creating a new function in `VersionUtilities` under the runtime-library, but thought to check first.
Let me know if it is ok.