### PR TITLE
Bump tsconfig target/lib from es6 to es2022

### DIFF
--- a/sample/tsconfig.json
+++ b/sample/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es6",
+		"target": "es2022",
 		"outDir": "out",
 		"lib": [
-			"es6"
+			"es2022"
 		],
 		"sourceMap": true,
 		"rootDir": "src",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
 		"module": "commonjs",
-		"target": "es6",
+		"target": "es2022",
 		"outDir": "dist",
 		"lib": [
-			"es6"
+			"es2022"
 		],
 		"skipLibCheck": true,
         "sourceMap": true,

--- a/vscode-dotnet-runtime-extension/tsconfig.json
+++ b/vscode-dotnet-runtime-extension/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es6",
+		"target": "es2022",
 		"outDir": "dist",
 		"lib": [
-			"es6"
+			"es2022"
 		],
 		"sourceMap": true,
 		"rootDir": "src",

--- a/vscode-dotnet-runtime-library/tsconfig.json
+++ b/vscode-dotnet-runtime-library/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
 		"module": "commonjs",
-		"target": "es6",
+		"target": "es2022",
 		"outDir": "dist",
 		"lib": [
-			"es6"
+			"es2022"
 		],
 		"skipLibCheck": true,
         "sourceMap": true,

--- a/vscode-dotnet-sdk-extension/tsconfig.json
+++ b/vscode-dotnet-sdk-extension/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es6",
+		"target": "es2022",
 		"outDir": "dist",
 		"lib": [
-			"es6"
+			"es2022"
 		],
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
The library and extensions set `target` and `lib` to `es6` (ES2015) in all tsconfig files. ES2015 predates `Array.prototype.includes` (ES2016), so the many `.includes()` calls across the codebase raised TS2550: "Property 'includes' does not exist on type 'string[]'. ... Try changing the 'lib' compiler option to 'es2016' or later."

`lib`/`target` are compile-time only and are independent of the VS Code runtime. The extensions declare `engines.vscode: ^1.101.0`, and VS Code 1.101 runs on Node 22.15.1 (Electron 35.5.1), which fully supports ES2022. Newer VS Code builds ship even newer Node versions (https://github.com/ewanharris/vscode-versions), so ES2022 is safe against the minimum supported host.