### PR TITLE
Support `preview` .NET versions in vscode acquisition 

### DIFF
--- a/Documentation/version-suffixes.md
+++ b/Documentation/version-suffixes.md
@@ -1,0 +1,28 @@
+# Supported Pre-Release Suffixes
+
+`historicalDotnetPreReleaseSuffixPattern` in `VersionUtilities.ts` accepts only
+suffix families supported by the official .NET release metadata feed. The
+examples are public artifacts that establish each family's historical use; they
+are not a list of the only accepted builds.
+
+| Suffix family | Historical version | Evidence |
+| --- | --- | --- |
+| `preview` | `.NET Core SDK 3.0.100-preview9-014004` | [.NET 3.0 releases.json](https://builds.dotnet.microsoft.com/dotnet/release-metadata/3.0/releases.json) |
+| `rc` | `.NET Core SDK 3.0.100-rc1-014190` | [.NET 3.0 releases.json](https://builds.dotnet.microsoft.com/dotnet/release-metadata/3.0/releases.json) |
+
+## Unsupported Families
+
+The following historical package suffixes are intentionally unsupported because
+they have no corresponding official .NET `releases.json` record. Their package
+history alone is insufficient evidence for acquisition-version support.
+
+| Suffix family | Historical package version |
+| --- | --- |
+| `alpha` | [`Microsoft.NET.Sdk 1.0.0-alpha-20161104-2`](https://www.nuget.org/packages/Microsoft.NET.Sdk/1.0.0-alpha-20161104-2) |
+| `beta` | [`Microsoft.Net.Native.Compiler 1.5.0-beta`](https://www.nuget.org/packages/Microsoft.Net.Native.Compiler/1.5.0-beta) |
+| `rel` | [`Microsoft.Net.Native.Compiler 2.2.12-rel-33220-00`](https://www.nuget.org/packages/Microsoft.Net.Native.Compiler/2.2.12-rel-33220-00) |
+| `arm64rel` | [`Microsoft.Net.Native.Compiler 2.1.8-arm64rel-26502-00`](https://www.nuget.org/packages/Microsoft.Net.Native.Compiler/2.1.8-arm64rel-26502-00) |
+
+The matcher intentionally excludes arbitrary labels such as `ci`, `foo`, and
+`bar-1.3`. A successful SemVer comparison does not make an unsupported suffix
+a valid .NET acquisition version.

--- a/vscode-dotnet-runtime-extension/src/LanguageModelTools.ts
+++ b/vscode-dotnet-runtime-extension/src/LanguageModelTools.ts
@@ -9,6 +9,7 @@ import
     {
         AcquireErrorConfiguration,
         checkForUnsupportedLinux,
+        compareSDKPatchOrPreRelease,
         convertToLinuxPackageManagerSupportedVersion,
         DotnetAcquisitionCompleted,
         DotnetAcquisitionStarted,
@@ -227,7 +228,9 @@ export function highestPatchInSameFeatureBand(requestedVersion: string, installe
         return undefined;
     }
 
-    return sameBand.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))[sameBand.length - 1];
+    // Order by feature-band patch and then pre-release identity so a stable release outranks its preview and
+    // higher-numbered previews outrank lower ones (localeCompare would mis-rank e.g. RTM below -preview).
+    return sameBand.sort((a, b) => compareSDKPatchOrPreRelease(a, b, eventStream, versionParseContext(eventStream, a)))[sameBand.length - 1];
 }
 
 /**

--- a/vscode-dotnet-runtime-extension/src/test/functional/LanguageModelTools.test.ts
+++ b/vscode-dotnet-runtime-extension/src/test/functional/LanguageModelTools.test.ts
@@ -1068,6 +1068,18 @@ suite('LanguageModelTools Tests', function ()
             {
                 assert.isUndefined(highestPatchInSameFeatureBand('10.0.106', [], eventStream));
             }).timeout(standardTimeoutTime);
+
+            test('Ranks a stable release above its preview of the same patch', () =>
+            {
+                const installed = ['11.0.100-preview.5.26352.110', '11.0.100-preview.6.26352.110', '11.0.100'];
+                assert.equal(highestPatchInSameFeatureBand('11.0.100', installed, eventStream), '11.0.100', 'The RTM outranks its previews');
+            }).timeout(standardTimeoutTime);
+
+            test('Ranks higher-numbered previews above lower ones', () =>
+            {
+                const installed = ['11.0.100-preview.5.26352.110', '11.0.100-preview.6.26352.110'];
+                assert.equal(highestPatchInSameFeatureBand('11.0.100-preview.5.26352.110', installed, eventStream), '11.0.100-preview.6.26352.110', 'preview.6 outranks preview.5');
+            }).timeout(standardTimeoutTime);
         });
 
         suite('resolveSdkVersionForInstall', function ()

--- a/vscode-dotnet-runtime-library/distro-data/distro-support.json
+++ b/vscode-dotnet-runtime-library/distro-data/distro-support.json
@@ -225,6 +225,18 @@
                 "aspnetcore": [
                     "aspnetcore-runtime-10.0"
                 ]
+            },
+            {
+                "version": "11.0",
+                "sdk": [
+                    "dotnet-sdk-11.0"
+                ],
+                "runtime": [
+                    "dotnet-runtime-11.0"
+                ],
+                "aspnetcore": [
+                    "aspnetcore-runtime-11.0"
+                ]
             }
         ],
         "versions": [
@@ -791,6 +803,18 @@
                 "aspnetcore": [
                     "aspnetcore-runtime-10.0"
                 ]
+            },
+            {
+                "version": "11.0",
+                "sdk": [
+                    "dotnet-sdk-11.0"
+                ],
+                "runtime": [
+                    "dotnet-runtime-11.0"
+                ],
+                "aspnetcore": [
+                    "aspnetcore-runtime-11.0"
+                ]
             }
         ],
         "versions": [
@@ -1069,6 +1093,18 @@
                 ],
                 "aspnetcore": [
                     "aspnetcore-runtime-10.0"
+                ]
+            },
+            {
+                "version": "11.0",
+                "sdk": [
+                    "dotnet-sdk-11.0"
+                ],
+                "runtime": [
+                    "dotnet-runtime-11.0"
+                ],
+                "aspnetcore": [
+                    "aspnetcore-runtime-11.0"
                 ]
             }
         ],

--- a/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/AcquisitionInvoker.ts
@@ -34,8 +34,8 @@ import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { IUtilityContext } from '../Utils/IUtilityContext';
 import { getDotnetExecutable } from '../Utils/TypescriptUtilities';
 import { WebRequestWorkerSingleton } from '../Utils/WebRequestWorkerSingleton';
+import { getDefaultArchitecture } from './ArchitectureUtilities';
 import { DotnetConditionValidator } from './DotnetConditionValidator';
-import { DotnetCoreAcquisitionWorker } from './DotnetCoreAcquisitionWorker';
 import { DotnetInstall } from './DotnetInstall';
 import { DotnetInstallMode } from './DotnetInstallMode';
 import { IAcquisitionInvoker } from './IAcquisitionInvoker';
@@ -244,7 +244,7 @@ At dotnet-install.ps1:1189 char:5
 
     private async getInstallCommand(version: string, dotnetInstallDir: string, installMode?: DotnetInstallMode, architecture?: string | null): Promise<string>
     {
-        const arch = this.fileUtilities.nodeArchToDotnetArch(architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture(), this.eventStream);
+        const arch = this.fileUtilities.nodeArchToDotnetArch(architecture ?? getDefaultArchitecture(), this.eventStream);
         let args = [
             '-InstallDir', this.escapeFilePath(dotnetInstallDir),
             '-Version', version,

--- a/vscode-dotnet-runtime-library/src/Acquisition/ArchitectureUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/ArchitectureUtilities.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+import * as os from 'os';
+
+export function getDefaultArchitecture(): string
+{
+    return os.arch();
+}

--- a/vscode-dotnet-runtime-library/src/Acquisition/DebianDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DebianDistroSDKProvider.ts
@@ -5,10 +5,10 @@
  * ------------------------------------------------------------------------------------------ */
 import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { IUtilityContext } from '../Utils/IUtilityContext';
+import { DistroVersionPair } from './DistroTypes';
 import { DotnetInstallMode } from './DotnetInstallMode';
 import { GenericDistroSDKProvider } from './GenericDistroSDKProvider';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
-import { DistroVersionPair } from './LinuxVersionResolver';
 
 export class DebianDistroSDKProvider extends GenericDistroSDKProvider
 {

--- a/vscode-dotnet-runtime-library/src/Acquisition/DistroTypes.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DistroTypes.ts
@@ -1,8 +1,7 @@
-/* --------------------------------------------------------------------------------------------
- *  Licensed to the .NET Foundation under one or more agreements.
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
 *  The .NET Foundation licenses this file to you under the MIT license.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
+*--------------------------------------------------------------------------------------------*/
 
 export interface DistroVersionPair
 {

--- a/vscode-dotnet-runtime-library/src/Acquisition/DistroTypes.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DistroTypes.ts
@@ -1,8 +1,7 @@
-/*---------------------------------------------------------------------------------------------
-*  Licensed to the .NET Foundation under one or more agreements.
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
 *  The .NET Foundation licenses this file to you under the MIT license.
-*--------------------------------------------------------------------------------------------*/
-
+*--------------------------------------------------------------------------------------------*/
 export interface DistroVersionPair
 {
     distro: string,

--- a/vscode-dotnet-runtime-library/src/Acquisition/DistroTypes.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DistroTypes.ts
@@ -1,0 +1,20 @@
+/* --------------------------------------------------------------------------------------------
+ *  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export interface DistroVersionPair
+{
+    distro: string,
+    version: string
+}
+
+export const enum DotnetDistroSupportStatus
+{
+    Unsupported = 'UNSUPPORTED',
+    Distro = 'DISTRO',
+    Microsoft = 'MICROSOFT',
+    Partial = 'PARTIAL',
+    Unknown = 'UNKNOWN'
+}

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -206,7 +206,7 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
     {
         if (requirement.rejectPreviews === true)
         {
-            return !versionUtils.isPreviewVersion(availableVersion, this.workerContext.eventStream, this.workerContext);
+            return !versionUtils.hasPreReleaseSuffix(availableVersion);
         }
         return true;
     }

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -94,7 +94,10 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
             const availableMinor = Number(versionUtils.getMinor(availableVersion, this.workerContext.eventStream, this.workerContext));
             const requestedMinor = Number(versionUtils.getMinor(requestedVersion, this.workerContext.eventStream, this.workerContext));
 
-            if (availableMinor === requestedMinor && requestedPatch)
+            // Use `!== null` rather than a truthy check so a fully specified x.y.0 request (patch 0, which is falsy)
+            // still enters the patch comparison branch. Otherwise x.y.0 would fall through to the minor-only 'else'
+            // branch and, under 'disable'/equal, incorrectly match any x.y.* (and could not distinguish x.y.0 previews).
+            if (availableMinor === requestedMinor && requestedPatch !== null)
             {
                 const availablePatch = this.getPatchOrFeatureBandWithPatch(availableVersion, requirement);
 
@@ -102,7 +105,11 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
                 {
                     // the 'availablePatch' must exist, since the version is from --list-runtimes or --list-sdks, or our internal tracking of installs.
                     case 'equal':
-                        return availablePatch === requestedPatch;
+                        // For an exact match (rollForward: 'disable'), a pre-release build must match exactly: a preview
+                        // is not its RTM, and two different previews of the same patch (e.g. -preview.5 vs -preview.6)
+                        // are not equal. This is a no-op for stable-vs-stable (both suffixes are '').
+                        return availablePatch === requestedPatch &&
+                            versionUtils.getPreReleaseSuffix(availableVersion) === versionUtils.getPreReleaseSuffix(requestedVersion);
                     case 'greater_than_or_equal':
                     case 'latestFeature':
                         return availablePatch! >= requestedPatch;

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -8,7 +8,7 @@ import { CommandExecutor } from '../Utils/CommandExecutor';
 import { FileUtilities } from '../Utils/FileUtilities';
 import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { IUtilityContext } from '../Utils/IUtilityContext';
-import { DotnetCoreAcquisitionWorker } from './DotnetCoreAcquisitionWorker';
+import { getDefaultArchitecture } from './ArchitectureUtilities';
 import { DotnetResolver } from './DotnetResolver';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IDotnetConditionValidator } from './IDotnetConditionValidator';
@@ -33,7 +33,7 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
     {
         const availableInstalls = await this.resolver.getDotnetInstalls(dotnetExecutablePath, requirement.acquireContext.mode ?? 'runtime', requirement.acquireContext.architecture);
         // Assumption : All APIs we call return only one architecture in the group of installs we get (currently a true assumption)
-        const determinedInstallArchitecture = availableInstalls.at(0)?.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture();
+        const determinedInstallArchitecture = availableInstalls.at(0)?.architecture ?? getDefaultArchitecture();
 
         if (requirement.acquireContext.mode === 'sdk')
         {

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -94,9 +94,6 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
             const availableMinor = Number(versionUtils.getMinor(availableVersion, this.workerContext.eventStream, this.workerContext));
             const requestedMinor = Number(versionUtils.getMinor(requestedVersion, this.workerContext.eventStream, this.workerContext));
 
-            // Use `!== null` rather than a truthy check so a fully specified x.y.0 request (patch 0, which is falsy)
-            // still enters the patch comparison branch. Otherwise x.y.0 would fall through to the minor-only 'else'
-            // branch and, under 'disable'/equal, incorrectly match any x.y.* (and could not distinguish x.y.0 previews).
             if (availableMinor === requestedMinor && requestedPatch !== null)
             {
                 const availablePatch = this.getPatchOrFeatureBandWithPatch(availableVersion, requirement);
@@ -105,9 +102,7 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
                 {
                     // the 'availablePatch' must exist, since the version is from --list-runtimes or --list-sdks, or our internal tracking of installs.
                     case 'equal':
-                        // For an exact match (rollForward: 'disable'), a pre-release build must match exactly: a preview
-                        // is not its RTM, and two different previews of the same patch (e.g. -preview.5 vs -preview.6)
-                        // are not equal. This is a no-op for stable-vs-stable (both suffixes are '').
+                        // For an exact match (rollForward: 'disable'), a pre-release build must match exactly (e.g. -preview.5 vs -preview.6)
                         return availablePatch === requestedPatch &&
                             versionUtils.getPreReleaseSuffix(availableVersion) === versionUtils.getPreReleaseSuffix(requestedVersion);
                     case 'greater_than_or_equal':

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetConditionValidator.ts
@@ -97,6 +97,9 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
             if (availableMinor === requestedMinor && requestedPatch !== null)
             {
                 const availablePatch = this.getPatchOrFeatureBandWithPatch(availableVersion, requirement);
+                const patchComparison = availablePatch === requestedPatch ?
+                    versionUtils.compareVersionsIncludingPreRelease(availableVersion, requestedVersion) :
+                    availablePatch! - requestedPatch;
 
                 switch (adjustedVersionSpec)
                 {
@@ -107,14 +110,14 @@ export class DotnetConditionValidator implements IDotnetConditionValidator
                             versionUtils.getPreReleaseSuffix(availableVersion) === versionUtils.getPreReleaseSuffix(requestedVersion);
                     case 'greater_than_or_equal':
                     case 'latestFeature':
-                        return availablePatch! >= requestedPatch;
+                        return patchComparison >= 0;
                     case 'less_than_or_equal':
-                        return availablePatch! <= requestedPatch;
+                        return patchComparison <= 0;
                     case 'latestPatch':
                         const availableBand = this.getFeatureBand(availableVersion, requirement);
                         const requestedBandStr = requirement.acquireContext.mode === 'sdk' ? versionUtils.getFeatureBandFromVersion(requestedVersion, this.workerContext.eventStream, this.workerContext, false) ?? null : null;
                         const requestedBand = requestedBandStr ? Number(requestedBandStr) : null;
-                        return availablePatch! >= requestedPatch && (availableBand ? availableBand === requestedBand : true);
+                        return patchComparison >= 0 && (availableBand ? availableBand === requestedBand : true);
                 }
             }
             else

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetCoreAcquisitionWorker.ts
@@ -52,6 +52,7 @@ import { executeWithLock, getDotnetExecutable, isRunningUnderWSL } from '../Util
 import { DOTNET_INFORMATION_CACHE_DURATION_MS, GLOBAL_LOCK_PING_DURATION_MS, LOCAL_LOCK_PING_DURATION_MS } from './CacheTimeConstants';
 import { directoryProviderFactory } from './DirectoryProviderFactory';
 import { DotnetConditionValidator } from './DotnetConditionValidator';
+import { getDefaultArchitecture } from './ArchitectureUtilities';
 import
 {
     DotnetInstall,
@@ -385,12 +386,12 @@ export class DotnetCoreAcquisitionWorker implements IDotnetCoreAcquisitionWorker
         {
             return 'null';
         }
-        return DotnetCoreAcquisitionWorker.defaultArchitecture();
+        return getDefaultArchitecture();
     }
 
     public static defaultArchitecture(): string
     {
-        return os.arch();
+        return getDefaultArchitecture();
     }
 
     private getErrorOrStringAsEventError(error: any)

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstall.ts
@@ -74,7 +74,11 @@ export function InstallToStrings(install: DotnetInstall)
 
 export function looksLikeRuntimeVersion(version: string): boolean
 {
-    const band: string | undefined = version.split('.')?.[2];
+    // Strip any pre-release suffix (e.g. -rc.2.24473.5 or -preview.6.26352.110) before measuring the third segment,
+    // otherwise a pre-release runtime version like 9.0.0-rc.2 would have its third segment ('0-rc') counted as longer
+    // than 2 characters and be misclassified as an SDK. A runtime's third segment is a bare patch (<= 2 digits) while
+    // an SDK's is a 3-digit feature band + patch (e.g. 100).
+    const band: string | undefined = version.split('.')?.[2]?.split('-')?.[0];
     return (band?.length ?? 0) <= 2; // assumption : there exists no runtime version at this point over 99 sub versions
 }
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/DotnetResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/DotnetResolver.ts
@@ -12,8 +12,8 @@ import { ExecutableArchitectureDetector } from '../Utils/ExecutableArchitectureD
 import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { IUtilityContext } from '../Utils/IUtilityContext';
 import { getDotnetExecutable } from '../Utils/TypescriptUtilities';
+import { getDefaultArchitecture } from './ArchitectureUtilities';
 import { DOTNET_INFORMATION_CACHE_DURATION_MS } from './CacheTimeConstants';
-import { DotnetCoreAcquisitionWorker } from './DotnetCoreAcquisitionWorker';
 import { DotnetInstallMode } from './DotnetInstallMode';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IDotnetListInfo } from './IDotnetListInfo';
@@ -43,7 +43,7 @@ export class DotnetResolver implements IDotnetResolver
         {
             if (mode === 'sdk')
             {
-                const availableSDKs = await this.getSDKs(dotnetExecutablePath, requestedArchitecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture());
+                const availableSDKs = await this.getSDKs(dotnetExecutablePath, requestedArchitecture ?? getDefaultArchitecture());
                 if (availableSDKs.length === 0)
                 {
                     return [];
@@ -68,7 +68,7 @@ export class DotnetResolver implements IDotnetResolver
             else
             {
                 // No need to consider SDKs when looking for runtimes as all the runtimes installed with the SDKs will be included in the runtimes list.
-                const availableRuntimes = await this.getRuntimes(dotnetExecutablePath, requestedArchitecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture());
+                const availableRuntimes = await this.getRuntimes(dotnetExecutablePath, requestedArchitecture ?? getDefaultArchitecture());
 
                 if (availableRuntimes.length === 0)
                 {
@@ -168,7 +168,7 @@ export class DotnetResolver implements IDotnetResolver
         try
         {
             const truePaths = [];
-            suggestedArchitecture ??= DotnetCoreAcquisitionWorker.defaultArchitecture()
+            suggestedArchitecture ??= getDefaultArchitecture()
 
             for (const tentativePath of tentativePaths)
             {
@@ -341,7 +341,7 @@ Please set the PATH to a dotnet host that matches the architecture. An incorrect
             return [];
         }
 
-        requestedArchitecture ??= DotnetCoreAcquisitionWorker.defaultArchitecture()
+        requestedArchitecture ??= getDefaultArchitecture()
 
         const windowsDesktopString = 'Microsoft.WindowsDesktop.App';
         const aspnetCoreString = 'Microsoft.AspNetCore.App';

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -148,7 +148,11 @@ export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider
         const commandResult = (await this.commandRunner.executeMultipleCommands(command, { cwd: path.resolve(rootDir), shell: true }, false))[0];
 
         commandResult.stdout = commandResult.stdout.replace('\n', '');
-        if (!versionUtils.isValidLongFormVersionFormat(commandResult.stdout, this.context.eventStream, this.context))
+        // `dotnet --version` reports the exact installed SDK, which may be a fully specified pre-release build (e.g.
+        // 11.0.100-preview.6.26352.110). isValidLongFormVersionFormat rejects the pre-release suffix, so also accept
+        // a fully specified preview version; otherwise an installed preview SDK would be treated as "not installed".
+        if (!versionUtils.isValidLongFormVersionFormat(commandResult.stdout, this.context.eventStream, this.context) &&
+            !versionUtils.isFullySpecifiedPreviewVersion(commandResult.stdout, this.context.eventStream, this.context))
         {
             return null;
         }

--- a/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GenericDistroSDKProvider.ts
@@ -8,9 +8,9 @@ import * as path from 'path';
 import { DistroPackagesSearch, DistroSupport, DotnetVersionResolutionError, EventBasedError } from '../EventStream/EventStreamEvents';
 import { CommandExecutor } from '../Utils/CommandExecutor';
 import { READ_SYMLINK_CACHE_DURATION_MS } from './CacheTimeConstants';
+import { DotnetDistroSupportStatus } from './DistroTypes';
 import { DotnetInstallMode } from './DotnetInstallMode';
 import { IDistroDotnetSDKProvider } from './IDistroDotnetSDKProvider';
-import { DotnetDistroSupportStatus } from './LinuxVersionResolver';
 import * as versionUtils from './VersionUtilities';
 
 export class GenericDistroSDKProvider extends IDistroDotnetSDKProvider

--- a/vscode-dotnet-runtime-library/src/Acquisition/GlobalInstallerResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/GlobalInstallerResolver.ts
@@ -233,7 +233,9 @@ export class GlobalInstallerResolver
         for (const sdk of sdks)
         {
             const thisSDKVersion: string = sdk[this.releasesSdkVersionKey];
-            if (thisSDKVersion === specificVersion) // NOTE that this will not catch things like -preview or build number suffixed versions.
+            // Exact string match, so a fully specified pre-release build (e.g. 11.0.100-preview.6.26352.110) matches
+            // the corresponding releases.json entry verbatim.
+            if (thisSDKVersion === specificVersion)
             {
                 const thisSDKFiles = sdk[this.releasesSdkFileKey];
                 for (const installer of thisSDKFiles)
@@ -286,8 +288,7 @@ Please report this issue so it can be remedied or investigated.`), getInstallFro
 
         const fileErr = new DotnetNoInstallerFileExistsError(new EventBasedError('DotnetNoInstallerFileExistsError',
             `The SDK installation files for version ${specificVersion} running on ${desiredRidPackage} couldn't be found.
-Is the version in support? Note that -preview versions or versions with build numbers aren't yet supported.
-Visit https://dotnet.microsoft.com/platform/support/policy/dotnet-core for support information.`), getInstallFromContext(this.context));
+Is the version in support? Visit https://dotnet.microsoft.com/platform/support/policy/dotnet-core for support information.`), getInstallFromContext(this.context));
         this.context.eventStream.post(fileErr);
         throw fileErr.error;
     }

--- a/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/IDistroDotnetSDKProvider.ts
@@ -13,10 +13,10 @@ import { CommandExecutorCommand } from '../Utils/CommandExecutorCommand';
 import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { IUtilityContext } from '../Utils/IUtilityContext';
 import { getInstallFromContext } from '../Utils/InstallIdUtilities';
+import { DistroVersionPair, DotnetDistroSupportStatus } from './DistroTypes';
 import { DotnetInstallMode } from './DotnetInstallMode';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { LinuxPackageCollection } from './LinuxPackageCollection';
-import { DistroVersionPair, DotnetDistroSupportStatus } from './LinuxVersionResolver';
 import { VersionResolver } from './VersionResolver';
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -22,6 +22,7 @@ import { getInstallFromContext } from '../Utils/InstallIdUtilities';
 import { IUtilityContext } from '../Utils/IUtilityContext';
 import { getRunningDistro, microsoftSupportedDistroIds } from '../Utils/TypescriptUtilities';
 import { DebianDistroSDKProvider } from './DebianDistroSDKProvider';
+import { DistroVersionPair, DotnetDistroSupportStatus } from './DistroTypes';
 import { DotnetInstallMode } from './DotnetInstallMode';
 import { GenericDistroSDKProvider } from './GenericDistroSDKProvider';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
@@ -31,40 +32,7 @@ import { DEBIAN_DISTRO_INFO_KEY, RED_HAT_DISTRO_INFO_KEY } from './StringConstan
 import { VersionResolver } from './VersionResolver';
 import * as versionUtils from './VersionUtilities';
 
-
-/**
- * An enumeration type representing all distros with their versions that we recognize.
- * @remarks
- * Each . in a semver should be represented with _.
- * The string representation of the enum should contain exactly one space that separates the distro, then the version.
- */
-export interface DistroVersionPair
-{
-    distro: string,
-    version: string
-}
-
-/**
- * @remarks
- * Distro support means that the distro provides a dotnet sdk package by default without intervention.
- *
- * Microsoft support means that Microsoft provides packages for the distro but it's not in the distro maintained feed.
- * For Microsoft support, we currently don't support installs of these feeds yet.
- *
- * Partial support does not have any change in behavior from unsupported currently and can mean whatever the distro maintainer wants.
- * But it generally means that the distro and microsoft both do not officially support that version of dotnet.
- *
- * Unknown is a placeholder for development testing and future potential implementation and should not be used by contributors.
- */
-export const enum DotnetDistroSupportStatus
-{
-    Unsupported = 'UNSUPPORTED',
-    Distro = 'DISTRO',
-    Microsoft = 'MICROSOFT',
-    Partial = 'PARTIAL',
-    Unknown = 'UNKNOWN'
-}
-
+export { DistroVersionPair, DotnetDistroSupportStatus } from './DistroTypes';
 
 /**
  * This class is responsible for detecting the distro and version of the Linux OS.

--- a/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LinuxVersionResolver.ts
@@ -291,8 +291,10 @@ If you experience issues, please reach out on https://github.com/dotnet/vscode-d
             if (existingGlobalInstallSDKVersion && Number(versionUtils.getMajorMinor(existingGlobalInstallSDKVersion, this.workerContext.eventStream, this.workerContext)) ===
                 Number(versionUtils.getMajorMinor(fullySpecifiedDotnetVersion, this.workerContext.eventStream, this.workerContext)))
             {
-                const isPatchUpgrade = Number(versionUtils.getFeatureBandPatchVersion(existingGlobalInstallSDKVersion, this.workerContext.eventStream, this.workerContext)) <
-                    Number(versionUtils.getFeatureBandPatchVersion(fullySpecifiedDotnetVersion, this.workerContext.eventStream, this.workerContext));
+                // compareSDKPatchOrPreRelease is pre-release aware, so an existing pre-release SDK that is older than
+                // the requested one (e.g. installed 11.0.100-preview.5 vs requested 11.0.100-preview.6, which share a
+                // feature-band patch) is still recognized as an upgrade rather than an already-satisfied install.
+                const isPatchUpgrade = versionUtils.compareSDKPatchOrPreRelease(existingGlobalInstallSDKVersion, fullySpecifiedDotnetVersion, this.workerContext.eventStream, this.workerContext) < 0;
 
                 if (Number(versionUtils.getMajorMinor(existingGlobalInstallSDKVersion, this.workerContext.eventStream, this.workerContext)) >
                     Number(versionUtils.getMajorMinor(fullySpecifiedDotnetVersion, this.workerContext.eventStream, this.workerContext))

--- a/vscode-dotnet-runtime-library/src/Acquisition/LocalInstallUpdateService.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LocalInstallUpdateService.ts
@@ -10,7 +10,7 @@ import { IDotnetAcquireResult } from '../IDotnetAcquireResult';
 import { IExtensionState } from '../IExtensionState';
 import { AcquireErrorConfiguration } from '../Utils/ErrorHandler';
 import { WebRequestWorkerSingleton } from '../Utils/WebRequestWorkerSingleton';
-import { DotnetCoreAcquisitionWorker } from './DotnetCoreAcquisitionWorker';
+import { getDefaultArchitecture } from './ArchitectureUtilities';
 import { DotnetInstallMode } from './DotnetInstallMode';
 import { IInstallationDirectoryProvider } from './IInstallationDirectoryProvider';
 import { IInstallManagementService } from './IInstallManagementService';
@@ -86,7 +86,7 @@ export class LocalInstallUpdateService extends IInstallManagementService
     {
         const runtimeInstalls = (await this.installTrackerType.getInstance(this.eventStream, this.extensionState).getExistingInstalls(this.managementDirectoryProvider, false)).filter(i => i.dotnetInstall.installMode !== 'sdk' && i.dotnetInstall.isGlobal !== true);
         const installGroupsToInstalls = new Map<string, { key: InstallGroup; installs: InstallRecord[] }>();
-        const currentArchitecture = DotnetCoreAcquisitionWorker.defaultArchitecture();
+        const currentArchitecture = getDefaultArchitecture();
 
         for (const install of runtimeInstalls)
         {
@@ -169,7 +169,7 @@ export class LocalInstallUpdateService extends IInstallManagementService
             const tracker = this.installTrackerType.getInstance(this.eventStream, this.extensionState);
             const extensionManagedInstalls = await tracker.getExistingInstalls(this.managementDirectoryProvider, false);
             const newInstallsInGroup = extensionManagedInstalls.filter(i => i.dotnetInstall.installMode === group.mode &&
-                (i.dotnetInstall.architecture || DotnetCoreAcquisitionWorker.defaultArchitecture()) === group.architecture &&
+                (i.dotnetInstall.architecture || getDefaultArchitecture()) === group.architecture &&
                 versionUtils.getMajorMinorFromValidVersion(i.dotnetInstall.version) === group.majorMinor);
 
             // All of the installs were uninstalled in the middle of this process.

--- a/vscode-dotnet-runtime-library/src/Acquisition/LocalInstallUpdateService.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/LocalInstallUpdateService.ts
@@ -189,13 +189,12 @@ export class LocalInstallUpdateService extends IInstallManagementService
                     const parts = install.dotnetInstall.version.split('.');
                     const latestParts = latestInstall.dotnetInstall.version.split('.');
 
-                    // Compare full third component if it exists
+                    // Compare full third component if it exists. compareVersionsIncludingPreRelease is pre-release
+                    // aware, so among installs sharing a patch (e.g. two previews like -preview.5 vs -preview.6, or a
+                    // preview vs its RTM) the genuinely newer one is selected instead of the first encountered.
                     if (parts.length > 2 && latestParts.length > 2)
                     {
-                        const currentPatch = Number(parts[2].split('-')?.[0] ?? 0); // Remove any suffix like -rc
-                        const latestPatch = Number(latestParts[2].split('-')?.[0] ?? 0);
-
-                        if (currentPatch > latestPatch)
+                        if (versionUtils.compareVersionsIncludingPreRelease(install.dotnetInstall.version, latestInstall.dotnetInstall.version) > 0)
                         {
                             latestInstall = install;
                         }

--- a/vscode-dotnet-runtime-library/src/Acquisition/RedHatDistroSDKProvider.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/RedHatDistroSDKProvider.ts
@@ -5,9 +5,9 @@
  * ------------------------------------------------------------------------------------------ */
 import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { IUtilityContext } from '../Utils/IUtilityContext';
+import { DistroVersionPair } from './DistroTypes';
 import { GenericDistroSDKProvider } from './GenericDistroSDKProvider';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
-import { DistroVersionPair } from './LinuxVersionResolver';
 
 export class RedHatDistroSDKProvider extends GenericDistroSDKProvider
 {

--- a/vscode-dotnet-runtime-library/src/Acquisition/VersionResolver.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/VersionResolver.ts
@@ -27,6 +27,7 @@ import
 import { DotnetInstallMode } from './DotnetInstallMode';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IVersionResolver } from './IVersionResolver';
+import * as versionUtils from './VersionUtilities';
 
 export class VersionResolver implements IVersionResolver
 {
@@ -169,7 +170,7 @@ export class VersionResolver implements IVersionResolver
             parsedVer = null;
         }
 
-        if (!parsedVer || (version.split('.').length !== 2 && version.split('.').length !== 3))
+        if (!parsedVer || (versionUtils.getVersionWithoutPreReleaseSuffix(version).split('.').length !== 2 && versionUtils.getVersionWithoutPreReleaseSuffix(version).split('.').length !== 3))
         {
             const err = new DotnetVersionResolutionError(new EventCancellationError('DotnetVersionResolutionError',
                 `An invalid version was requested. Version: ${version}`),

--- a/vscode-dotnet-runtime-library/src/Acquisition/VersionUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/VersionUtilities.ts
@@ -19,6 +19,8 @@ import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { BAD_VERSION } from './StringConstants';
 
 const invalidFeatureBandErrorString = `A feature band couldn't be determined for the requested version: `;
+// Historical evidence for each accepted suffix family is documented in Documentation/version-suffixes.md.
+const historicalDotnetPreReleaseSuffixPattern = /^(?:preview|rc)(?:(?:\.\d+)+|\d+(?:\.\d+)*(?:-(?:\d+(?:-\d+)*|final))?|-\d+(?:-\d+)*)?$/i;
 
 /**
  *
@@ -144,6 +146,10 @@ export function getSDKPatchVersionString(fullySpecifiedVersion: string, eventStr
 }
 
 
+/**
+ *
+ * FullySpecifiedVersion is expected to be a fully specified version, but may be a preview version.
+ */
 export function getSDKFeatureBandOrPatchFromFullySpecifiedVersion(fullySpecifiedVersion: string): string
 {
     const patch: string | undefined = fullySpecifiedVersion.split('.')?.[2]?.substring(1)?.split('-')?.[0];
@@ -275,12 +281,17 @@ function getPreReleaseSuffixStartIndex(version: string): number
  * @param version the requested version to analyze.
  * @returns true IFF version is a fully specified SDK version that also carries a pre-release suffix, e.g.
  * 11.0.100-preview.6.26352.110 or 8.0.100-rc.2.24473.5. The portion before the '-' must itself be a fully
- * specified version (e.g. 11.0.100) and there must be a non-empty suffix after it.
+ * specified version (e.g. 11.0.100) and the suffix must match a historically published .NET format.
  */
 export function isFullySpecifiedPreviewVersion(version: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): boolean
 {
-    return getPreReleaseSuffix(version).length > 0 &&
+    return isHistoricalDotnetPreReleaseSuffix(getPreReleaseSuffix(version)) &&
         isFullySpecifiedVersion(getVersionWithoutPreReleaseSuffix(version), eventStream, context);
+}
+
+function isHistoricalDotnetPreReleaseSuffix(suffix: string): boolean
+{
+    return historicalDotnetPreReleaseSuffixPattern.test(suffix);
 }
 
 /**
@@ -308,6 +319,8 @@ export function isFullySpecifiedVersion(version: string, eventStream: IEventStre
  * -preview.6) sort older than the corresponding stable release and older than higher-numbered pre-releases, matching
  * semver ordering. This lets callers distinguish e.g. 11.0.100-preview.5 from 11.0.100-preview.6, which have the same
  * numeric feature-band patch.
+ * @remarks These comparison functions do not validate supported .NET suffixes. Do not use their result to infer
+ * support for arbitrary SemVer suffixes such as -ci; validate versions with isFullySpecifiedVersion first.
  */
 export function compareSDKPatchOrPreRelease(versionA: string, versionB: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): number
 {
@@ -339,7 +352,8 @@ export function compareSDKPatchOrPreRelease(versionA: string, versionB: string, 
  * semantics (a stable release outranks its pre-release; higher-numbered pre-releases outrank lower ones). Unlike
  * compareSDKPatchOrPreRelease this works for BOTH runtime and SDK versions because both are valid semver. Returns a
  * negative number if versionA is older than versionB, 0 if equivalent, and a positive number if versionA is newer.
- * Falls back to 0 when neither version can be parsed by semver.
+ * Falls back to 0 when neither version can be parsed by semver. This does not make arbitrary SemVer suffixes (for
+ * example, -ci) supported .NET versions; validate versions with isFullySpecifiedVersion before comparing them.
  */
 export function compareVersionsIncludingPreRelease(versionA: string, versionB: string): number
 {

--- a/vscode-dotnet-runtime-library/src/Acquisition/VersionUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/VersionUtilities.ts
@@ -336,6 +336,26 @@ export function compareSDKPatchOrPreRelease(versionA: string, versionB: string, 
 
 /**
  *
+ * @remarks Compares two versions that share the same major.minor, ordering by their remaining components (a runtime
+ * patch like 8.0.19 or an SDK feature-band patch like 8.0.301) and then by any pre-release suffix, using semver
+ * semantics (a stable release outranks its pre-release; higher-numbered pre-releases outrank lower ones). Unlike
+ * compareSDKPatchOrPreRelease this works for BOTH runtime and SDK versions because both are valid semver. Returns a
+ * negative number if versionA is older than versionB, 0 if equivalent, and a positive number if versionA is newer.
+ * Falls back to 0 when neither version can be parsed by semver.
+ */
+export function compareVersionsIncludingPreRelease(versionA: string, versionB: string): number
+{
+    const semverA = semver.parse(versionA) ?? semver.coerce(versionA);
+    const semverB = semver.parse(versionB) ?? semver.coerce(versionB);
+    if (semverA && semverB)
+    {
+        return semver.compare(semverA, semverB);
+    }
+    return 0;
+}
+
+/**
+ *
  * @param version the requested version to analyze.
  * @returns true IFF a major release represented as an integer was given. e.g. 6, which we convert to 6.0, OR a major minor was given, e.g. 6.1.
  */

--- a/vscode-dotnet-runtime-library/src/Acquisition/VersionUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/VersionUtilities.ts
@@ -3,6 +3,7 @@
 *  The .NET Foundation licenses this file to you under the MIT license.
 *--------------------------------------------------------------------------------------------*/
 
+import * as semver from 'semver';
 import { IEventStream } from '../EventStream/EventStream';
 import
 {
@@ -241,12 +242,83 @@ export function isNonSpecificFeatureBandedVersion(version: string): boolean
 
 /**
  *
+ * @param version a version string that may carry a pre-release suffix, e.g. 11.0.100-preview.6.26352.110.
+ * @returns the portion of the version before any pre-release suffix, e.g. 11.0.100. Returns the input unchanged
+ * when no pre-release suffix is present.
+ */
+export function getVersionWithoutPreReleaseSuffix(version: string): string
+{
+    const dashIndex = version.indexOf('-');
+    return dashIndex === -1 ? version : version.substring(0, dashIndex);
+}
+
+/**
+ *
  * @param version the requested version to analyze.
- * @returns true IFF version is a specific version e.g. 7.0.301.
+ * @returns true IFF version is a fully specified SDK version that also carries a pre-release suffix, e.g.
+ * 11.0.100-preview.6.26352.110 or 8.0.100-rc.2.24473.5. The portion before the '-' must itself be a fully
+ * specified version (e.g. 11.0.100) and there must be a non-empty suffix after it.
+ */
+export function isFullySpecifiedPreviewVersion(version: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): boolean
+{
+    const dashIndex = version.indexOf('-');
+    if (dashIndex === -1)
+    {
+        return false;
+    }
+
+    const baseVersion = version.substring(0, dashIndex);
+    const preReleaseSuffix = version.substring(dashIndex + 1);
+    return preReleaseSuffix.length > 0 && isFullySpecifiedVersion(baseVersion, eventStream, context);
+}
+
+/**
+ *
+ * @param version the requested version to analyze.
+ * @returns true IFF version is a specific version e.g. 7.0.301, including fully specified pre-release builds such
+ * as 11.0.100-preview.6.26352.110.
  */
 export function isFullySpecifiedVersion(version: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): boolean
 {
+    // A fully specified pre-release build (e.g. 11.0.100-preview.6.26352.110) is also fully specified; validate its
+    // numeric base (11.0.100) and short-circuit before the strictly-numeric checks below, which reject the suffix.
+    if (isFullySpecifiedPreviewVersion(version, eventStream, context))
+    {
+        return true;
+    }
     return version.split('.').every(x => isNumber(x)) && isValidLongFormVersionFormat(version, eventStream, context) && !isNonSpecificFeatureBandedVersion(version);
+}
+
+/**
+ *
+ * @remarks Compares two fully specified SDK versions that share the same major.minor and feature band, ordering them
+ * by feature-band patch and then by any pre-release suffix. Returns a negative number if versionA is older than
+ * versionB, 0 if they are equivalent, and a positive number if versionA is newer. Pre-release builds (e.g.
+ * -preview.6) sort older than the corresponding stable release and older than higher-numbered pre-releases, matching
+ * semver ordering. This lets callers distinguish e.g. 11.0.100-preview.5 from 11.0.100-preview.6, which have the same
+ * numeric feature-band patch.
+ */
+export function compareSDKPatchOrPreRelease(versionA: string, versionB: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): number
+{
+    const patchA = Number(getFeatureBandPatchVersion(versionA, eventStream, context));
+    const patchB = Number(getFeatureBandPatchVersion(versionB, eventStream, context));
+    if (patchA !== patchB)
+    {
+        return patchA - patchB;
+    }
+
+    // Feature-band patches are equal; disambiguate using any pre-release suffix. A stable release outranks a
+    // pre-release, and higher-numbered pre-releases outrank lower ones (semver ordering).
+    const semverA = semver.parse(versionA) ?? semver.coerce(versionA);
+    const semverB = semver.parse(versionB) ?? semver.coerce(versionB);
+    if (semverA && semverB)
+    {
+        return semver.compare(semverA, semverB);
+    }
+
+    // If semver cannot parse either version (e.g. an unusual internal build string), treat them as equivalent so
+    // callers fall back to their prior "already installed" behavior rather than performing an unnecessary reinstall.
+    return 0;
 }
 
 /**

--- a/vscode-dotnet-runtime-library/src/Acquisition/VersionUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/VersionUtilities.ts
@@ -254,6 +254,19 @@ export function getVersionWithoutPreReleaseSuffix(version: string): string
 
 /**
  *
+ * @param version a version string that may carry a pre-release suffix, e.g. 11.0.100-preview.6.26352.110.
+ * @returns the pre-release suffix (the portion after the first '-'), e.g. preview.6.26352.110, or '' when the
+ * version has no pre-release suffix. Two versions represent the exact same release iff their numeric parts and
+ * this suffix both match.
+ */
+export function getPreReleaseSuffix(version: string): string
+{
+    const dashIndex = version.indexOf('-');
+    return dashIndex === -1 ? '' : version.substring(dashIndex + 1);
+}
+
+/**
+ *
  * @param version the requested version to analyze.
  * @returns true IFF version is a fully specified SDK version that also carries a pre-release suffix, e.g.
  * 11.0.100-preview.6.26352.110 or 8.0.100-rc.2.24473.5. The portion before the '-' must itself be a fully

--- a/vscode-dotnet-runtime-library/src/Acquisition/VersionUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/VersionUtilities.ts
@@ -221,12 +221,12 @@ export function isValidLongFormVersionFormat(fullySpecifiedVersion: string, even
 
 /**
  *
- * @param fullySpecifiedVersion the requested version to analyze.
- * @returns true IFF version is of an rc, preview, internal build, etc.
+ * @param version the version string to analyze.
+ * @returns true IFF the version has a non-empty pre-release suffix. This function does not validate the version.
  */
-export function isPreviewVersion(fullySpecifiedVersion: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): boolean
+export function hasPreReleaseSuffix(version: string): boolean
 {
-    return fullySpecifiedVersion.includes('-');
+    return getPreReleaseSuffix(version).length > 0;
 }
 
 /**
@@ -248,7 +248,7 @@ export function isNonSpecificFeatureBandedVersion(version: string): boolean
  */
 export function getVersionWithoutPreReleaseSuffix(version: string): string
 {
-    const dashIndex = version.indexOf('-');
+    const dashIndex = getPreReleaseSuffixStartIndex(version);
     return dashIndex === -1 ? version : version.substring(0, dashIndex);
 }
 
@@ -261,8 +261,13 @@ export function getVersionWithoutPreReleaseSuffix(version: string): string
  */
 export function getPreReleaseSuffix(version: string): string
 {
-    const dashIndex = version.indexOf('-');
+    const dashIndex = getPreReleaseSuffixStartIndex(version);
     return dashIndex === -1 ? '' : version.substring(dashIndex + 1);
+}
+
+function getPreReleaseSuffixStartIndex(version: string): number
+{
+    return version.indexOf('-');
 }
 
 /**
@@ -274,15 +279,8 @@ export function getPreReleaseSuffix(version: string): string
  */
 export function isFullySpecifiedPreviewVersion(version: string, eventStream: IEventStream, context: IAcquisitionWorkerContext): boolean
 {
-    const dashIndex = version.indexOf('-');
-    if (dashIndex === -1)
-    {
-        return false;
-    }
-
-    const baseVersion = version.substring(0, dashIndex);
-    const preReleaseSuffix = version.substring(dashIndex + 1);
-    return preReleaseSuffix.length > 0 && isFullySpecifiedVersion(baseVersion, eventStream, context);
+    return getPreReleaseSuffix(version).length > 0 &&
+        isFullySpecifiedVersion(getVersionWithoutPreReleaseSuffix(version), eventStream, context);
 }
 
 /**

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -557,12 +557,14 @@ Permissions: ${JSON.stringify(await this.commandRunner.execute(CommandExecutor.m
                 ( // Side by side installs of the same major.minor and band can cause issues in some cases. So we decided to just not allow it unless upgrading to a newer patch version.
                 // The installer can catch this but we can avoid unnecessary work this way,
                 // and for windows the installer may never appear to the user. With this approach, we don't need to handle installer error codes.
+                // compareSDKPatchOrPreRelease is pre-release aware, so a request for a newer pre-release of the same
+                // feature-band patch (e.g. 11.0.100-preview.6 when 11.0.100-preview.5 is installed) is treated as an
+                // upgrade rather than an existing conflicting install.
                 Number(versionUtils.getMajorMinor(requestedVersion, this.acquisitionContext.eventStream, this.acquisitionContext)) ===
                 Number(versionUtils.getMajorMinor(sdk, this.acquisitionContext.eventStream, this.acquisitionContext)) &&
                 Number(versionUtils.getFeatureBandFromVersion(requestedVersion, this.acquisitionContext.eventStream, this.acquisitionContext)) ===
                 Number(versionUtils.getFeatureBandFromVersion(sdk, this.acquisitionContext.eventStream, this.acquisitionContext)) &&
-                Number(versionUtils.getFeatureBandPatchVersion(requestedVersion, this.acquisitionContext.eventStream, this.acquisitionContext)) <=
-                Number(versionUtils.getFeatureBandPatchVersion(sdk, this.acquisitionContext.eventStream, this.acquisitionContext))
+                versionUtils.compareSDKPatchOrPreRelease(requestedVersion, sdk, this.acquisitionContext.eventStream, this.acquisitionContext) <= 0
             )
             {
                 return sdk;

--- a/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
+++ b/vscode-dotnet-runtime-library/src/Acquisition/WinMacGlobalInstaller.ts
@@ -38,8 +38,8 @@ import { ICommandExecutor } from '../Utils/ICommandExecutor';
 import { IFileUtilities } from '../Utils/IFileUtilities';
 import { IUtilityContext } from '../Utils/IUtilityContext';
 import { executeWithLock, getOSArch } from '../Utils/TypescriptUtilities';
+import { getDefaultArchitecture } from './ArchitectureUtilities';
 import { GLOBAL_LOCK_PING_DURATION_MS, SYSTEM_INFORMATION_CACHE_DURATION_MS } from './CacheTimeConstants';
-import { DotnetCoreAcquisitionWorker } from './DotnetCoreAcquisitionWorker';
 import { DotnetInstall } from './DotnetInstall';
 import { IAcquisitionWorkerContext } from './IAcquisitionWorkerContext';
 import { IGlobalInstaller } from './IGlobalInstaller';
@@ -479,7 +479,7 @@ Please correct your PATH variable or make sure the 'open' utility is installed s
                 this.acquisitionContext.eventStream.post(new MacInstallerFailure(`The installer failed.`, installerResult.status, installerResult.stderr, installerResult.stdout));
                 await this.darwinInstallBackup(installerPath);
 
-                const expectedDotnetHostPath = await this.getExpectedGlobalSDKPath(this.acquisitionContext.acquisitionContext.version, this.acquisitionContext.acquisitionContext.architecture ?? DotnetCoreAcquisitionWorker.defaultArchitecture());
+                const expectedDotnetHostPath = await this.getExpectedGlobalSDKPath(this.acquisitionContext.acquisitionContext.version, this.acquisitionContext.acquisitionContext.architecture ?? getDefaultArchitecture());
                 const expectedInstall = getInstallFromContext(this.acquisitionContext);
                 const validatedInstall = this.acquisitionContext.installationValidator.validateDotnetInstall(expectedInstall, expectedDotnetHostPath, false, false);
                 if (validatedInstall)

--- a/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
+++ b/vscode-dotnet-runtime-library/src/EventStream/EventStreamEvents.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import * as fs from 'fs';
 import * as path from 'path';
-import { DotnetInstall, InstallToStrings } from '../Acquisition/DotnetInstall';
+import type { DotnetInstall } from '../Acquisition/DotnetInstall';
 import { DotnetInstallMode } from '../Acquisition/DotnetInstallMode';
 import { IDotnetInstallationContext } from '../Acquisition/IDotnetInstallationContext';
 import { DotnetInstallType } from '../IDotnetAcquireContext';
@@ -12,6 +12,17 @@ import { IDotnetFindPathContext } from '../IDotnetFindPathContext';
 import { EventType } from './EventType';
 import { IEvent } from './IEvent';
 import { TelemetryUtilities } from './TelemetryUtilities';
+
+function InstallToStrings(install: DotnetInstall)
+{
+    return {
+        installId: install.installId,
+        version: install.version,
+        architecture: install.architecture ?? 'unspecified',
+        isGlobal: install.isGlobal.toString(),
+        installMode: install.installMode.toString()
+    };
+}
 
 export class EventCancellationError extends Error
 {

--- a/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/ErrorHandler.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import * as fs from 'fs';
 import open = require('open');
-import { DotnetCoreAcquisitionWorker } from '../Acquisition/DotnetCoreAcquisitionWorker';
+import { getDefaultArchitecture } from '../Acquisition/ArchitectureUtilities';
 import { GetDotnetInstallInfo } from '../Acquisition/DotnetInstall';
 import { IAcquisitionWorkerContext } from '../Acquisition/IAcquisitionWorkerContext';
 import
@@ -86,7 +86,7 @@ export async function callWithErrorHandling<T>(callback: () => T, context: IIssu
         {
             const installInfo = GetDotnetInstallInfo(acquireContext.acquisitionContext.version, acquireContext.acquisitionContext.mode!,
                 acquireContext.acquisitionContext.installType ?? 'local', acquireContext.acquisitionContext.architecture ??
-                DotnetCoreAcquisitionWorker.defaultArchitecture());
+                getDefaultArchitecture());
             // Remove this when https://github.com/typescript-eslint/typescript-eslint/issues/2728 is done
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             const originalEventName = (caughtError?.eventType) ?? 'Unknown';

--- a/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
@@ -67,6 +67,17 @@ export function getVersionFromLegacyInstallId(installId: string): string
 {
     if (isGlobalLegacyInstallId(installId))
     {
+        // Global install ids are encoded as `${version}-global~${arch}...` (see getInstallIdCustomArchitecture).
+        // The version itself may contain dashes (e.g. a pre-release build like 11.0.100-preview.6.26352.110), so we
+        // must split on the `-global` marker rather than the first dash, otherwise the version would be truncated
+        // (e.g. to 11.0.100) and no longer match the tracked install record.
+        const globalMarkerIndex = installId.indexOf('-global');
+        if (globalMarkerIndex !== -1)
+        {
+            return installId.substring(0, globalMarkerIndex);
+        }
+
+        // Fallback for malformed ids that contain 'global' without the canonical '-global' marker.
         const splitId = installId.split('-');
         return splitId[0];
     }

--- a/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
@@ -68,7 +68,7 @@ export function getVersionFromLegacyInstallId(installId: string): string
     if (isGlobalLegacyInstallId(installId))
     {
         // Global install ids are encoded as `${version}-global~${arch}...` but the version may contain dashes
-        const globalMarkerIndex = installId.indexOf('-global');
+        const globalMarkerIndex = installId.toLowerCase().indexOf('-global');
         if (globalMarkerIndex !== -1)
         {
             return installId.substring(0, globalMarkerIndex);

--- a/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { DotnetCoreAcquisitionWorker } from '../Acquisition/DotnetCoreAcquisitionWorker';
+import { getDefaultArchitecture } from '../Acquisition/ArchitectureUtilities';
 import { DotnetInstall, looksLikeRuntimeVersion } from '../Acquisition/DotnetInstall';
 import { DOTNET_INSTALL_MODE_LIST, DotnetInstallMode } from '../Acquisition/DotnetInstallMode';
 import { IAcquisitionWorkerContext } from '../Acquisition/IAcquisitionWorkerContext';
@@ -19,7 +19,7 @@ export function getInstallIdCustomArchitecture(version: string, architecture: st
     }
     else if (architecture === undefined)
     {
-        architecture = DotnetCoreAcquisitionWorker.defaultArchitecture();
+        architecture = getDefaultArchitecture();
     }
 
     return installType === 'global' ? `${version}-global~${architecture}${mode === 'aspnetcore' ? '~aspnetcore' : ''}` :
@@ -97,7 +97,7 @@ export function getAssumedInstallInfo(id: string, mode: DotnetInstallMode | null
     return {
         installId: id,
         version: getVersionFromLegacyInstallId(id),
-        architecture: getArchFromLegacyInstallId(id) ?? DotnetCoreAcquisitionWorker.defaultArchitecture(),
+        architecture: getArchFromLegacyInstallId(id) ?? getDefaultArchitecture(),
         isGlobal: isGlobalLegacyInstallId(id),
 
         // This code is for legacy install strings where the info was not recorded.

--- a/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
@@ -67,10 +67,7 @@ export function getVersionFromLegacyInstallId(installId: string): string
 {
     if (isGlobalLegacyInstallId(installId))
     {
-        // Global install ids are encoded as `${version}-global~${arch}...` (see getInstallIdCustomArchitecture).
-        // The version itself may contain dashes (e.g. a pre-release build like 11.0.100-preview.6.26352.110), so we
-        // must split on the `-global` marker rather than the first dash, otherwise the version would be truncated
-        // (e.g. to 11.0.100) and no longer match the tracked install record.
+        // Global install ids are encoded as `${version}-global~${arch}...` but the version may contain dashes
         const globalMarkerIndex = installId.indexOf('-global');
         if (globalMarkerIndex !== -1)
         {

--- a/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
+++ b/vscode-dotnet-runtime-library/src/Utils/InstallIdUtilities.ts
@@ -103,7 +103,7 @@ export function getAssumedInstallInfo(id: string, mode: DotnetInstallMode | null
         // This code is for legacy install strings where the info was not recorded.
         // At the time only runtime or sdk was permitted and there were no outlier edge case versions that would be wrong.
         // So this assumption can hold true below. Do not utilize this going forward for new code.
-        installMode: mode ?? isRuntimeInstallId(id) ? 'runtime' : 'sdk'
+        installMode: mode ?? (isRuntimeInstallId(id) ? 'runtime' : 'sdk')
     };
 }
 

--- a/vscode-dotnet-runtime-library/src/test/mocks/mock-channel-11-preview-index.json
+++ b/vscode-dotnet-runtime-library/src/test/mocks/mock-channel-11-preview-index.json
@@ -1,0 +1,57 @@
+{
+    "channel-version": "11.0",
+    "latest-sdk": "11.0.100-preview.6.26352.110",
+    "releases": [
+        {
+            "sdks": [
+                {
+                    "version": "11.0.100-preview.6.26352.110",
+                    "files": [
+                        {
+                            "name": "dotnet-sdk-11.0.100-preview.6.26352.110-win-x64.exe",
+                            "rid": "win-x64",
+                            "url": "https://download.visualstudio.microsoft.com/dotnet-sdk-11.0.100-preview.6.26352.110-win-x64.exe",
+                            "hash": "preview-hash"
+                        },
+                        {
+                            "name": "dotnet-sdk-11.0.100-preview.6.26352.110-win-x86.exe",
+                            "rid": "win-x86",
+                            "url": "https://download.visualstudio.microsoft.com/dotnet-sdk-11.0.100-preview.6.26352.110-win-x86.exe",
+                            "hash": "preview-hash"
+                        },
+                        {
+                            "name": "dotnet-sdk-11.0.100-preview.6.26352.110-win-arm64.exe",
+                            "rid": "win-arm64",
+                            "url": "https://download.visualstudio.microsoft.com/dotnet-sdk-11.0.100-preview.6.26352.110-win-arm64.exe",
+                            "hash": "preview-hash"
+                        },
+                        {
+                            "name": "dotnet-sdk-11.0.100-preview.6.26352.110-osx-x64.pkg",
+                            "rid": "osx-x64",
+                            "url": "https://download.visualstudio.microsoft.com/dotnet-sdk-11.0.100-preview.6.26352.110-osx-x64.pkg",
+                            "hash": "preview-hash"
+                        },
+                        {
+                            "name": "dotnet-sdk-11.0.100-preview.6.26352.110-osx-arm64.pkg",
+                            "rid": "osx-arm64",
+                            "url": "https://download.visualstudio.microsoft.com/dotnet-sdk-11.0.100-preview.6.26352.110-osx-arm64.pkg",
+                            "hash": "preview-hash"
+                        },
+                        {
+                            "name": "dotnet-sdk-11.0.100-preview.6.26352.110-linux-x64.tar.gz",
+                            "rid": "linux-x64",
+                            "url": "https://download.visualstudio.microsoft.com/dotnet-sdk-11.0.100-preview.6.26352.110-linux-x64.tar.gz",
+                            "hash": "preview-hash"
+                        },
+                        {
+                            "name": "dotnet-sdk-11.0.100-preview.6.26352.110-linux-arm64.tar.gz",
+                            "rid": "linux-arm64",
+                            "url": "https://download.visualstudio.microsoft.com/dotnet-sdk-11.0.100-preview.6.26352.110-linux-arm64.tar.gz",
+                            "hash": "preview-hash"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetConditionValidator.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetConditionValidator.test.ts
@@ -282,4 +282,34 @@ suite('DotnetConditionValidator Unit Tests', function ()
         isAccepted = conditionValidator.stringVersionMeetsRequirement('9.0.0', '9.0.0', { acquireContext: runtimeContext, versionSpecRequirement: 'disable' });
         assert.isTrue(isAccepted, 'disable takes the exact matching x.y.0 runtime');
     });
+
+    test('rollForward compares pre-release suffixes when feature-band patches are equal', async () =>
+    {
+        const conditionValidator = new DotnetConditionValidator(acquisitionContext, utilityContext, mockExecutor);
+        const sdkContext = lodash.cloneDeep(acquisitionContext.acquisitionContext);
+        sdkContext.mode = 'sdk';
+        const requirement = { acquireContext: sdkContext, versionSpecRequirement: 'greater_than_or_equal' as const };
+
+        let isAccepted = conditionValidator.stringVersionMeetsRequirement('11.0.100-preview.6.26352.110', '11.0.100-preview.5.26352.110', requirement);
+        assert.isTrue(isAccepted, 'a later preview satisfies an earlier preview request');
+
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('11.0.100-preview.5.26352.110', '11.0.100-preview.6.26352.110', requirement);
+        assert.isFalse(isAccepted, 'an earlier preview does not satisfy a later preview request');
+
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('11.0.100', '11.0.100-preview.6.26352.110', requirement);
+        assert.isTrue(isAccepted, 'the RTM satisfies a preview request for the same feature-band patch');
+
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('11.0.100-preview.6.26352.110', '11.0.100', requirement);
+        assert.isFalse(isAccepted, 'a preview does not satisfy an RTM request for the same feature-band patch');
+
+        const latestPatchRequirement = { acquireContext: sdkContext, versionSpecRequirement: 'latestPatch' as const };
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('11.0.100-preview.5.26352.110', '11.0.100-preview.6.26352.110', latestPatchRequirement);
+        assert.isFalse(isAccepted, 'latestPatch does not roll forward to an earlier preview in the same feature band');
+
+        const runtimeContext = lodash.cloneDeep(acquisitionContext.acquisitionContext);
+        runtimeContext.mode = 'runtime';
+        const runtimeRequirement = { acquireContext: runtimeContext, versionSpecRequirement: 'greater_than_or_equal' as const };
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('9.0.0-rc.1.24431.7', '9.0.0-rc.2.24473.5', runtimeRequirement);
+        assert.isFalse(isAccepted, 'an earlier runtime release candidate does not satisfy a later release candidate request');
+    });
 });

--- a/vscode-dotnet-runtime-library/src/test/unit/DotnetConditionValidator.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/DotnetConditionValidator.test.ts
@@ -236,4 +236,50 @@ suite('DotnetConditionValidator Unit Tests', function ()
         isAccepted = conditionValidator.stringVersionMeetsRequirement('9.0.1', '9.0.1', { acquireContext: contextThatCanBeIgnoredExceptMode, versionSpecRequirement: 'disable' });
         assert.isTrue(isAccepted, 'disable only takes the exact match sdk');
     });
+
+    test('rollForward disable distinguishes preview identity', async () =>
+    {
+        const conditionValidator = new DotnetConditionValidator(acquisitionContext, utilityContext, mockExecutor);
+
+        const sdkContext = lodash.cloneDeep(acquisitionContext.acquisitionContext);
+        sdkContext.mode = 'sdk';
+
+        // A different preview of the same feature-band patch must not satisfy an exact request.
+        let isAccepted = conditionValidator.stringVersionMeetsRequirement('11.0.100-preview.5.26352.110', '11.0.100-preview.6.26352.110', { acquireContext: sdkContext, versionSpecRequirement: 'disable' });
+        assert.isNotTrue(isAccepted, 'disable rejects a different preview of the same sdk patch');
+
+        // A stable release must not satisfy an exact preview request (and vice-versa).
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('11.0.100', '11.0.100-preview.6.26352.110', { acquireContext: sdkContext, versionSpecRequirement: 'disable' });
+        assert.isNotTrue(isAccepted, 'disable rejects the RTM when an exact preview is requested');
+
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('11.0.100-preview.6.26352.110', '11.0.100', { acquireContext: sdkContext, versionSpecRequirement: 'disable' });
+        assert.isNotTrue(isAccepted, 'disable rejects a preview when the RTM is requested');
+
+        // The exact same preview satisfies the request.
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('11.0.100-preview.6.26352.110', '11.0.100-preview.6.26352.110', { acquireContext: sdkContext, versionSpecRequirement: 'disable' });
+        assert.isTrue(isAccepted, 'disable takes the exact matching preview sdk');
+
+        // A stable-vs-stable exact match is unaffected by the pre-release identity check.
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('11.0.100', '11.0.100', { acquireContext: sdkContext, versionSpecRequirement: 'disable' });
+        assert.isTrue(isAccepted, 'disable still takes the exact matching stable sdk');
+
+        // Runtime pre-release identity is likewise exact, including for x.y.0 previews (patch 0).
+        const runtimeContext = lodash.cloneDeep(acquisitionContext.acquisitionContext);
+        runtimeContext.mode = 'runtime';
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('9.0.0-rc.1.24431.7', '9.0.0-rc.2.24473.5', { acquireContext: runtimeContext, versionSpecRequirement: 'disable' });
+        assert.isNotTrue(isAccepted, 'disable rejects a different preview of the same runtime patch');
+
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('9.0.0', '9.0.0-rc.2.24473.5', { acquireContext: runtimeContext, versionSpecRequirement: 'disable' });
+        assert.isNotTrue(isAccepted, 'disable rejects the RTM when an exact runtime preview is requested');
+
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('9.0.0-rc.2.24473.5', '9.0.0-rc.2.24473.5', { acquireContext: runtimeContext, versionSpecRequirement: 'disable' });
+        assert.isTrue(isAccepted, 'disable takes the exact matching preview runtime');
+
+        // The x.y.0 guard fix also makes exact stable runtime matching correct (no longer matches any x.y.*).
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('9.0.5', '9.0.0', { acquireContext: runtimeContext, versionSpecRequirement: 'disable' });
+        assert.isNotTrue(isAccepted, 'disable does not match a higher patch when x.y.0 is requested');
+
+        isAccepted = conditionValidator.stringVersionMeetsRequirement('9.0.0', '9.0.0', { acquireContext: runtimeContext, versionSpecRequirement: 'disable' });
+        assert.isTrue(isAccepted, 'disable takes the exact matching x.y.0 runtime');
+    });
 });

--- a/vscode-dotnet-runtime-library/src/test/unit/GlobalInstallerResolver.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/GlobalInstallerResolver.test.ts
@@ -18,11 +18,13 @@ const featureBandVersion = '7.0.1xx';
 const newestFeatureBandedVersion = '7.0.109';
 const majorOnly = '7';
 const majorMinorOnly = '7.0';
+const previewVersion = '11.0.100-preview.6.26352.110';
 
 const context = new MockExtensionContext();
 const eventStream = new MockEventStream();
 const filePath = path.join(__dirname, '../../..', 'src', 'test', 'mocks', 'mock-channel-7-index.json');
 const otherUrlFilePath = path.join(__dirname, '../../..', 'src', 'test', 'mocks', 'mock-channel-6-index.json');
+const previewFilePath = path.join(__dirname, '../../..', 'src', 'test', 'mocks', 'mock-channel-11-preview-index.json');
 const timeoutTime = 10000;
 
 suite('Global Installer Resolver Tests', function ()
@@ -83,6 +85,17 @@ suite('Global Installer Resolver Tests', function ()
         {
             assert.include(installerUrl, 'pkg');
         }
+    });
+
+    test('It resolves a fully specified preview SDK', async () =>
+    {
+        const acquisitionContext = getMockAcquisitionContext('sdk', previewVersion);
+        const provider = new GlobalInstallerResolver(acquisitionContext, previewVersion);
+        provider.customWebRequestWorker = new FileWebRequestWorker(previewFilePath);
+
+        assert.equal(await provider.getFullySpecifiedVersion(), previewVersion);
+        assert.include(await provider.getInstallerUrl(), previewVersion);
+        assert.equal(await provider.getInstallerHash(), 'preview-hash');
     });
 
     test('It parses the major format', async () =>

--- a/vscode-dotnet-runtime-library/src/test/unit/InstallIdUtilities.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/InstallIdUtilities.test.ts
@@ -5,7 +5,7 @@
 import * as chai from 'chai';
 import * as os from 'os';
 import { looksLikeRuntimeVersion } from '../../Acquisition/DotnetInstall';
-import { getInstallIdCustomArchitecture, getVersionFromLegacyInstallId } from '../../Utils/InstallIdUtilities';
+import { getAssumedInstallInfo, getInstallIdCustomArchitecture, getVersionFromLegacyInstallId } from '../../Utils/InstallIdUtilities';
 
 const assert = chai.assert;
 
@@ -52,5 +52,10 @@ suite('Install Id Utilities Unit Tests', function ()
         assert.equal(looksLikeRuntimeVersion(stableVersion), false, 'A stable SDK feature-band version is not a runtime version');
         assert.equal(looksLikeRuntimeVersion('8.0.19'), true, 'A stable runtime patch version is a runtime version');
         assert.equal(looksLikeRuntimeVersion('9.0.0-rc.2.24473.5'), true, 'A preview runtime patch version is a runtime version');
+    });
+
+    test('It preserves an explicit install mode when assuming legacy install info', async () =>
+    {
+        assert.equal(getAssumedInstallInfo('8.0.19', 'sdk').installMode, 'sdk');
     });
 });

--- a/vscode-dotnet-runtime-library/src/test/unit/InstallIdUtilities.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/InstallIdUtilities.test.ts
@@ -23,6 +23,9 @@ suite('Install Id Utilities Unit Tests', function ()
 
         const rcId = getInstallIdCustomArchitecture(rcVersion, os.arch(), 'sdk', 'global');
         assert.equal(getVersionFromLegacyInstallId(rcId), rcVersion, 'The full rc version is recovered from the global install id');
+
+        const mixedCaseMarkerId = previewId.replace('-global', '-GLOBAL');
+        assert.equal(getVersionFromLegacyInstallId(mixedCaseMarkerId), previewVersion, 'The full preview version is recovered from a mixed-case global marker');
     });
 
     test('It extracts the version from a stable global install id', async () =>

--- a/vscode-dotnet-runtime-library/src/test/unit/InstallIdUtilities.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/InstallIdUtilities.test.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+*  Licensed to the .NET Foundation under one or more agreements.
+*  The .NET Foundation licenses this file to you under the MIT license.
+*--------------------------------------------------------------------------------------------*/
+import * as chai from 'chai';
+import * as os from 'os';
+import { looksLikeRuntimeVersion } from '../../Acquisition/DotnetInstall';
+import { getInstallIdCustomArchitecture, getVersionFromLegacyInstallId } from '../../Utils/InstallIdUtilities';
+
+const assert = chai.assert;
+
+const stableVersion = '8.0.100';
+const previewVersion = '11.0.100-preview.6.26352.110';
+const rcVersion = '9.0.100-rc.2.24473.5';
+
+suite('Install Id Utilities Unit Tests', function ()
+{
+    test('It extracts the full version from a global preview install id', async () =>
+    {
+        // Regression: the version has dashes, so splitting on the first '-' would truncate it to 11.0.100.
+        const previewId = getInstallIdCustomArchitecture(previewVersion, os.arch(), 'sdk', 'global');
+        assert.equal(getVersionFromLegacyInstallId(previewId), previewVersion, 'The full preview version is recovered from the global install id');
+
+        const rcId = getInstallIdCustomArchitecture(rcVersion, os.arch(), 'sdk', 'global');
+        assert.equal(getVersionFromLegacyInstallId(rcId), rcVersion, 'The full rc version is recovered from the global install id');
+    });
+
+    test('It extracts the version from a stable global install id', async () =>
+    {
+        const stableId = getInstallIdCustomArchitecture(stableVersion, os.arch(), 'sdk', 'global');
+        assert.equal(getVersionFromLegacyInstallId(stableId), stableVersion);
+    });
+
+    test('It extracts the version from a global install id without an architecture', async () =>
+    {
+        const previewId = getInstallIdCustomArchitecture(previewVersion, null, 'sdk', 'global');
+        assert.equal(getVersionFromLegacyInstallId(previewId), previewVersion, 'The full preview version is recovered when no architecture is encoded');
+    });
+
+    test('It extracts the version from a local install id', async () =>
+    {
+        const localId = getInstallIdCustomArchitecture(stableVersion, os.arch(), 'sdk', 'local');
+        assert.equal(getVersionFromLegacyInstallId(localId), stableVersion);
+    });
+
+    test('It classifies SDK and runtime versions including previews', async () =>
+    {
+        assert.equal(looksLikeRuntimeVersion(previewVersion), false, 'A preview SDK feature-band version is not a runtime version');
+        assert.equal(looksLikeRuntimeVersion(stableVersion), false, 'A stable SDK feature-band version is not a runtime version');
+        assert.equal(looksLikeRuntimeVersion('8.0.19'), true, 'A stable runtime patch version is a runtime version');
+        assert.equal(looksLikeRuntimeVersion('9.0.0-rc.2.24473.5'), true, 'A preview runtime patch version is a runtime version');
+    });
+});

--- a/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/InstallTracker.test.ts
@@ -456,6 +456,28 @@ suite('InstallTracker Unit Tests', function ()
 
     }).timeout(defaultTimeoutTime);
 
+    test('It Preserves Pre-Release Suffixes When Converting Legacy Global Install Ids', async () =>
+    {
+        resetExtensionState();
+
+        const tracker = new MockInstallTracker(mockContext.eventStream, mockContext.extensionState);
+        const previewFive = '11.0.100-preview.5.26352.110';
+        const previewSix = '11.0.100-preview.6.26352.110';
+        const previewFiveId = `${previewFive}-global~${os.arch()}`;
+        const previewSixId = `${previewSix}-global~${os.arch()}`;
+        const extensionStateWithLegacyStrings = new MockExtensionContext();
+        extensionStateWithLegacyStrings.update('installed', [previewFiveId, previewSixId]);
+        tracker.setExtensionState(extensionStateWithLegacyStrings);
+
+        const installs = await tracker.getExistingInstalls(mockContext.installDirectoryProvider);
+
+        assert.lengthOf(installs, 2, 'Distinct preview install IDs should remain distinct after migration');
+        assert.sameMembers(installs.map(install => install.dotnetInstall.version), [previewFive, previewSix],
+            'Legacy global preview IDs should retain their complete versions');
+        assert.isTrue(installs.every(install => install.dotnetInstall.isGlobal), 'Migrated records should remain global installs');
+        assert.isTrue(installs.every(install => install.dotnetInstall.installMode === 'sdk'), 'Preview feature-band installs should remain SDK installs');
+    }).timeout(defaultTimeoutTime);
+
     test('It Handles Null Owner Gracefully on Duplicate Install and Removal', async () =>
     {
         resetExtensionState();

--- a/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LinuxDistroTests.test.ts
@@ -49,7 +49,7 @@ suite('Linux Distro Logic Unit Tests', function ()
         if (shouldRun)
         {
             const recVersion = await provider.getRecommendedDotnetVersion(installType);
-            const correctVersion = await getLinuxSupportedDotnetSDKVersion(acquisitionContext);
+            const correctVersion = await getLinuxSupportedDotnetSDKVersion(acquisitionContext, pair);
             const correctXXVersion = `${versionUtils.getMajorMinor(correctVersion, acquisitionContext.eventStream, acquisitionContext)}.1xx`;
             assert.equal(mockExecutor.attemptedCommand,
                 `apt-cache -o DPkg::Lock::Timeout=180 search --names-only ^dotnet-sdk-${versionUtils.getMajorMinor(getLatestLinuxDotnet(), acquisitionContext.eventStream, acquisitionContext)}$`, 'Searched for the newest package last with regex'); // this may fail if test not exec'd first

--- a/vscode-dotnet-runtime-library/src/test/unit/LocalInstallUpdateService.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/LocalInstallUpdateService.test.ts
@@ -168,6 +168,44 @@ suite('LocalInstallUpdateService Unit Tests', function ()
         assert.strictEqual(ownersAdded[0].install.installId, updatedInstall.dotnetInstall.installId, 'Latest install should receive owners');
     });
 
+    test('It selects the RTM over previews with the same runtime patch', async () =>
+    {
+        const onlineStub = {
+            isOnline: async () => true
+        } as unknown as WebRequestWorkerSingleton;
+        (WebRequestWorkerSingleton as unknown as { getInstance: () => WebRequestWorkerSingleton }).getInstance = () => onlineStub;
+
+        const eventStream = new MockEventStream();
+        const extensionState = new MockExtensionContext();
+        extensionState.update('dotnet.latestUpdateDate', new Date(0));
+        const directoryProvider = new TestInstallationDirectoryProvider('/tmp');
+        const currentArch = DotnetCoreAcquisitionWorker.defaultArchitecture();
+        const previewFive = createInstallRecord('11.0.0-preview.5.26352.110', currentArch, 'runtime', ['preview-owner']);
+        const previewSix = createInstallRecord('11.0.0-preview.6.26352.110', currentArch, 'runtime', []);
+        const stable = createInstallRecord('11.0.0', currentArch, 'runtime', []);
+
+        const trackerInstance = LocalUpdateServiceTestTracker.getInstance(eventStream, extensionState);
+        trackerInstance.setInstallSequences([[previewFive, previewSix], [previewFive, previewSix, stable]]);
+
+        const uninstallContexts: IDotnetAcquireContext[] = [];
+        const updateService = new LocalInstallUpdateService(eventStream, extensionState, directoryProvider,
+            async () => undefined,
+            async (uninstallContext: IDotnetAcquireContext) =>
+            {
+                uninstallContexts.push(uninstallContext);
+                return '0';
+            },
+            new MockLoggingObserver(), LocalUpdateServiceTestTracker);
+
+        await updateService.ManageInstalls(0);
+
+        const ownersAdded = trackerInstance.getOwnersAdded();
+        assert.lengthOf(ownersAdded, 1, 'Owners should transfer to the newest install');
+        assert.strictEqual(ownersAdded[0].install.installId, stable.dotnetInstall.installId, 'RTM should be selected over equal-patch previews');
+        assert.sameMembers(uninstallContexts.map(context => context.version), [previewFive.dotnetInstall.version, previewSix.dotnetInstall.version],
+            'Both preview installs should be removed after RTM is selected');
+    });
+
     test('It removes outdated installs when using the real tracker implementation', async () =>
     {
         const onlineStub = {

--- a/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/TestUtility.ts
@@ -174,5 +174,5 @@ export async function getLinuxSupportedDotnetSDKVersion(context: IAcquisitionWor
 
 export function getLatestLinuxDotnet()
 {
-    return '10.0.100';
+    return '11.0.100';
 }

--- a/vscode-dotnet-runtime-library/src/test/unit/VersionUtilities.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/VersionUtilities.test.ts
@@ -145,6 +145,13 @@ suite('Version Utilities Unit Tests', function ()
         assert.equal(resolver.getVersionWithoutPreReleaseSuffix(fullySpecifiedVersion), fullySpecifiedVersion, 'It leaves a stable version unchanged');
     });
 
+    test('Extracts Pre-Release Suffix From Version', async () =>
+    {
+        assert.equal(resolver.getPreReleaseSuffix(previewVersion), 'preview.6.26352.110');
+        assert.equal(resolver.getPreReleaseSuffix(rcVersion), 'rc.2.24473.5');
+        assert.equal(resolver.getPreReleaseSuffix(fullySpecifiedVersion), '', 'A stable version has no pre-release suffix');
+    });
+
     test('Compares SDK Patch Or Pre-Release', async () =>
     {
         // Different feature-band patch numbers compare numerically.

--- a/vscode-dotnet-runtime-library/src/test/unit/VersionUtilities.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/VersionUtilities.test.ts
@@ -95,17 +95,17 @@ suite('Version Utilities Unit Tests', function ()
         assert.equal(resolver.getFeatureBandPatchVersion('8.0.400-preview.0.24324.5', mockEventStream, mockCtx), '0');
     });
 
-    test('Detects IsPreview Version', async () =>
+    test('Detects Pre-Release Suffix', async () =>
     {
-        assert.equal(resolver.isPreviewVersion('8.0.400-preview.0.24324.5', mockEventStream, mockCtx), true);
-        assert.equal(resolver.isPreviewVersion('9.0.0-rc.2', mockEventStream, mockCtx), true);
-        assert.equal(resolver.isPreviewVersion('9.0.0-rc.2.24473.5', mockEventStream, mockCtx), true);
-        assert.equal(resolver.isPreviewVersion('9.0.0-rc.2.24473.5', mockEventStream, mockCtx), true);
-        assert.equal(resolver.isPreviewVersion('8.0.0-preview.7', mockEventStream, mockCtx), true);
-        assert.equal(resolver.isPreviewVersion('10.0.0-alpha.2.24522.8', mockEventStream, mockCtx), true);
-        assert.equal(resolver.isPreviewVersion(featureBandVersion, mockEventStream, mockCtx), false);
-        assert.equal(resolver.isPreviewVersion(majorMinorOnly, mockEventStream, mockCtx), false);
-        assert.equal(resolver.isPreviewVersion(badSDKVersionPatch, mockEventStream, mockCtx), false);
+        assert.equal(resolver.hasPreReleaseSuffix('8.0.400-preview.0.24324.5'), true);
+        assert.equal(resolver.hasPreReleaseSuffix('9.0.0-rc.2'), true);
+        assert.equal(resolver.hasPreReleaseSuffix('9.0.0-rc.2.24473.5'), true);
+        assert.equal(resolver.hasPreReleaseSuffix('8.0.0-preview.7'), true);
+        assert.equal(resolver.hasPreReleaseSuffix('10.0.0-alpha.2.24522.8'), true);
+        assert.equal(resolver.hasPreReleaseSuffix(featureBandVersion), false);
+        assert.equal(resolver.hasPreReleaseSuffix(majorMinorOnly), false);
+        assert.equal(resolver.hasPreReleaseSuffix(badSDKVersionPatch), false);
+        assert.equal(resolver.hasPreReleaseSuffix('8.0.100-'), false, 'A delimiter without content is not a suffix');
     });
 
     test('Detects Unspecified Patch Version', async () =>
@@ -125,6 +125,7 @@ suite('Version Utilities Unit Tests', function ()
         assert.equal(resolver.isFullySpecifiedVersion(majorMinorOnly, mockEventStream, mockCtx), false, 'It detects major.minor as not fully specified');
         assert.equal(resolver.isFullySpecifiedVersion(previewVersion, mockEventStream, mockCtx), true, 'It counts a fully specified preview build as fully specified');
         assert.equal(resolver.isFullySpecifiedVersion(rcVersion, mockEventStream, mockCtx), true, 'It counts a fully specified rc build as fully specified');
+        assert.equal(resolver.isFullySpecifiedVersion('-foo', mockEventStream, mockCtx), false, 'A suffix without a numeric version is not fully specified');
     });
 
     test('Detects if Fully Specified Preview Version', async () =>
@@ -136,6 +137,7 @@ suite('Version Utilities Unit Tests', function ()
         assert.equal(resolver.isFullySpecifiedPreviewVersion(featureBandVersion, mockEventStream, mockCtx), false, 'A feature band is not a fully specified preview');
         assert.equal(resolver.isFullySpecifiedPreviewVersion(majorMinorOnly, mockEventStream, mockCtx), false, 'A major.minor is not a fully specified preview');
         assert.equal(resolver.isFullySpecifiedPreviewVersion('11.0-preview.6', mockEventStream, mockCtx), false, 'A partial version with a suffix is not fully specified');
+        assert.equal(resolver.isFullySpecifiedPreviewVersion('-foo', mockEventStream, mockCtx), false, 'A suffix without a numeric version is not fully specified');
     });
 
     test('Strips Pre-Release Suffix From Version', async () =>

--- a/vscode-dotnet-runtime-library/src/test/unit/VersionUtilities.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/VersionUtilities.test.ts
@@ -126,6 +126,8 @@ suite('Version Utilities Unit Tests', function ()
         assert.equal(resolver.isFullySpecifiedVersion(previewVersion, mockEventStream, mockCtx), true, 'It counts a fully specified preview build as fully specified');
         assert.equal(resolver.isFullySpecifiedVersion(rcVersion, mockEventStream, mockCtx), true, 'It counts a fully specified rc build as fully specified');
         assert.equal(resolver.isFullySpecifiedVersion('-foo', mockEventStream, mockCtx), false, 'A suffix without a numeric version is not fully specified');
+        assert.equal(resolver.isFullySpecifiedVersion('10.0.100-foo', mockEventStream, mockCtx), false, 'An unknown pre-release suffix is not fully specified');
+        assert.equal(resolver.isFullySpecifiedVersion('10.0.100-bar-1.3', mockEventStream, mockCtx), false, 'An unknown compound pre-release suffix is not fully specified');
     });
 
     test('Detects if Fully Specified Preview Version', async () =>
@@ -133,11 +135,16 @@ suite('Version Utilities Unit Tests', function ()
         assert.equal(resolver.isFullySpecifiedPreviewVersion(previewVersion, mockEventStream, mockCtx), true, 'It detects a fully specified preview build');
         assert.equal(resolver.isFullySpecifiedPreviewVersion(rcVersion, mockEventStream, mockCtx), true, 'It detects a fully specified rc build');
         assert.equal(resolver.isFullySpecifiedPreviewVersion('8.0.400-preview.0.24324.5', mockEventStream, mockCtx), true);
+        assert.equal(resolver.isFullySpecifiedPreviewVersion('1.0.100-preview2.1-003177', mockEventStream, mockCtx), true, 'It supports the historical .NET Core preview format');
         assert.equal(resolver.isFullySpecifiedPreviewVersion(fullySpecifiedVersion, mockEventStream, mockCtx), false, 'A stable fully specified version is not a preview');
         assert.equal(resolver.isFullySpecifiedPreviewVersion(featureBandVersion, mockEventStream, mockCtx), false, 'A feature band is not a fully specified preview');
         assert.equal(resolver.isFullySpecifiedPreviewVersion(majorMinorOnly, mockEventStream, mockCtx), false, 'A major.minor is not a fully specified preview');
         assert.equal(resolver.isFullySpecifiedPreviewVersion('11.0-preview.6', mockEventStream, mockCtx), false, 'A partial version with a suffix is not fully specified');
         assert.equal(resolver.isFullySpecifiedPreviewVersion('-foo', mockEventStream, mockCtx), false, 'A suffix without a numeric version is not fully specified');
+        assert.equal(resolver.isFullySpecifiedPreviewVersion('10.0.100-foo', mockEventStream, mockCtx), false, 'An unknown pre-release suffix is not fully specified');
+        assert.equal(resolver.isFullySpecifiedPreviewVersion('10.0.100-bar-1.3', mockEventStream, mockCtx), false, 'An unknown compound pre-release suffix is not fully specified');
+        assert.equal(resolver.isFullySpecifiedPreviewVersion('2.2.100-rel-33220-00', mockEventStream, mockCtx), false, 'A package-only Native suffix is not supported without release metadata');
+        assert.equal(resolver.isFullySpecifiedPreviewVersion('4.8.100-arm64rel-26502-00', mockEventStream, mockCtx), false, 'A package-only Native ARM64 suffix is not supported without release metadata');
     });
 
     test('Strips Pre-Release Suffix From Version', async () =>

--- a/vscode-dotnet-runtime-library/src/test/unit/VersionUtilities.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/VersionUtilities.test.ts
@@ -17,6 +17,8 @@ const twoDigitMajorVersion = '10.0.102';
 const featureBandVersion = '7.0.2xx';
 const majorOnly = '7';
 const majorMinorOnly = '7.0';
+const previewVersion = '11.0.100-preview.6.26352.110';
+const rcVersion = '9.0.100-rc.2.24473.5';
 
 const badSDKVersionPeriods = '10.10';
 const badSDKVersionPatch = '7.1.10';
@@ -121,6 +123,43 @@ suite('Version Utilities Unit Tests', function ()
         assert.equal(resolver.isFullySpecifiedVersion(majorOnly, mockEventStream, mockCtx), false, 'It detects major only versions are not fully specified');
         assert.equal(resolver.isFullySpecifiedVersion(featureBandVersion, mockEventStream, mockCtx), false, 'It counts feature band only with xxx as not fully specified');
         assert.equal(resolver.isFullySpecifiedVersion(majorMinorOnly, mockEventStream, mockCtx), false, 'It detects major.minor as not fully specified');
+        assert.equal(resolver.isFullySpecifiedVersion(previewVersion, mockEventStream, mockCtx), true, 'It counts a fully specified preview build as fully specified');
+        assert.equal(resolver.isFullySpecifiedVersion(rcVersion, mockEventStream, mockCtx), true, 'It counts a fully specified rc build as fully specified');
+    });
+
+    test('Detects if Fully Specified Preview Version', async () =>
+    {
+        assert.equal(resolver.isFullySpecifiedPreviewVersion(previewVersion, mockEventStream, mockCtx), true, 'It detects a fully specified preview build');
+        assert.equal(resolver.isFullySpecifiedPreviewVersion(rcVersion, mockEventStream, mockCtx), true, 'It detects a fully specified rc build');
+        assert.equal(resolver.isFullySpecifiedPreviewVersion('8.0.400-preview.0.24324.5', mockEventStream, mockCtx), true);
+        assert.equal(resolver.isFullySpecifiedPreviewVersion(fullySpecifiedVersion, mockEventStream, mockCtx), false, 'A stable fully specified version is not a preview');
+        assert.equal(resolver.isFullySpecifiedPreviewVersion(featureBandVersion, mockEventStream, mockCtx), false, 'A feature band is not a fully specified preview');
+        assert.equal(resolver.isFullySpecifiedPreviewVersion(majorMinorOnly, mockEventStream, mockCtx), false, 'A major.minor is not a fully specified preview');
+        assert.equal(resolver.isFullySpecifiedPreviewVersion('11.0-preview.6', mockEventStream, mockCtx), false, 'A partial version with a suffix is not fully specified');
+    });
+
+    test('Strips Pre-Release Suffix From Version', async () =>
+    {
+        assert.equal(resolver.getVersionWithoutPreReleaseSuffix(previewVersion), '11.0.100');
+        assert.equal(resolver.getVersionWithoutPreReleaseSuffix(rcVersion), '9.0.100');
+        assert.equal(resolver.getVersionWithoutPreReleaseSuffix(fullySpecifiedVersion), fullySpecifiedVersion, 'It leaves a stable version unchanged');
+    });
+
+    test('Compares SDK Patch Or Pre-Release', async () =>
+    {
+        // Different feature-band patch numbers compare numerically.
+        assert.isBelow(resolver.compareSDKPatchOrPreRelease('7.0.301', '7.0.311', mockEventStream, mockCtx), 0, '301 is older than 311');
+        assert.isAbove(resolver.compareSDKPatchOrPreRelease('7.0.311', '7.0.301', mockEventStream, mockCtx), 0, '311 is newer than 301');
+        assert.equal(resolver.compareSDKPatchOrPreRelease('7.0.301', '7.0.301', mockEventStream, mockCtx), 0, 'Identical stable versions are equal');
+
+        // Same feature-band patch, differing pre-release identity.
+        assert.isBelow(resolver.compareSDKPatchOrPreRelease('11.0.100-preview.5.26352.110', '11.0.100-preview.6.26352.110', mockEventStream, mockCtx), 0, 'preview.5 is older than preview.6');
+        assert.isAbove(resolver.compareSDKPatchOrPreRelease('11.0.100-preview.6.26352.110', '11.0.100-preview.5.26352.110', mockEventStream, mockCtx), 0, 'preview.6 is newer than preview.5');
+        assert.equal(resolver.compareSDKPatchOrPreRelease('11.0.100-preview.6.26352.110', '11.0.100-preview.6.26352.110', mockEventStream, mockCtx), 0, 'Identical preview builds are equal');
+
+        // A stable release outranks a pre-release with the same numeric patch.
+        assert.isAbove(resolver.compareSDKPatchOrPreRelease('11.0.100', '11.0.100-preview.6.26352.110', mockEventStream, mockCtx), 0, 'A stable release is newer than its preview');
+        assert.isBelow(resolver.compareSDKPatchOrPreRelease('11.0.100-preview.6.26352.110', '11.0.100', mockEventStream, mockCtx), 0, 'A preview is older than its stable release');
     });
 
     test('Detects if Only Major or Minor Given', async () =>

--- a/vscode-dotnet-runtime-library/src/test/unit/VersionUtilities.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/VersionUtilities.test.ts
@@ -169,6 +169,26 @@ suite('Version Utilities Unit Tests', function ()
         assert.isBelow(resolver.compareSDKPatchOrPreRelease('11.0.100-preview.6.26352.110', '11.0.100', mockEventStream, mockCtx), 0, 'A preview is older than its stable release');
     });
 
+    test('Compares Versions Including Pre-Release (runtime + sdk)', async () =>
+    {
+        // Runtime patch ordering.
+        assert.isBelow(resolver.compareVersionsIncludingPreRelease('8.0.5', '8.0.19'), 0, '8.0.5 is older than 8.0.19');
+        assert.isAbove(resolver.compareVersionsIncludingPreRelease('8.0.19', '8.0.5'), 0, '8.0.19 is newer than 8.0.5');
+
+        // SDK feature-band patch ordering.
+        assert.isBelow(resolver.compareVersionsIncludingPreRelease('8.0.301', '8.0.311'), 0, '8.0.301 is older than 8.0.311');
+
+        // Pre-release ordering for both runtime and SDK.
+        assert.isBelow(resolver.compareVersionsIncludingPreRelease('9.0.0-rc.1.24431.7', '9.0.0-rc.2.24473.5'), 0, 'rc.1 is older than rc.2');
+        assert.isAbove(resolver.compareVersionsIncludingPreRelease('9.0.0', '9.0.0-rc.2.24473.5'), 0, 'A stable runtime release is newer than its rc');
+        assert.isBelow(resolver.compareVersionsIncludingPreRelease('11.0.100-preview.5.26352.110', '11.0.100-preview.6.26352.110'), 0, 'sdk preview.5 is older than preview.6');
+        assert.equal(resolver.compareVersionsIncludingPreRelease('8.0.19', '8.0.19'), 0, 'Identical versions are equivalent');
+
+        // .NET releases order preview < rc < GA within a base version; semver identifier ordering matches this.
+        assert.isBelow(resolver.compareVersionsIncludingPreRelease('9.0.0-preview.7.24405.7', '9.0.0-rc.1.24431.7'), 0, 'preview is older than rc');
+        assert.isBelow(resolver.compareVersionsIncludingPreRelease('9.0.0-rc.2.24473.5', '9.0.0'), 0, 'rc is older than GA');
+    });
+
     test('Detects if Only Major or Minor Given', async () =>
     {
         assert.equal(resolver.isNonSpecificMajorOrMajorMinorVersion(fullySpecifiedVersion), false, 'It does not think a fully specified version is major.minor only');

--- a/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
+++ b/vscode-dotnet-runtime-library/src/test/unit/WinMacGlobalInstaller.test.ts
@@ -99,6 +99,42 @@ suite('Windows & Mac Global Installer Tests', function ()
         }
     });
 
+    test('It treats a newer preview of the same feature-band patch as an upgrade, not a conflict', async () =>
+    {
+        if (os.platform() === 'win32')
+        {
+            const installedPreview = '11.0.100-preview.5.26352.110';
+            const requestedNewerPreview = '11.0.100-preview.6.26352.110';
+
+            mockExecutor.fakeReturnValue = {
+                stdout: `
+        ${installedPreview}    REG_DWORD    0x1
+       `,
+                status: '0',
+                stderr: ''
+            };
+
+            // preview.6 is newer than the installed preview.5 (same numeric feature-band patch), so it should upgrade.
+            let conflictExists = await installer.GlobalWindowsInstallWithConflictingVersionAlreadyExists(requestedNewerPreview);
+            assert.deepStrictEqual(conflictExists, '', 'A newer preview of the same patch is not a conflict');
+
+            // Requesting the exact installed preview is an existing install (conflict).
+            conflictExists = await installer.GlobalWindowsInstallWithConflictingVersionAlreadyExists(installedPreview);
+            assert.deepStrictEqual(conflictExists, installedPreview, 'The exact same preview is treated as already installed');
+
+            // Requesting an older preview when a newer one is installed is a conflict (do not downgrade).
+            mockExecutor.fakeReturnValue = {
+                stdout: `
+        ${requestedNewerPreview}    REG_DWORD    0x1
+       `,
+                status: '0',
+                stderr: ''
+            };
+            conflictExists = await installer.GlobalWindowsInstallWithConflictingVersionAlreadyExists(installedPreview);
+            assert.deepStrictEqual(conflictExists, requestedNewerPreview, 'An older preview conflicts with a newer installed preview');
+        }
+    });
+
     test('It runs the correct install command', async () =>
     {
         mockExecutor.fakeReturnValue = { stdout: `0`, status: '0', stderr: '' };


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/2759

I also built the VSIX to confirm manually that it works now, and will have vendors also try our testing plan with preview versions.